### PR TITLE
ci: make publishing verbose

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -47,3 +47,4 @@ jobs:
         with:
           packages-dir: ./${{ inputs.package }}/dist/
           repository-url: ${{ inputs.repository-url }}
+          verbose: true


### PR DESCRIPTION
This PR makes publishing verbose, because I just had a test publishing failure that withheld useful information without this option.