### PR TITLE
revert: intefaces/tls_certificates version bump from failed release

### DIFF
--- a/interfaces/tls_certificates/src/charmlibs/interfaces/tls_certificates/_version.py
+++ b/interfaces/tls_certificates/src/charmlibs/interfaces/tls_certificates/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.0.0"
+__version__ = "1.0.0.dev0"


### PR DESCRIPTION
Revert "feat: release charmlibs-interfaces-tls_certificates 1.0.0 (#182)"

This reverts commit c6cc92acc4c34b77cec5c8d4e9a91fdab5b972fe.