### PR TITLE
docs: update conf.py for documentation.ubuntu.com

### DIFF
--- a/.docs/conf.py
+++ b/.docs/conf.py
@@ -87,7 +87,7 @@ copyright = "%s, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-charmlibs.readthedocs-hosted.com/"
+ogp_site_url = "https://documentation.ubuntu.com/charmlibs/"
 
 
 # Preview name of the documentation website
@@ -123,7 +123,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "github.com/canonical/charmtech-charmlibs",
+    "product_page": "github.com/canonical/charmlibs",
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # TODO: [@dwilding DONE] To add a tag image, uncomment and update as needed.
@@ -149,7 +149,7 @@ html_context = {
     #
     # NOTE: If set, links for viewing the documentation source files
     #       and creating GitHub issues are added at the bottom of each page.
-    "github_url": "https://github.com/canonical/charmtech-charmlibs",
+    "github_url": "https://github.com/canonical/charmlibs",
     # Docs branch in the repo; used in links for viewing the source files
     #
     # TODO: To customise the branch, uncomment and update as needed.
@@ -181,7 +181,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'charmlibs'
 
 
 # Template and asset locations
@@ -216,7 +216,7 @@ redirects = {}
 
 linkcheck_ignore = [
     "http://127.0.0.1:8000"
-    ]
+]
 
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'


### PR DESCRIPTION
This PR updates `conf.py` for documentation.ubuntu.com/charmlibs, as well as a few stray references to `charmtech-charmlibs`.