### PR TITLE
ci: switch from charm-tech to charmlibs-maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,29 @@
 # default
-. @canonical/charm-tech
-/interfaces/ @canonical/charm-tech
+. @canonical/charmlibs-maintainers
+/interfaces/ @canonical/charmlibs-maintainers
 
 # codeowners
-/.github/CODEOWNERS @canonical/charm-tech
+/.github/CODEOWNERS @canonical/charmlibs-maintainers
 
 # infra
-/.github/ @canonical/charm-tech
-/docs.just @canonical/charm-tech
-/justfile @canonical/charm-tech
-/LICENSE @canonical/charm-tech
-/pyproject.toml @canonical/charm-tech
-/SECURITY.md @canonical/charm-tech
+/.github/ @canonical/charmlibs-maintainers
+/docs.just @canonical/charmlibs-maintainers
+/justfile @canonical/charmlibs-maintainers
+/LICENSE @canonical/charmlibs-maintainers
+/pyproject.toml @canonical/charmlibs-maintainers
+/SECURITY.md @canonical/charmlibs-maintainers
 
 # docs
-/.docs/ @canonical/charm-tech
-/interfaces/README.md @canonical/charm-tech
-/README.md @canonical/charm-tech
+/.docs/ @canonical/charmlibs-maintainers
+/interfaces/README.md @canonical/charmlibs-maintainers
+/README.md @canonical/charmlibs-maintainers
 
 # namespace reservation
-/.package/ @canonical/charm-tech
-/interfaces/.package/ @canonical/charm-tech
+/.package/ @canonical/charmlibs-maintainers
+/interfaces/.package/ @canonical/charmlibs-maintainers
 
 # charmlibs packages (alphabetical)
-/apt/ @canonical/charm-tech
-/pathops/ @canonical/charm-tech
+/apt/ @canonical/charmlibs-maintainers
+/pathops/ @canonical/charmlibs-maintainers
 
 # charmlibs.interfaces packages (alphabetical)


### PR DESCRIPTION
This PR switches ownership of everything currently specified in the `CODEOWNERS` file from `charm-tech` to `charmlibs-maintainers`. The `charmlibs-maintainers` team is currently the exact same people, but the code review settings are different: only I will be requested for reviews, so the rest of the team should not get spammed. However, the rest of the team still has code owner permissions, and can provide the required approvals to merge PRs affecting the files the team owns.