### PR TITLE
chore: apply global test per-file-ignores to interfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"./*/tests/*" = [
+"./**/tests/*" = [
     # All documentation linting.
     "D",
 


### PR DESCRIPTION
This PR updates the glob for the `tests` directories in the global `ruff` config for `per-file-ignores` to use `**` instead of `*`, including `interfaces/foo/tests` and `interfaces/foo/interface/tests`.