### PR TITLE
feat: release charmlibs-interfaces-tls_certificates 1.0.0

### DIFF
--- a/interfaces/tls_certificates/src/charmlibs/interfaces/tls_certificates/_version.py
+++ b/interfaces/tls_certificates/src/charmlibs/interfaces/tls_certificates/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0.dev0"
+__version__ = "1.0.0"


### PR DESCRIPTION
This PR bumps the version of the `charmlibs-interfaces-tls_certificates` lib to `1.0.0` to trigger a release.

The release for this library was tested by releasing the `1.0.0.dev0` version to: https://test.pypi.org/project/charmlibs-interfaces-tls-certificates/