### PR TITLE
ci: replace functional-pebble recipe with setup and teardown scripts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -135,8 +135,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.init.outputs.functional-matrix) }}
     runs-on: ${{ matrix.ubuntu }}
-    env:
-      RECIPE_SUFFIX: ${{ matrix.pebble != 'no-pebble' && '-pebble' || '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -156,11 +154,11 @@ jobs:
 
       - name: Run functional tests
         if: matrix.sudo == 'no-sudo'
-        run: uvx --from rust-just just python=${{ matrix.python }} functional$RECIPE_SUFFIX ${{ inputs.package }}
+        run: uvx --from rust-just just python=${{ matrix.python }} functional ${{ inputs.package }}
 
       - name: Run functional tests with sudo
         if: matrix.sudo != 'no-sudo'
-        run: sudo env "PATH=$PATH" uvx --from rust-just just python=${{ matrix.python }} functional$RECIPE_SUFFIX ${{ inputs.package }}
+        run: sudo env "PATH=$PATH" uvx --from rust-just just python=${{ matrix.python }} functional ${{ inputs.package }}
 
   integration:
     needs: init

--- a/pathops/tests/functional/setup.sh
+++ b/pathops/tests/functional/setup.sh
@@ -1,0 +1,5 @@
+# sourced by `just functional pathops`
+export PEBBLE=/tmp/pebble-test
+umask 0
+pebble run --create-dirs &>/dev/null &
+PEBBLE_PID=$!

--- a/pathops/tests/functional/teardown.sh
+++ b/pathops/tests/functional/teardown.sh
@@ -1,0 +1,2 @@
+# sourced by `just functional pathops`
+kill $PEBBLE_PID


### PR DESCRIPTION
How we handle running `functional` tests with `pebble` has always been a bit of a CI wart, and this became very evident when working on the tutorial in #159. This PR replaces the separate `functional` and `functional-pebble` recipes with sourcing `tests/functional/setup.sh` and `tests/functional/teardown.sh` in `just functional` before and after running tests.

The primary motivation for this change is to have a simpler and more consistent CI and task runner interface for most developers. This PR does not add these files to the template, as most libraries won't need them -- we'll cover this functionality in the docs soon (not the tutorial), and just point to `pathops` as the example.