### PR TITLE
docs: for apt, clarify that `add_package` doesn't raise `PackageNotFoundError`

### DIFF
--- a/apt/src/charmlibs/apt/__init__.py
+++ b/apt/src/charmlibs/apt/__init__.py
@@ -37,9 +37,9 @@ To install packages with convenience methods::
     except PackageError as e:
         logger.error("could not install package. Reason: %s", e.message)
 
-The convenience methods do not raise :class:`PackageNotFoundError`. If any packages aren't found
-in the cache, :func:`apt.add_package` raises :class:`PackageError` with a message 'Failed to
-install packages: foo, bar'.
+The convenience methods don't raise :class:`PackageNotFoundError`. If any packages aren't found in
+the cache, :func:`apt.add_package` raises :class:`PackageError` with a message 'Failed to install
+packages: foo, bar'.
 
 To find details of a specific package::
 


### PR DESCRIPTION
When testing the apt library, I noticed that `add_package` doesn't raise `PackageNotFoundError` if any packages aren't found. Instead, the function raises `PackageError`. That's because `add_package` relies on a function `_add` to add each package, and `_add` catches `PackageNotFoundError` and returns a boolean instead.

This PR updates the relevant docs to clarify when `PackageNotFoundError` is raised.

**[Preview docs](https://canonical-ubuntu-documentation-library--124.com.readthedocs.build/charmlibs/reference/charmlibs/apt/)**