### PR TITLE
ci: correct path for tls_certificates interface

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,4 +27,4 @@
 /pathops/ @canonical/charmlibs-maintainers
 
 # charmlibs.interfaces packages (alphabetical)
-/tls_certificates/ @canonical/tls
+/interfaces/tls_certificates/ @canonical/tls


### PR DESCRIPTION
This PR is a quick correction to the path specified for the `tls_certificates` interface directory in #168.