### PR TITLE
ci: don't include removed packages in the list of packages to release

### DIFF
--- a/.github/unify-publish-inputs.py
+++ b/.github/unify-publish-inputs.py
@@ -73,7 +73,7 @@ def _get_packages(old_ref: str, new_ref: str) -> list[str]:
     for p in changed_packages:
         old = old_versions[p]
         new = new_versions[p]
-        if '.dev' not in new and old != new:
+        if new is not None and '.dev' not in new and old != new:
             packages_to_release.append(p)
             logger.info('%s: %s -> %s', p, old, new)
     return packages_to_release


### PR DESCRIPTION
We release packages when a merge to main contains a version change for that package, excluding `.dev` releases. This includes the case when a new package is added (old version is `None`). However, it also erroneously includes the case where a package is *removed* from the repository (*new* version is `None`). This would fail anyway when we try to run the release script, since the package files are not longer present. For sanity, this PR excludes removed packages from the list of packages to release.