### PR TITLE
docs: show ruff extend-per-file-ignores table in template pyproject.toml

### DIFF
--- a/.example/pyproject.toml
+++ b/.example/pyproject.toml
@@ -49,6 +49,12 @@ path = "src/charmlibs/example/_version.py"
 extend = "../pyproject.toml"
 src = ["src", "tests/unit", "tests/functional", "tests/integration"]  # correctly sort local imports in tests
 
+[tool.ruff.lint.extend-per-file-ignores]
+# add additional per-file-ignores here to avoid overriding repo-level config
+"tests/**/*" = [
+    # "E501",  # line too long
+]
+
 [tool.pyright]
 extends = "../pyproject.toml"
 include = ["src", "tests"]

--- a/.template/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/.template/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -49,6 +49,12 @@ path = "src/charmlibs/{{ cookiecutter.project_slug }}/_version.py"
 extend = "../pyproject.toml"
 src = ["src", "tests/unit", "tests/functional", "tests/integration"]  # correctly sort local imports in tests
 
+[tool.ruff.lint.extend-per-file-ignores]
+# add additional per-file-ignores here to avoid overriding repo-level config
+"tests/**/*" = [
+    # "E501",  # line too long
+]
+
 [tool.pyright]
 extends = "../pyproject.toml"
 include = ["src", "tests"]


### PR DESCRIPTION
This PR adds the `tool.ruff.extend-per-file-ignores` table to the template and example's `pyproject.toml`.