### PR TITLE
ci: correctly specify the default code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # default
-. @canonical/charmlibs-maintainers
+* @canonical/charmlibs-maintainers
 /interfaces/ @canonical/charmlibs-maintainers
 
 # codeowners


### PR DESCRIPTION
This PR corrects the syntax used to specify the default code owners for the repo. See the [example here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file).