### PR TITLE
chore: add an option to skip Juju integration tests on test publish

### DIFF
--- a/.github/workflows/test-publish.yaml
+++ b/.github/workflows/test-publish.yaml
@@ -5,10 +5,15 @@ on:
       package:
         required: true
         type: string
+      skip-juju:
+        description: Skip Juju integration tests.
+        required: false
+        type: boolean
 
 jobs:
   test-publish:
     uses: ./.github/workflows/publish.yaml
     with: 
       package: ${{ inputs.package }}
+      skip-juju: ${{ inputs.skip-juju }}
       repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,15 @@ on:
         # no default will be null, which is falsey -- if we set a default it will be coerced to a string
         required: false
         type: boolean
+  workflow_dispatch:
+    inputs:
+      package:
+        required: true
+        type: string
+      skip-juju:
+        # no default will be null, which is falsey -- if we set a default it will be coerced to a string
+        required: false
+        type: boolean
 
 jobs:
   init:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,6 +9,10 @@ on:
       package:
         required: true
         type: string
+      skip-juju:
+        # no default will be null, which is falsey -- if we set a default it will be coerced to a string
+        required: false
+        type: boolean
 
 jobs:
   init:
@@ -114,7 +118,7 @@ jobs:
 
   juju:
     needs: init
-    if: contains(fromJson(needs.init.outputs.tests), 'juju')
+    if: contains(fromJson(needs.init.outputs.tests), 'juju') && !inputs.skip-juju
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR adds an input to the `tests.yaml` workflow to skip Juju integration tests. This is passed through from the `test-publish.yaml` job to allow faster test publishing. I've also made `tests.yaml` dispatchable too.