### PR TITLE
ci: check then format is wrong, we should format then check

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,8 +24,8 @@ fast-lint:
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:
-    uv run ruff check --preview --fix
     uv run ruff format --preview
+    uv run ruff check --preview --fix
 
 [doc('Run global `fast-lint` and package specific `static` analysis, e.g. `just python=3.8 lint pathops`.')]
 lint package *pyright_args: fast-lint (static package pyright_args)


### PR DESCRIPTION
As an alternative to #138, flip the order of the command we run in `just format` to `ruff format` *then* `ruff check --fix`, as this is what charmers have found works best -- thanks @PietroPasotti.