### PR TITLE
docs: update links to Ops and Charmcraft docs

### DIFF
--- a/_charmlibs/README.md
+++ b/_charmlibs/README.md
@@ -6,6 +6,6 @@ This namespace is for packages designed to be used by [Juju charms](https://juju
 
 See more:
 
-- Get started with charm development, using [Charmcraft tutorials](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/) and [Ops tutorials](https://ops.readthedocs.io/en/latest/tutorial/index.html)
-- Learn how to [use and write charm libraries](https://ops.readthedocs.io/en/latest/howto/manage-libraries.html)
+- Get started with charm development, using [Charmcraft tutorials](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/) and [Ops tutorials](https://documentation.ubuntu.com/ops/latest/tutorial/)
+- Learn how to [use and write charm libraries](https://documentation.ubuntu.com/ops/latest/howto/manage-libraries/)
 - Learn how to [distribute your own charm library as a Python package](https://canonical-charmlibs.readthedocs-hosted.com/how-to/python-package/)

--- a/_charmlibs/README.md
+++ b/_charmlibs/README.md
@@ -6,6 +6,6 @@ This namespace is for packages designed to be used by [Juju charms](https://juju
 
 See more:
 
-- Get started with charm development, using [Charmcraft tutorials](https://canonical-charmcraft.readthedocs-hosted.com/en/stable/tutorial/) and [Ops tutorials](https://documentation.ubuntu.com/ops/latest/tutorial/)
+- Get started with charm development, using [Charmcraft tutorials](https://documentation.ubuntu.com/charmcraft/stable/tutorial/) and [Ops tutorials](https://documentation.ubuntu.com/ops/latest/tutorial/)
 - Learn how to [use and write charm libraries](https://documentation.ubuntu.com/ops/latest/howto/manage-libraries/)
 - Learn how to [distribute your own charm library as a Python package](https://canonical-charmlibs.readthedocs-hosted.com/how-to/python-package/)

--- a/_docs/conf.py
+++ b/_docs/conf.py
@@ -270,7 +270,7 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    'ops': ('https://ops.readthedocs.io/en/latest', None),
+    'ops': ('https://documentation.ubuntu.com/ops/latest', None),
     'python': ('https://docs.python.org/3', None),
     'juju': ('https://documentation.ubuntu.com/juju/3.6', None),
     'charmcraft': ('https://canonical-charmcraft.readthedocs-hosted.com/en/latest', None),

--- a/_docs/conf.py
+++ b/_docs/conf.py
@@ -273,7 +273,7 @@ intersphinx_mapping = {
     'ops': ('https://documentation.ubuntu.com/ops/latest', None),
     'python': ('https://docs.python.org/3', None),
     'juju': ('https://documentation.ubuntu.com/juju/3.6', None),
-    'charmcraft': ('https://canonical-charmcraft.readthedocs-hosted.com/en/latest', None),
+    'charmcraft': ('https://documentation.ubuntu.com/charmcraft/latest/', None),
 }
 
 maximum_signature_line_length = 80

--- a/_docs/conf.py
+++ b/_docs/conf.py
@@ -273,7 +273,7 @@ intersphinx_mapping = {
     'ops': ('https://documentation.ubuntu.com/ops/latest', None),
     'python': ('https://docs.python.org/3', None),
     'juju': ('https://documentation.ubuntu.com/juju/3.6', None),
-    'charmcraft': ('https://documentation.ubuntu.com/charmcraft/latest/', None),
+    'charmcraft': ('https://documentation.ubuntu.com/charmcraft/latest', None),
 }
 
 maximum_signature_line_length = 80


### PR DESCRIPTION
Now that Ops and Charmcraft docs have moved to documentation.ubuntu.com, we should update links (not time-critical, as there are redirects).