### PR TITLE
ci: wire up the skip-juju option correctly through publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,9 @@ on:
       package:
         required: true
         type: string
+      skip-juju:
+        required: false
+        type: boolean
       repository-url:
         # One of:
         # https://upload.pypi.org/legacy/
@@ -19,6 +22,7 @@ jobs:
     uses: ./.github/workflows/tests.yaml
     with:
       package: ${{ inputs.package }}
+      skip-juju: ${{ inputs.skip-juju }}
   build-n-publish:
     needs: tests
     name: Build and publish package

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,7 @@ on:
         required: true
         type: string
       skip-juju:
+        description: Skip Juju integration tests.
         # no default will be null, which is falsey -- if we set a default it will be coerced to a string
         required: false
         type: boolean
@@ -19,6 +20,7 @@ on:
         required: true
         type: string
       skip-juju:
+        description: Skip Juju integration tests.
         # no default will be null, which is falsey -- if we set a default it will be coerced to a string
         required: false
         type: boolean


### PR DESCRIPTION
This PR is a quick amendment to the last PR to wire up the option correctly through test-publish -> publish -> tests.