### PR TITLE
ci: add just add command (again)

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,10 +7,7 @@ python := '3.10'
 # for integration tests, e.g. `just tag=24.04 pack-k8s` `just tag=foo integration-machine`
 tag := env('CHARMLIBS_TAG', '')
 
-_coverage := 'coverage==7.6.1'
-_pyright := 'pyright==1.1.397'
-_pytest := 'pytest==8.3.5'
-_with_test_deps := '--with ' + _coverage + ' --with ' + _pyright + ' --with ' + _pytest
+_uv_run_with_test_requirements := 'uv run --with-requirements ' + quote(join(justfile_dir(), 'test-requirements.txt'))
 
 # this is the first recipe in the file, so it will run if just is called without a recipe
 [doc('Describe usage and list the available recipes.')]
@@ -31,8 +28,14 @@ fast-lint:
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format:
-    uv run ruff format --preview
-    uv run ruff check --preview --fix
+    uv run --only-group=fast-lint ruff format --preview
+    uv run --only-group=fast-lint ruff check --preview --fix
+
+[doc("Run `uv add` for package, respecting repo-level version constraints, e.g. `just add pathops 'pydantic>=2'`.")]
+add package +args:
+    #!/usr/bin/env -S bash -xueo pipefail
+    cd '{{package}}'
+    uv add --constraints {{quote(join(justfile_dir(), 'test-requirements.txt'))}} {{args}}
 
 [doc('Run global `fast-lint` and package specific `static` analysis, e.g. `just python=3.10 lint pathops`.')]
 lint package *pyright_args: fast-lint (static package pyright_args)
@@ -41,7 +44,7 @@ lint package *pyright_args: fast-lint (static package pyright_args)
 static package *args:
     #!/usr/bin/env -S bash -xueo pipefail
     cd '{{package}}'
-    uv run {{_with_test_deps}} \
+    {{_uv_run_with_test_requirements}} \
         --group lint --group unit --group functional --group integration \
         pyright --pythonversion='{{python}}' {{args}}
 
@@ -71,10 +74,10 @@ _coverage package test_suite +flags:
     cd '{{package}}'
     export COVERAGE_RCFILE='{{justfile_directory()}}/pyproject.toml'
     DATA_FILE=".report/coverage-$(basename {{test_suite}})-{{python}}.db"
-    uv run {{_with_test_deps}} --group {{test_suite}} \
+    {{_uv_run_with_test_requirements}} --group {{test_suite}} \
         coverage run --data-file="$DATA_FILE" --source='src' \
         -m pytest --tb=native -vv {{flags}} 'tests/{{test_suite}}'
-    uv run {{_with_test_deps}} --group {{test_suite}} \
+    {{_uv_run_with_test_requirements}} --group {{test_suite}} \
         coverage report --data-file="$DATA_FILE"
 
 [doc("Combine `coverage` reports, e.g. `just python=3.10 combine-coverage pathops`.")]
@@ -93,11 +96,11 @@ combine-coverage package:
     export COVERAGE_RCFILE='{{justfile_directory()}}/pyproject.toml'
     DATA_FILE='.report/coverage-all-{{python}}.db'
     HTML_DIR='.report/htmlcov-all-{{python}}'
-    uv run coverage combine --keep --data-file="$DATA_FILE" "${data_files[@]}"
-    uv run coverage xml --data-file="$DATA_FILE" -o '.report/coverage-all-{{python}}.xml'
+    {{_uv_run_with_test_requirements}} coverage combine --keep --data-file="$DATA_FILE" "${data_files[@]}"
+    {{_uv_run_with_test_requirements}} coverage xml --data-file="$DATA_FILE" -o '.report/coverage-all-{{python}}.xml'
     rm -rf "$HTML_DIR"  # let coverage create html directory from scratch
-    uv run coverage html --data-file="$DATA_FILE" --show-contexts --directory="$HTML_DIR"
-    uv run coverage report --data-file="$DATA_FILE"
+    {{_uv_run_with_test_requirements}} coverage html --data-file="$DATA_FILE" --show-contexts --directory="$HTML_DIR"
+    {{_uv_run_with_test_requirements}} coverage report --data-file="$DATA_FILE"
 
 [doc("Execute pack script to pack Kubernetes charm(s) for Juju integration tests.")]
 pack-k8s package *args: (_pack package 'k8s' args)
@@ -121,5 +124,5 @@ integration-machine package +flags='-rA': (_integration package 'machine' 'not k
 _integration package substrate label +flags:
     #!/usr/bin/env -S bash -xueo pipefail
     cd '{{package}}'
-    CHARMLIBS_SUBSTRATE={{substrate}} CHARMLIBS_TAG='{{tag}}' uv run {{_with_test_deps}} --group integration \
+    CHARMLIBS_SUBSTRATE={{substrate}} CHARMLIBS_TAG='{{tag}}' {{_uv_run_with_test_requirements}} --group integration \
         pytest --tb=native -vv -m '{{label}}' tests/integration  {{flags}}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,3 @@
+coverage==7.6.1
+pyright==1.1.397
+pytest==8.3.5


### PR DESCRIPTION
In a previous PR I suggested that we didn't need `just add`, because `uv add --constraints` didn't respect the constraints for the package being added -- that is, if `pytest` is in our constraints with some version, `uv add --constraints=$FILE pytest` will still install the latest version of `pytest`. But it does seem important to provide a way for library authors to add their own dependencies while respecting our test package versions (this became clear while writing the tutorial in #159).

This PR achieves this by moving the test dependencies to a `requirements.txt` format file suitable for use with both `uv run --with-requirements` and `uv add --constraints`, which also feels like a more idiomatic way to specify dependency versions. `uv run` invocations are updated accordingly.

Additionally, this PR introduces more robust variadic argument handling via the `positional-arguments` directive, out of necessity for `just add` (see comments), and as a driveby fix for `just static`.