### PR TITLE
ci: add a package local justfile to improve the developer experience

### DIFF
--- a/.local-justfile
+++ b/.local-justfile
@@ -1,7 +1,7 @@
 _root := shell('git rev-parse --show-toplevel')
-_package := shell('realpath --relative-to=' + _root + ' ' + justfile_directory())
+_package := shell('realpath --relative-to="$1" "$2"', _root, justfile_directory())
 
-help:
+_help:
     @echo 'Local justfile for {{CYAN}}{{_package}}/{{NORMAL}}.'
     @echo 'All these recipes from the global justfile are available:'
     @cd {{_root}} && just --list --unsorted --list-heading=''

--- a/.local-justfile
+++ b/.local-justfile
@@ -8,6 +8,9 @@ help:
     @echo 'However, the {{CYAN}}package{{NORMAL}} argument must be omitted from these recipes:'
     @just --list --unsorted --list-heading=''
 
+docs *args:
+    cd '{{_root}}' && just docs {{args}}
+
 _run recipe *args:
     cd '{{_root}}' && just {{recipe}} {{_package}} {{args}}
 

--- a/.local-justfile
+++ b/.local-justfile
@@ -15,7 +15,6 @@ docs *args:
 _run recipe *args:
     cd '{{_root}}' && just {{recipe}} {{_package}} {{args}}
 
-add *args: (_run 'add' args)
 lint *args: (_run 'lint' args)
 static *args: (_run 'static' args)
 unit *args: (_run 'unit' args)

--- a/.local-justfile
+++ b/.local-justfile
@@ -1,0 +1,24 @@
+root := shell('git rev-parse --show-toplevel')
+package := file_name(justfile_directory())
+
+help:
+    @echo 'Local justfile for {{CYAN}}{{package}}/{{NORMAL}}.'
+    @echo 'All these recipes from the global justfile are available:'
+    @cd {{root}} && just --list --unsorted --list-heading=''
+    @echo 'However, the package argument must be omitted from these recipes:'
+    @just --list --unsorted --list-heading=''
+
+_package recipe +args:
+    cd '{{root}}' && just {{recipe}} {{package}} {{args}}
+
+add *args: (_package 'add' args)
+lint *args: (_package 'lint' args)
+static *args: (_package 'static' args)
+unit *args: (_package 'unit' args)
+functional *args: (_package 'functional' args)
+functional-pebble *args: (_package 'functional-pebble' args)
+combine-coverage *args: (_package 'combine-coverage' args)
+pack-k8s *args: (_package 'pack-k8s' args)
+pack-machine *args: (_package 'pack-machine' args)
+integration-k8s *args: (_package 'integration-k8s' args)
+integration-machine *args: (_package 'integration-machine' args)

--- a/.local-justfile
+++ b/.local-justfile
@@ -1,24 +1,24 @@
-root := shell('git rev-parse --show-toplevel')
-package := file_name(justfile_directory())
+_root := shell('git rev-parse --show-toplevel')
+_package := shell('realpath --relative-to=' + _root + ' ' + justfile_directory())
 
 help:
-    @echo 'Local justfile for {{CYAN}}{{package}}/{{NORMAL}}.'
+    @echo 'Local justfile for {{CYAN}}{{_package}}/{{NORMAL}}.'
     @echo 'All these recipes from the global justfile are available:'
-    @cd {{root}} && just --list --unsorted --list-heading=''
-    @echo 'However, the package argument must be omitted from these recipes:'
+    @cd {{_root}} && just --list --unsorted --list-heading=''
+    @echo 'However, the {{CYAN}}package{{NORMAL}} argument must be omitted from these recipes:'
     @just --list --unsorted --list-heading=''
 
-_package recipe +args:
-    cd '{{root}}' && just {{recipe}} {{package}} {{args}}
+_run recipe *args:
+    cd '{{_root}}' && just {{recipe}} {{_package}} {{args}}
 
-add *args: (_package 'add' args)
-lint *args: (_package 'lint' args)
-static *args: (_package 'static' args)
-unit *args: (_package 'unit' args)
-functional *args: (_package 'functional' args)
-functional-pebble *args: (_package 'functional-pebble' args)
-combine-coverage *args: (_package 'combine-coverage' args)
-pack-k8s *args: (_package 'pack-k8s' args)
-pack-machine *args: (_package 'pack-machine' args)
-integration-k8s *args: (_package 'integration-k8s' args)
-integration-machine *args: (_package 'integration-machine' args)
+add *args: (_run 'add' args)
+lint *args: (_run 'lint' args)
+static *args: (_run 'static' args)
+unit *args: (_run 'unit' args)
+functional *args: (_run 'functional' args)
+functional-pebble *args: (_run 'functional-pebble' args)
+combine-coverage *args: (_run 'combine-coverage' args)
+pack-k8s *args: (_run 'pack-k8s' args)
+pack-machine *args: (_run 'pack-machine' args)
+integration-k8s *args: (_run 'integration-k8s' args)
+integration-machine *args: (_run 'integration-machine' args)

--- a/.local-justfile
+++ b/.local-justfile
@@ -8,6 +8,7 @@ help:
     @echo 'However, the {{CYAN}}package{{NORMAL}} argument must be omitted from these recipes:'
     @just --list --unsorted --list-heading=''
 
+[private]
 docs *args:
     cd '{{_root}}' && just docs {{args}}
 

--- a/.package/justfile
+++ b/.package/justfile
@@ -1,0 +1,1 @@
+../.local-justfile

--- a/apt/justfile
+++ b/apt/justfile
@@ -1,0 +1,1 @@
+../.local-justfile

--- a/interfaces/.package/justfile
+++ b/interfaces/.package/justfile
@@ -1,0 +1,1 @@
+../../.local-justfile

--- a/pathops/justfile
+++ b/pathops/justfile
@@ -1,0 +1,1 @@
+../.local-justfile


### PR DESCRIPTION
This PR adds a lightweight `justfile` named `.local-justfile`. It is not used in CI, nor is it used when invoking `just` anywhere in the repo without further steps.

The intended use is to add a symlink from `<package>/justfile` to the `.local-justfile`. This will allow `just` invocations from below the `<package>/` directory to omit the `package` argument, e.g. `just unit` instead of `just unit <package>`. Importantly, `<package>/justfile` is also not used in CI -- this is purely for developer experience.

This PR adds symlinks for the `apt` and `pathops` packages. It could be added to the template as well.