### PR TITLE
docs: Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Security updates will be released for all major versions that have had releases in the last year.
+Security updates will be released for all major versions from 1.0 onwards that have had releases in the last year.
 
 ## Reporting a vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security policy
+
+## Supported versions
+
+Security updates will be released for all major versions that have had releases in the last year.
+
+## Reporting a vulnerability
+
+Please provide a description of the issue, the steps you took to
+create the issue, affected versions, and, if known, mitigations for
+the issue.
+
+The easiest way to report a security issue is through
+[GitHub's security advisory for this project](https://github.com/canonical/charmlibs-pathops/security/advisories/new). See
+[Privately reporting a security
+vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions on reporting using GitHub's security advisory feature.
+
+The pathops GitHub admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then figure out a fix, get a CVE assigned, and coordinate
+the release of the fix.
+
+You may also send email to security@ubuntu.com. Email may optionally be
+encrypted to OpenPGP key
+[`4072 60F7 616E CE4D 9D12 4627 98E9 740D C345 39E0`](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x407260f7616ece4d9d12462798e9740dc34539e0)
+
+If you have a deadline for public disclosure, please let us know.
+Our vulnerability management team intends to respond within 3 working
+days of your report. This project aims to resolve all vulnerabilities
+within 90 days.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.


### PR DESCRIPTION
I've made some assumptions here - let me know if you want any of these changed:

* The GitHub security reporting functionality will get turned on (it's not perfect, but it's the best choice for projects hosted on GitHub in my opinion).
* Email to the Canonical security team is also ok (I'm quite biased towards email, but I do feel it's good to have as a backup that doesn't rely on third-party tooling and is very low-tech).
* Security support will be provided for all major versions that are active, where "active" means have had a release in the previous 12 months. This is low burden as long as you're not going to be releasing a lot of major versions. It seems reasonable for users if you're expecting (and supporting) people to update to the latest major version quickly.
* The same 3 day response and 3 month fix timelines that Charm-Tech is using elsewhere.
* There's one security policy that applies to all libs in the monorepo.