### PR TITLE
ci: correct path for CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 /interfaces/ @canonical/charmlibs-maintainers
 
 # codeowners
-/.github/CODEOWNERS @canonical/charmlibs-maintainers
+/CODEOWNERS @canonical/charmlibs-maintainers
 
 # infra
 /.github/ @canonical/charmlibs-maintainers


### PR DESCRIPTION
This PR updates the path in the `CODEOWNERS` file for the `CODEOWNERS` file itself.