### PR TITLE
ci: add a static job to check if tests matrix passed/skipped

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/tests.yaml
     with:
       package: ${{ matrix.package }}
-  
+
   tests-passed:
     needs: [tests]
     if: ${{ !cancelled() }}  # run even if tests are skipped or failed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,3 +39,15 @@ jobs:
     uses: ./.github/workflows/tests.yaml
     with:
       package: ${{ matrix.package }}
+  
+  tests-passed:
+    needs: [tests]
+    if: ${{ !cancelled() }}  # run even if tests are skipped or failed
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ needs.tests.result == 'success' }}
+        run: echo 'Tests succeeded :D'
+      - if: ${{ needs.tests.result == 'skipped' }}
+        run: echo 'No tests needed :)'
+      - if: ${{ needs.tests.result == 'failure' }}
+        run: echo 'Tests failed :(' && exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     if: ${{ !cancelled() }}  # run even if tests are skipped or failed
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ needs.test.result != 'success' && needs.test.result != 'skipped' }}
+      - if: ${{ needs.tests.result != 'success' && needs.tests.result != 'skipped' }}
         run: |
           echo '${{ toJSON(needs) }}'
           exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
     if: ${{ !cancelled() }}  # run even if tests are skipped or failed
     runs-on: ubuntu-latest
     steps:
+      - run: echo ${{ needs.test.result }}
+      - run: echo ${{ needs.test }}
+      - run: echo ${{ needs }}
       - if: ${{ needs.tests.result == 'success' }}
         run: echo 'Tests succeeded :D'
       - if: ${{ needs.tests.result == 'skipped' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,5 +47,5 @@ jobs:
     steps:
       - if: ${{ needs.test.result != 'success' && needs.test.result != 'skipped' }}
         run: |
-          echo '${{ needs.test.result }}'
+          echo '${{ toJSON(needs) }}'
           exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,12 +45,7 @@ jobs:
     if: ${{ !cancelled() }}  # run even if tests are skipped or failed
     runs-on: ubuntu-latest
     steps:
-      - run: echo ${{ needs.test.result }}
-      - run: echo ${{ needs.test }}
-      - run: echo ${{ needs }}
-      - if: ${{ needs.tests.result == 'success' }}
-        run: echo 'Tests succeeded :D'
-      - if: ${{ needs.tests.result == 'skipped' }}
-        run: echo 'No tests needed :)'
-      - if: ${{ needs.tests.result == 'failure' }}
-        run: echo 'Tests failed :(' && exit 1
+      - if: ${{ needs.test.result != 'success' && needs.test.result != 'skipped' }}
+        run: |
+          echo '${{ needs.test.result }}'
+          exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -157,7 +157,6 @@ jobs:
     env:
       CHARMLIBS_BASE: ${{ matrix.base }}
     steps:
-      - run: exit 1
       - uses: actions/checkout@v4
 
       - name: Install concierge

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,6 +86,8 @@ jobs:
       matrix:
         python: ${{ fromJson(needs.init.outputs.python) }}
     steps:
+      - run: exit 0
+
       - uses: actions/checkout@v4
 
       - name: Install uv
@@ -103,6 +105,8 @@ jobs:
       matrix:
         python: ${{ fromJson(needs.init.outputs.python) }}
     steps:
+      - run: exit 1
+
       - uses: actions/checkout@v4
 
       - name: Install uv
@@ -121,6 +125,8 @@ jobs:
     env:
       RECIPE_SUFFIX: ${{ matrix.pebble != 'no-pebble' && '-pebble' || '' }}
     steps:
+      - run: exit 1
+
       - uses: actions/checkout@v4
 
       - name: Set up Go
@@ -157,6 +163,8 @@ jobs:
     env:
       CHARMLIBS_BASE: ${{ matrix.base }}
     steps:
+      - run: exit $(python -c 'import random; print(random.choice([0, 1]), end="")')
+
       - uses: actions/checkout@v4
 
       - name: Install concierge

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -86,8 +86,6 @@ jobs:
       matrix:
         python: ${{ fromJson(needs.init.outputs.python) }}
     steps:
-      - run: exit 0
-
       - uses: actions/checkout@v4
 
       - name: Install uv
@@ -105,8 +103,6 @@ jobs:
       matrix:
         python: ${{ fromJson(needs.init.outputs.python) }}
     steps:
-      - run: exit 1
-
       - uses: actions/checkout@v4
 
       - name: Install uv
@@ -125,8 +121,6 @@ jobs:
     env:
       RECIPE_SUFFIX: ${{ matrix.pebble != 'no-pebble' && '-pebble' || '' }}
     steps:
-      - run: exit 1
-
       - uses: actions/checkout@v4
 
       - name: Set up Go
@@ -163,8 +157,6 @@ jobs:
     env:
       CHARMLIBS_BASE: ${{ matrix.base }}
     steps:
-      - run: exit 1
-
       - uses: actions/checkout@v4
 
       - name: Install concierge

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -157,6 +157,7 @@ jobs:
     env:
       CHARMLIBS_BASE: ${{ matrix.base }}
     steps:
+      - run: exit 1
       - uses: actions/checkout@v4
 
       - name: Install concierge

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -163,7 +163,7 @@ jobs:
     env:
       CHARMLIBS_BASE: ${{ matrix.base }}
     steps:
-      - run: exit $(python -c 'import random; print(random.choice([0, 1]), end="")')
+      - run: exit 1
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR adds a static `tests-passed` job to the `ci` workflow to check if the dynamically generated jobs from the tests matrix passed (or were skipped). This is necessary because the branch protection rules require a known job ID to be specified when setting required checks (which block merging PRs). Not only do we dynamically run different jobs depending on what tests a package has (etc), but we may skip running them altogether if a package hasn't been changed in that PR.