### PR TITLE
ci: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,29 @@
+# default
+. @canonical/charm-tech
+/interfaces/ @canonical/charm-tech
+
+# codeowners
+/.github/CODEOWNERS @canonical/charm-tech
+
+# infra
+/.github/ @canonical/charm-tech
+/docs.just @canonical/charm-tech
+/justfile @canonical/charm-tech
+/LICENSE @canonical/charm-tech
+/pyproject.toml @canonical/charm-tech
+/SECURITY.md @canonical/charm-tech
+
+# docs
+/.docs/ @canonical/charm-tech
+/interfaces/README.md @canonical/charm-tech
+/README.md @canonical/charm-tech
+
+# namespace reservation
+/.package/ @canonical/charm-tech
+/interfaces/.package/ @canonical/charm-tech
+
+# charmlibs packages (alphabetical)
+/apt/ @canonical/charm-tech
+/pathops/ @canonical/charm-tech
+
+# charmlibs.interfaces packages (alphabetical)


### PR DESCRIPTION
This PR adds the `CODEOWNERS` file that will be used to allow library owners to approve PRs that affect just their libraries. `@canonical/charm-tech` is set as the default owner for the repository (`.`), as well as set explicitly for the `CODEOWNERS` file itself, the repository infra files (e.g. `/pyproject.toml`, `/justfile`), global docs, and the packages that we currently own. PRs adding a new library will add a `CODEOWNERS` entry for its package directory, which will require `@canonical/charm-tech` approval. After that, the owners of the package directory will be able to approve changes on their own.