### PR TITLE
ci: treat .scripts directory as global for detecting changed packages in CI

### DIFF
--- a/.github/get-changed.py
+++ b/.github/get-changed.py
@@ -24,7 +24,7 @@ import os
 import pathlib
 import subprocess
 
-_GLOBAL_FILES = {'.github', 'justfile', 'pyproject.toml'}
+_GLOBAL_FILES = {'.github', '.scripts', 'justfile', 'pyproject.toml'}
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 
 logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
This PR adds `.scripts/` to the list directories considered as global for the purposes of deciding which tests to run -- if a global file is changed, tests are run for all packages.