### PR TITLE
ci: use exclude instead of extend-exclude in base pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,31 @@ exclude_also = [
 [tool.ruff]
 line-length = 99
 target-version = "py38"
-extend-exclude = [
+exclude = [
+    # these are the default values of ruff's exclude
+    # they're duplicated here instead of using extend-exclude
+    # so that libraries can use extend-exclude
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "dist",
+    "node_modules",
+    "venv",
+    # these are the custom excludes specified by this repo
     "__pycache__",
     "*.egg_info",
     "htmlcov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ exclude_also = [
 line-length = 99
 target-version = "py38"
 exclude = [
-    # these are the default values of ruff's exclude
+    # These are the default values of ruff's exclude
     # they're duplicated here instead of using extend-exclude
-    # so that libraries can use extend-exclude
+    # so that libraries can use extend-exclude.
     ".bzr",
     ".direnv",
     ".eggs",
@@ -53,7 +53,7 @@ exclude = [
     "dist",
     "node_modules",
     "venv",
-    # these are the custom excludes specified by this repo
+    # These are the custom excludes specified by this repo.
     "__pycache__",
     "*.egg_info",
     "htmlcov",


### PR DESCRIPTION
This PR updates the repo-level `pyproject.toml` to use `ruff`s `exclude` field instead of `extend-exclude`, so that packages that `extend` this config can use `extend-exclude` freely. Because the `exclude` field completely overrides any default exclusions, we add [ruff's defaults](https://docs.astral.sh/ruff/configuration/) here explicitly.