### PR TITLE
docs: try building package reference docs individually

### DIFF
--- a/.docs/.sphinx/requirements.txt
+++ b/.docs/.sphinx/requirements.txt
@@ -2,6 +2,5 @@ canonical-sphinx[full]
 sphinx-autobuild
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
-ops
 sphinx-datatables>=0.3
 sphinx-sitemap~=2.8

--- a/.docs/extensions/package_docs.py
+++ b/.docs/extensions/package_docs.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import pathlib
+import shutil
 import typing
 
 ####################
@@ -26,22 +27,38 @@ import typing
 if typing.TYPE_CHECKING:
     import sphinx.application
 
+COMBINE_DOCS = '__combine__'
+
 
 def setup(app: sphinx.application.Sphinx) -> dict[str, str | bool]:
     """Entrypoint for Sphinx extensions, connects generation code to Sphinx event."""
-    app.connect('builder-inited', _package_docs)
+    app.connect('builder-inited', _builder_inited)
+    app.connect('build-finished', _build_finished)
+    app.add_config_value('package', default=None, rebuild='')
+    print('setup')
     return {'version': '1.0.0', 'parallel_read_safe': False, 'parallel_write_safe': False}
 
 
-def _package_docs(app: sphinx.application.Sphinx) -> None:
-    _main(pathlib.Path(app.confdir))
+def _builder_inited(app: sphinx.application.Sphinx) -> None:
+    print('builder-inited start')
+    _package_docs_rst(docs_dir=pathlib.Path(app.confdir), package=app.config.package)
+    print('builder-inited end')
 
 
-####################
-# generation logic #
-####################
+def _build_finished(app: sphinx.application.Sphinx, exception: Exception | None) -> None:
+    print('build-finished start')
+    if exception:
+        print(exception)
+        return
+    _package_docs_html(build_dir=pathlib.Path(app.outdir), package=app.config.package)
+    print('build-finished end')
 
-AUTOMODULE_TEMPLATE = """
+
+########################
+# rst generation logic #
+########################
+
+PACKAGE_DOCS_TEMPLATE = """
 .. raw:: html
 
    <style>
@@ -52,32 +69,44 @@ AUTOMODULE_TEMPLATE = """
 
 {package}
 {underline}
+""".strip()
+AUTOMODULE_SUFFIX_TEMPLATE = """
 
 .. automodule:: {package}
-""".strip()
+""".rstrip()
 
 
-def _main(docs_dir: pathlib.Path) -> None:
-    _generate_files(docs_dir, exclude='interfaces')
-    _generate_files(docs_dir, subdir='interfaces')
+def _package_docs_rst(docs_dir: pathlib.Path, package: str | None) -> None:
+    if package == COMBINE_DOCS:
+        return
+    _generate_rst_files(docs_dir, exclude='interfaces', automodule_package=package)
+    _generate_rst_files(docs_dir, subdir='interfaces', automodule_package=package)
 
 
-def _generate_files(docs_dir: pathlib.Path, subdir: str = '.', exclude: str | None = None) -> None:
+def _generate_rst_files(
+    docs_dir: pathlib.Path,
+    subdir: str = '.',
+    exclude: str | None = None,
+    automodule_package: str | None = None,
+) -> None:
     generated_dir = docs_dir / 'reference' / 'charmlibs' / subdir
     generated_dir.mkdir(exist_ok=True)
     # Any directory starting with a-z is assumed to be a package (except the interfaces directory)
+    root = docs_dir.parent
     package_dir_names = sorted(
         path.name
-        for path in (docs_dir.parent / subdir).glob(r'[a-z]*')
+        for path in (root / subdir).glob(r'[a-z]*')
         if path.is_dir() and path.name != exclude
     )
     for package_dir_name in package_dir_names:
         prefix = 'charmlibs.' if subdir == '.' else f'charmlibs.{subdir}.'
         package = package_dir_name.replace('-', '_')
-        automodule = AUTOMODULE_TEMPLATE.format(
+        content = PACKAGE_DOCS_TEMPLATE.format(
             prefix=prefix, package=package, underline='=' * len(package)
         )
-        _write_if_needed(path=generated_dir / f'{package}.rst', content=automodule)
+        if (root / subdir / package_dir_name) == root / automodule_package:
+            content += AUTOMODULE_SUFFIX_TEMPLATE.format(package=package)
+        _write_if_needed(path=generated_dir / f'{package}.rst', content=content)
 
 
 def _write_if_needed(path: pathlib.Path, content: str) -> None:
@@ -88,3 +117,33 @@ def _write_if_needed(path: pathlib.Path, content: str) -> None:
     """
     if not path.exists() or path.read_text() != content:
         path.write_text(content)
+
+
+#######################
+# html snapshot logic #
+#######################
+
+
+def _package_docs_html(build_dir: pathlib.Path, package: str | None) -> None:
+    if package is None:
+        return
+    if package == COMBINE_DOCS:
+        _combine_html(build_dir)
+    else:
+        _snapshot_html(build_dir, package)
+
+
+def _snapshot_html(build_dir: pathlib.Path, package: str) -> None:
+    html_dir = build_dir / 'reference' / 'charmlibs' / package
+    snapshot_dir = build_dir / '_snapshot' / html_dir.relative_to(build_dir)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(html_dir / 'index.html', snapshot_dir)
+
+
+def _combine_html(build_dir: pathlib.Path) -> None:
+    snapshot_dir = build_dir / '_snapshot'
+    for dir_path, _, filenames in snapshot_dir.walk():
+        for filename in filenames:
+            src = dir_path / filename
+            dst = build_dir / dir_path.relative_to(snapshot_dir) / filename
+            shutil.copy(src, dst)

--- a/.docs/extensions/package_docs.py
+++ b/.docs/extensions/package_docs.py
@@ -35,7 +35,9 @@ def setup(app: sphinx.application.Sphinx) -> dict[str, str | bool]:
 
 
 def _builder_inited(app: sphinx.application.Sphinx) -> None:
-    _package_docs_rst(docs_dir=pathlib.Path(app.confdir), package=app.config.package)
+    package = app.config.package
+    if package is not None:
+        _package_docs_rst(docs_dir=pathlib.Path(app.confdir), package=package)
 
 
 ########################
@@ -58,7 +60,7 @@ PACKAGE_DOCS_TEMPLATE = """
 """.strip()
 
 
-def _package_docs_rst(docs_dir: pathlib.Path, package: str | None) -> None:
+def _package_docs_rst(docs_dir: pathlib.Path, package: str) -> None:
     subdir, _, package_dir_name = package.rpartition('/')
     subdir = subdir or '.'
     generated_dir = docs_dir / 'reference' / 'charmlibs' / subdir

--- a/.docs/extensions/package_docs.py
+++ b/.docs/extensions/package_docs.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import pathlib
-import shutil
 import typing
 
 ####################
@@ -27,31 +26,16 @@ import typing
 if typing.TYPE_CHECKING:
     import sphinx.application
 
-COMBINE_DOCS = '__combine__'
-
 
 def setup(app: sphinx.application.Sphinx) -> dict[str, str | bool]:
     """Entrypoint for Sphinx extensions, connects generation code to Sphinx event."""
     app.connect('builder-inited', _builder_inited)
-    app.connect('build-finished', _build_finished)
     app.add_config_value('package', default=None, rebuild='')
-    print('setup')
     return {'version': '1.0.0', 'parallel_read_safe': False, 'parallel_write_safe': False}
 
 
 def _builder_inited(app: sphinx.application.Sphinx) -> None:
-    print('builder-inited start')
     _package_docs_rst(docs_dir=pathlib.Path(app.confdir), package=app.config.package)
-    print('builder-inited end')
-
-
-def _build_finished(app: sphinx.application.Sphinx, exception: Exception | None) -> None:
-    print('build-finished start')
-    if exception:
-        print(exception)
-        return
-    _package_docs_html(build_dir=pathlib.Path(app.outdir), package=app.config.package)
-    print('build-finished end')
 
 
 ########################
@@ -69,44 +53,24 @@ PACKAGE_DOCS_TEMPLATE = """
 
 {package}
 {underline}
-""".strip()
-AUTOMODULE_SUFFIX_TEMPLATE = """
 
 .. automodule:: {package}
-""".rstrip()
+""".strip()
 
 
 def _package_docs_rst(docs_dir: pathlib.Path, package: str | None) -> None:
-    if package == COMBINE_DOCS:
-        return
-    _generate_rst_files(docs_dir, exclude='interfaces', automodule_package=package)
-    _generate_rst_files(docs_dir, subdir='interfaces', automodule_package=package)
-
-
-def _generate_rst_files(
-    docs_dir: pathlib.Path,
-    subdir: str = '.',
-    exclude: str | None = None,
-    automodule_package: str | None = None,
-) -> None:
+    subdir, _, package_dir_name = package.rpartition('/')
+    subdir = subdir or '.'
     generated_dir = docs_dir / 'reference' / 'charmlibs' / subdir
-    generated_dir.mkdir(exist_ok=True)
-    # Any directory starting with a-z is assumed to be a package (except the interfaces directory)
+    generated_dir.mkdir(parents=True, exist_ok=True)
     root = docs_dir.parent
-    package_dir_names = sorted(
-        path.name
-        for path in (root / subdir).glob(r'[a-z]*')
-        if path.is_dir() and path.name != exclude
+    assert (root / subdir / package_dir_name).is_dir()
+    prefix = 'charmlibs.' if subdir == '.' else f'charmlibs.{subdir}.'
+    module = package_dir_name.replace('-', '_')
+    content = PACKAGE_DOCS_TEMPLATE.format(
+        prefix=prefix, package=module, underline='=' * len(package)
     )
-    for package_dir_name in package_dir_names:
-        prefix = 'charmlibs.' if subdir == '.' else f'charmlibs.{subdir}.'
-        package = package_dir_name.replace('-', '_')
-        content = PACKAGE_DOCS_TEMPLATE.format(
-            prefix=prefix, package=package, underline='=' * len(package)
-        )
-        if (root / subdir / package_dir_name) == root / automodule_package:
-            content += AUTOMODULE_SUFFIX_TEMPLATE.format(package=package)
-        _write_if_needed(path=generated_dir / f'{package}.rst', content=content)
+    _write_if_needed(path=generated_dir / f'{package}.rst', content=content)
 
 
 def _write_if_needed(path: pathlib.Path, content: str) -> None:
@@ -117,33 +81,3 @@ def _write_if_needed(path: pathlib.Path, content: str) -> None:
     """
     if not path.exists() or path.read_text() != content:
         path.write_text(content)
-
-
-#######################
-# html snapshot logic #
-#######################
-
-
-def _package_docs_html(build_dir: pathlib.Path, package: str | None) -> None:
-    if package is None:
-        return
-    if package == COMBINE_DOCS:
-        _combine_html(build_dir)
-    else:
-        _snapshot_html(build_dir, package)
-
-
-def _snapshot_html(build_dir: pathlib.Path, package: str) -> None:
-    html_dir = build_dir / 'reference' / 'charmlibs' / package
-    snapshot_dir = build_dir / '_snapshot' / html_dir.relative_to(build_dir)
-    snapshot_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy(html_dir / 'index.html', snapshot_dir)
-
-
-def _combine_html(build_dir: pathlib.Path) -> None:
-    snapshot_dir = build_dir / '_snapshot'
-    for dir_path, _, filenames in snapshot_dir.walk():
-        for filename in filenames:
-            src = dir_path / filename
-            dst = build_dir / dir_path.relative_to(snapshot_dir) / filename
-            shutil.copy(src, dst)

--- a/.docs/extensions/package_docs.py
+++ b/.docs/extensions/package_docs.py
@@ -36,6 +36,9 @@ def setup(app: sphinx.application.Sphinx) -> dict[str, str | bool]:
 
 def _package_docs(app: sphinx.application.Sphinx) -> None:
     package = app.config.package
+    # generate reference docs for the current package
+    # package is None if not set explicitly
+    # e.g. when running `just docs run` or `just docs linkcheck`
     if package is not None:
         _main(docs_dir=pathlib.Path(app.confdir), package=package)
 

--- a/.docs/extensions/package_docs.py
+++ b/.docs/extensions/package_docs.py
@@ -29,22 +29,22 @@ if typing.TYPE_CHECKING:
 
 def setup(app: sphinx.application.Sphinx) -> dict[str, str | bool]:
     """Entrypoint for Sphinx extensions, connects generation code to Sphinx event."""
-    app.connect('builder-inited', _builder_inited)
+    app.connect('builder-inited', _package_docs)
     app.add_config_value('package', default=None, rebuild='')
     return {'version': '1.0.0', 'parallel_read_safe': False, 'parallel_write_safe': False}
 
 
-def _builder_inited(app: sphinx.application.Sphinx) -> None:
+def _package_docs(app: sphinx.application.Sphinx) -> None:
     package = app.config.package
     if package is not None:
-        _package_docs_rst(docs_dir=pathlib.Path(app.confdir), package=package)
+        _main(docs_dir=pathlib.Path(app.confdir), package=package)
 
 
-########################
-# rst generation logic #
-########################
+####################
+# generation logic #
+####################
 
-PACKAGE_DOCS_TEMPLATE = """
+AUTOMODULE_TEMPLATE = """
 .. raw:: html
 
    <style>
@@ -60,7 +60,7 @@ PACKAGE_DOCS_TEMPLATE = """
 """.strip()
 
 
-def _package_docs_rst(docs_dir: pathlib.Path, package: str) -> None:
+def _main(docs_dir: pathlib.Path, package: str) -> None:
     subdir, _, package_dir_name = package.rpartition('/')
     subdir = subdir or '.'
     generated_dir = docs_dir / 'reference' / 'charmlibs' / subdir
@@ -69,7 +69,7 @@ def _package_docs_rst(docs_dir: pathlib.Path, package: str) -> None:
     assert (root / subdir / package_dir_name).is_dir()
     prefix = 'charmlibs.' if subdir == '.' else f'charmlibs.{subdir}.'
     module = package_dir_name.replace('-', '_')
-    content = PACKAGE_DOCS_TEMPLATE.format(
+    content = AUTOMODULE_TEMPLATE.format(
         prefix=prefix, package=module, underline='=' * len(package)
     )
     _write_if_needed(path=generated_dir / f'{package}.rst', content=content)

--- a/docs.just
+++ b/docs.just
@@ -2,7 +2,14 @@ set working-directory := '.docs'
 
 build_dir := env('READTHEDOCS_OUTPUT', '_build')
 
-[doc('Build the docs, generating reference docs for all packages, or just those specified. e.g. `just docs html interfaces/foo`.')]
+# this is the first recipe in the file, so it will run if just is called without a recipe
+[doc("""
+Build the docs, generating reference docs for all packages, or just those specified.
+
+`just docs` is an alias for `just docs html`. To specify packages, you must use the full recipe, e.g.
+`just docs html interfaces/foo`.
+Run `just docs clean` first to generate reference docs from scratch if you run into import errors.
+""")]
 html *packages:
     #!/usr/bin/env -S uv run --script --no-project
     import pathlib, subprocess
@@ -42,6 +49,10 @@ html *packages:
     # Or run just once with package=None if there were no packages.
     for package in packages[-1 :] or [None]:
         build(package)
+
+[doc('Show help for the docs recipes.')]
+help:
+    @just --list docs --unsorted
 
 [doc('Watch, build, and serve the docs.')]
 run:

--- a/docs.just
+++ b/docs.just
@@ -6,45 +6,38 @@ build_dir := env('READTHEDOCS_OUTPUT', '_build')
 html:
     #!/usr/bin/env -S uv run --script --no-project
     import pathlib, subprocess
-    root = pathlib.Path('{{justfile_directory()}}')
-    *packages, last = [
-        *sorted(p.name for p in root.glob(r'[a-z]*') if p.is_dir() and p.name != 'interfaces'),
-        *sorted(f'interfaces/{p.name}' for p in (root / 'interfaces').glob(r'[a-z]*') if p.is_dir()),
-    ]
-    uvx = [
-        'uvx',
-        '--from', 'sphinx',
-        '--with-requirements', '.sphinx/requirements.txt',
-    ]
-    sphinx = [
-        'sphinx-build',
-        '-T', '-W', '--keep-going',
-        '-b', 'dirhtml',
-        '-d', '_build/doctrees',
-        '-D', 'language=en',
-    ]
-    targets = ['.', '{{build_dir}}/html']
-    for package in packages:
+    ROOT = pathlib.Path('{{justfile_directory()}}')
+
+    def build(package: str | None, suppress_warnings: bool = False) -> None:
         cmd = [
-            *uvx,
-            '--with', f'../{package}',
-            *sphinx,
-            '-D', f'package={package}',
-            '-D', 'suppress_warnings=ref.ref,ref.doc,myst.xref_missing',
-            *targets,
+            'uvx',
+            '--from', 'sphinx',
+            '--with-requirements', '.sphinx/requirements.txt',
+            *(['--with', str(ROOT / package)] if package else []),
+            'sphinx-build',
+            '-T', '-W', '--keep-going',
+            '-b', 'dirhtml',
+            '-d', '_build/doctrees',
+            '-D', 'language=en',
+            *(['-D', f'package={package}'] if package else []),
+            *(
+                ['-D', 'suppress_warnings=ref.ref,ref.doc,myst.xref_missing']
+                if suppress_warnings
+                else []
+            ),
+            '.', '{{build_dir}}/html',
         ]
         print(cmd)
         subprocess.check_call(cmd)
-    package = last
-    cmd = [
-        *uvx,
-        '--with', f'../{package}',
-        *sphinx,
-        '-D', f'package={package}',
-        *targets,
+
+    packages = [
+        *sorted(p.name for p in ROOT.glob(r'[a-z]*') if p.is_dir() and p.name != 'interfaces'),
+        *sorted(f'interfaces/{p.name}' for p in (ROOT / 'interfaces').glob(r'[a-z]*') if p.is_dir()),
     ]
-    print(cmd)
-    subprocess.check_call(cmd)
+    for package in packages[: -1]:
+        build(package, suppress_warnings=True)
+    for package in packages[-1 :] or [None]:
+        build(package)
 
 [doc('Watch, build, and serve the docs.')]
 run:

--- a/docs.just
+++ b/docs.just
@@ -3,16 +3,14 @@ set working-directory := '.docs'
 build_dir := env('READTHEDOCS_OUTPUT', '_build')
 
 [doc('Build the docs.')]
-html *packages='__all__':
+html:
     #!/usr/bin/env -S uv run --script --no-project
     import pathlib, subprocess
     root = pathlib.Path('{{justfile_directory()}}')
-    packages = '{{packages}}'.split()
-    if '__all__' in packages:
-        packages = [
-            *sorted(p.name for p in root.glob(r'[a-z]*') if p.is_dir() and p.name != 'interfaces'),
-            *sorted(f'interfaces/{p.name}' for p in (root / 'interfaces').glob(r'[a-z]*') if p.is_dir()),
-        ]
+    *packages, last = [
+        *sorted(p.name for p in root.glob(r'[a-z]*') if p.is_dir() and p.name != 'interfaces'),
+        *sorted(f'interfaces/{p.name}' for p in (root / 'interfaces').glob(r'[a-z]*') if p.is_dir()),
+    ]
     uvx = [
         'uvx',
         '--from', 'sphinx',
@@ -37,7 +35,14 @@ html *packages='__all__':
         ]
         print(cmd)
         subprocess.check_call(cmd)
-    cmd = [*uvx, *sphinx, '-D', 'package=__combine__', *targets]
+    package = last
+    cmd = [
+        *uvx,
+        '--with', f'../{package}',
+        *sphinx,
+        '-D', f'package={package}',
+        *targets,
+    ]
     print(cmd)
     subprocess.check_call(cmd)
 

--- a/docs.just
+++ b/docs.just
@@ -54,13 +54,13 @@ html *packages: _clean-charmlibs-reference-docs
 help:
     @just --list docs --unsorted
 
-[doc('Watch, build, and serve the docs.')]
-run:
+[doc('Watch, build, and serve the docs -- does not include package reference docs.')]
+run: _clean-charmlibs-reference-docs
     uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
         sphinx-autobuild --watch .. --ignore '**/generated/*' -b dirhtml . '{{build_dir}}/html'
 
-[doc('Check links.')]
-linkcheck:
+[doc('Check links -- does not include package reference docs.')]
+linkcheck: _clean-charmlibs-reference-docs
     uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
         sphinx-build -b linkcheck . '{{build_dir}}'
 

--- a/docs.just
+++ b/docs.just
@@ -30,12 +30,16 @@ html:
         print(cmd)
         subprocess.check_call(cmd)
 
+    # Any directory (or subdirectory of interfaces) starting with a-z is assumed to be a package.
     packages = [
         *sorted(p.name for p in ROOT.glob(r'[a-z]*') if p.is_dir() and p.name != 'interfaces'),
         *sorted(f'interfaces/{p.name}' for p in (ROOT / 'interfaces').glob(r'[a-z]*') if p.is_dir()),
     ]
+    # Suppress ref warnings on all but last package as refs can't all resolve.
     for package in packages[: -1]:
         build(package, suppress_warnings=True)
+    # Run with the usual warnings for the last package.
+    # Or run just once with package=None if there were no packages.
     for package in packages[-1 :] or [None]:
         build(package)
 

--- a/docs.just
+++ b/docs.just
@@ -10,7 +10,7 @@ Build the docs, generating reference docs for all packages, or just those specif
 `just docs html interfaces/foo`.
 Run `just docs clean` first to generate reference docs from scratch if you run into import errors.
 """)]
-html *packages:
+html *packages: _clean-charmlibs-reference-docs
     #!/usr/bin/env -S uv run --script --no-project
     import pathlib, subprocess
     ROOT = pathlib.Path('{{justfile_directory()}}')
@@ -69,14 +69,17 @@ spelling: html
     uvx pyspelling -c .sphinx/spellingcheck.yaml -j $(nproc)
 
 [doc('Remove files created by building the docs.')]
-clean:
+clean: _clean-charmlibs-reference-docs
     git clean -fx '{{build_dir}}'
     rm -rf .sphinx/.doctrees
     rm -rf .sphinx/node_modules/
     rm -rf .sphinx/styles
     rm -rf .sphinx/vale.ini
-    rm -rf reference/charmlibs
     rm -rf reference/generated
+
+[doc('Remove .rst automodule files generated when building docs.')]
+_clean-charmlibs-reference-docs:
+    rm -rf reference/charmlibs
 
 [doc('Run `pyright` for local sphinx extensions.')]
 ext-static *pyrightargs:

--- a/docs.just
+++ b/docs.just
@@ -24,7 +24,7 @@ html *packages: _clean-charmlibs-reference-docs
             'sphinx-build',
             '-T', '-W', '--keep-going',
             '-b', 'dirhtml',
-            '-d', '_build/doctrees',
+            '-d', '.sphinx/.doctrees',
             '-D', 'language=en',
             *(['-D', f'package={package}'] if package else []),
             *(

--- a/docs.just
+++ b/docs.just
@@ -3,9 +3,43 @@ set working-directory := '.docs'
 build_dir := env('READTHEDOCS_OUTPUT', '_build')
 
 [doc('Build the docs.')]
-html:
-    uvx --with-requirements=.sphinx/requirements.txt --from=sphinx \
-        sphinx-build -T -W --keep-going -b dirhtml -d _build/doctrees -D language=en . '{{build_dir}}/html'
+html *packages='__all__':
+    #!/usr/bin/env -S uv run --script --no-project
+    import pathlib, subprocess
+    root = pathlib.Path('{{justfile_directory()}}')
+    packages = '{{packages}}'.split()
+    if '__all__' in packages:
+        packages = [
+            *sorted(p.name for p in root.glob(r'[a-z]*') if p.is_dir() and p.name != 'interfaces'),
+            *sorted(f'interfaces/{p.name}' for p in (root / 'interfaces').glob(r'[a-z]*') if p.is_dir()),
+        ]
+    uvx = [
+        'uvx',
+        '--from', 'sphinx',
+        '--with-requirements', '.sphinx/requirements.txt',
+    ]
+    sphinx = [
+        'sphinx-build',
+        '-T', '-W', '--keep-going',
+        '-b', 'dirhtml',
+        '-d', '_build/doctrees',
+        '-D', 'language=en',
+    ]
+    targets = ['.', '{{build_dir}}/html']
+    for package in packages:
+        cmd = [
+            *uvx,
+            '--with', f'../{package}',
+            *sphinx,
+            '-D', f'package={package}',
+            '-D', 'suppress_warnings=ref.ref,ref.doc,myst.xref_missing',
+            *targets,
+        ]
+        print(cmd)
+        subprocess.check_call(cmd)
+    cmd = [*uvx, *sphinx, '-D', 'package=__combine__', *targets]
+    print(cmd)
+    subprocess.check_call(cmd)
 
 [doc('Watch, build, and serve the docs.')]
 run:

--- a/docs.just
+++ b/docs.just
@@ -2,8 +2,8 @@ set working-directory := '.docs'
 
 build_dir := env('READTHEDOCS_OUTPUT', '_build')
 
-[doc('Build the docs.')]
-html:
+[doc('Build the docs, generating reference docs for all packages, or just those specified. e.g. `just docs html interfaces/foo`.')]
+html *packages:
     #!/usr/bin/env -S uv run --script --no-project
     import pathlib, subprocess
     ROOT = pathlib.Path('{{justfile_directory()}}')
@@ -31,7 +31,7 @@ html:
         subprocess.check_call(cmd)
 
     # Any directory (or subdirectory of interfaces) starting with a-z is assumed to be a package.
-    packages = [
+    packages = '{{packages}}'.split() or [
         *sorted(p.name for p in ROOT.glob(r'[a-z]*') if p.is_dir() and p.name != 'interfaces'),
         *sorted(f'interfaces/{p.name}' for p in (ROOT / 'interfaces').glob(r'[a-z]*') if p.is_dir()),
     ]


### PR DESCRIPTION
This PR changes the `just docs html` recipe to incrementally build the package reference docs, by running `sphinx-build` once for each package, with that package installed in the virtual environment. The local `package_docs` extension has been updated accordingly to only create the automodule rst file for the specified package, rather than for all packages at once. Together, this completely eliminates the need for package dependencies to be added to the docs `requirements.txt` or to `autodoc_mock_imports`.

As a developer convenience, `just docs html` can be invoked with specific package names to limit reference docs generation to only the specified packages.

The `just docs run` and `just docs linkcheck` recipes have not been modified. The `package_docs` extension will skip generating the package reference docs when these recipes run (since they don't set the `package` config option). This means that they work mostly as expected, but won't create (or check) package reference docs.