### PR TITLE
ci: correctly handle empty ubuntu version config for functional tests

### DIFF
--- a/.github/get-functional-test-matrix.py
+++ b/.github/get-functional-test-matrix.py
@@ -54,7 +54,7 @@ def _get_matrix(package: pathlib.Path) -> dict[str, list[str]]:
     pyproject_toml = tomli.loads((package / 'pyproject.toml').read_text())
     table = pyproject_toml.get('tool', {}).get('charmlibs', {}).get('functional', {})
     return {
-        'ubuntu': [f'ubuntu-{v}' for v in table.get('ubuntu', ['latest'])],
+        'ubuntu': [f'ubuntu-{v}' for v in table.get('ubuntu') or ['latest']],
         'sudo': ['sudo'] if table.get('sudo') else ['no-sudo'],
         'pebble': [f'pebble@{v}' for v in table.get('pebble', [])] or ['no-pebble'],
     }


### PR DESCRIPTION
The script that parse `tool.charmlibs.functional` doesn't handle an empty `ubuntu` list correctly -- this should be equivalent to not specifying `ubuntu` at all, otherwise (if the package has `tests/functional`), the functional tests job will run with an empty `ubuntu` list for the matrix, and fail.