### PR TITLE
ci: skip tests and publication if no packages have had version bumps

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,6 +33,7 @@ jobs:
 
   tests:
     needs: unify-inputs
+    if: ${{ needs.unify-inputs.outputs.packages != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +45,7 @@ jobs:
 
   build-n-publish:
     needs: [unify-inputs,tests]
+    if: ${{ needs.unify-inputs.outputs.packages != '[]' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR updates the `publish.yaml` workflow to gracefully skip the `tests` and `build-n-publish` jobs if there are no packages for publication.