### PR TITLE
ci: allow pyproject.toml in non package dirs

### DIFF
--- a/.scripts/ls.py
+++ b/.scripts/ls.py
@@ -211,7 +211,8 @@ def _get_version(root: pathlib.Path, package: pathlib.Path | str) -> str | None:
     if not (root / package).exists():
         return None
     logger.debug('Computing version for %s', package)
-    dist_name = tomllib.loads((root / package / 'pyproject.toml').read_text())['project']['name']
+    with (root / package / 'pyproject.toml').open() as f:
+        dist_name = tomllib.load(f)['project']['name']
     script = f'import importlib.metadata; print(importlib.metadata.version("{dist_name}"))'
     cmd = ['uv', 'run', '--no-project', '--with', f'./{package}', 'python', '-c', script]
     return subprocess.check_output(cmd, cwd=root, text=True).strip()

--- a/.scripts/ls.py
+++ b/.scripts/ls.py
@@ -211,17 +211,7 @@ def _get_version(root: pathlib.Path, package: pathlib.Path | str) -> str | None:
     if not (root / package).exists():
         return None
     logger.debug('Computing version for %s', package)
-    # TODO: read dist name from pyproject.toml, using either tomli or tomllib
-    aliases = {
-        # placeholders
-        '.package': 'charmlibs',
-        'interfaces/.package': 'charmlibs-interfaces',
-        # examples
-        '.example': 'charmlibs-example',
-        'interfaces/.example': 'charmlibs-interfaces-example',
-        '.tutorial': 'charmlibs-uptime',
-    }
-    dist_name = aliases.get(str(package), f'charmlibs-{package}'.replace('/', '-'))
+    dist_name = tomllib.loads((root / package / 'pyproject.toml').read_text())['project']['name']
     script = f'import importlib.metadata; print(importlib.metadata.version("{dist_name}"))'
     cmd = ['uv', 'run', '--no-project', '--with', f'./{package}', 'python', '-c', script]
     return subprocess.check_output(cmd, cwd=root, text=True).strip()


### PR DESCRIPTION
This PR updates `.scripts/ls.py` to use `tomllib` for two purposes:
1. Only count a directory as a package if the `pyproject.toml` file has a `project` table -- this will allow us to use `pyproject.toml` files for tool configuration in non-package directories (like interface directories that only have the interface definition).
2. Remove the `aliases` table and read the package's distribution name from the `pyproject.toml` file directly.