### PR TITLE
ci: don't fail fast in tests matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
     needs: [fast-lint, get-packages]
     if: ${{ needs.get-packages.outputs.packages != '[]' }}
     strategy:
+      fail-fast: false
       matrix:
         package: ${{ fromJson(needs.get-packages.outputs.packages) }}
     uses: ./.github/workflows/tests.yaml


### PR DESCRIPTION
This PR adds the `fail-fast: false` change from #147, without the complicated `concurrency:` shenanigans.