### PR TITLE
ci: add explicit codeowners for charmlibs-snap

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,6 +25,7 @@
 # charmlibs packages (alphabetical)
 /apt/ @canonical/charmlibs-maintainers
 /pathops/ @canonical/charmlibs-maintainers
+/snap/ @canonical/charmlibs-maintainers
 
 # charmlibs.interfaces packages (alphabetical)
 /interfaces/tls_certificates/ @canonical/tls


### PR DESCRIPTION
This PR adds an explicit entry to the `CODEOWNERS` file for `charmlibs-snap`.