### PR TITLE
docs: urls like interfaces/<interface>/v0 instead of readme-v0

### DIFF
--- a/.docs/extensions/interface_docs.py
+++ b/.docs/extensions/interface_docs.py
@@ -81,7 +81,7 @@ def _main(docs_dir: pathlib.Path) -> None:
                 lambda m: f'[m.group(1)]({base_url}/{m.group(2)})',  # noqa: B023
                 readme_raw,
             )
-            _write_if_needed(path=interface_ref_dir / f'readme-{v.name}.md', content=readme)
+            _write_if_needed(path=interface_ref_dir / f'{v.name}.md', content=readme)
 
 
 def _write_if_needed(path: pathlib.Path, content: str) -> None:


### PR DESCRIPTION
This PR changes the readme files to be written to `v<N>.md` instead of `readme-v<N>.md` so that the URLs are nicer.