### PR TITLE
ci: install pytest-interface-tester when type checking

### DIFF
--- a/justfile
+++ b/justfile
@@ -62,6 +62,7 @@ static package *args:
     cd '{{package}}'
     {{_uv_run_with_test_requirements}} \
         --group lint --group unit --group functional --group integration \
+        --with pytest-interface-tester \
         pyright --pythonversion='{{python}}' "${@}"
 
 [doc("Run unit tests with `coverage`, e.g. `just python=3.10 unit pathops`.")]


### PR DESCRIPTION
This PR updates the `just static` recipe, used for type checking locally and in CI, to install `pytest-interface-tester` when running `pyright`. This is to support type checking the `schema.py` and `test_provider.py` and `test_requirer.py` files added in interface definitions (e.g.: #174).

I'm not sure if this is the right approach.
- One alternative would be to require interface libraries to add `pytest-interface-tester` to their `lint` dependency group -- but how would we handle interfaces without a library?
- Another idea would be to support some dependency configuration for the interfaces themselves, e.g. a `requirements.txt` file under `interfaces/<interface name>/interface` alongside the `vN` directories. This would require some logic to handle the file not existing, since it won't exist for non-interface libraries.
- A third idea would be to separate the interface type checking from the library type checking entirely. So we might have `just lint interfaces/foo` and `just interface lint foo`. We'd probably still want `ruff` to check the interface files when running `just fast-lint` though, so maybe that would be a little confusing.

I'm happy to try some other ideas, or we could just merge this simple fix for now and investigate other approaches if it becomes a problem down the line.