### PR TITLE
ci: configure dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"  # This is hard-coded to the 1st of the month
+    labels:
+      - "dependencies"
+  - package-ecosystem: "pip"
+    directories:
+      - "/"
+      - "/[a-z]*"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0  # Security updates only
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Follows the approach taken in [ops](https://github.com/canonical/operator/blob/main/.github/dependabot.yaml) with the exception of checking multiple directories for Python dependencies using [directory globbing](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--). This should support character ranges, since it [uses](https://github.com/dependabot/dependabot-core/pull/9646) Ruby's [Dir.glob](https://ruby-doc.org/core-2.6.8/Dir.html#method-c-glob) under the hood.