### PR TITLE
ci: lower apt version so we can trigger the 1.0.0 release by bumping it

### DIFF
--- a/apt/src/charmlibs/apt/__init__.py
+++ b/apt/src/charmlibs/apt/__init__.py
@@ -114,7 +114,7 @@ from urllib.parse import urlparse
 
 import opentelemetry.trace
 
-__version__ = '1.0.0'
+__version__ = '0.0.0.dev0'
 
 logger = logging.getLogger(__name__)
 tracer = opentelemetry.trace.get_tracer(__name__)


### PR DESCRIPTION
This PR lowers the apt package's version (and will be merged with the publication workflow disabled), so that we can release the 1.0 version by bumping it later.