### PR TITLE
docs: make template prompt accurate for interface libraries

### DIFF
--- a/.template/cookiecutter.json
+++ b/.template/cookiecutter.json
@@ -9,8 +9,8 @@
   "__import_pkg": "{{ cookiecutter.__ns }}.{{ cookiecutter.__pkg }}",
   "__dist_pkg": "{{ cookiecutter.__import_pkg.replace('.', '-').replace('_', '-') }}",
   "__prompts__": {
-    "project_slug": "The canonical interface name for interface libraries, otherwise the import package name without the charmlibs prefix, e.g.",
-    "min_python_version": "The minimum Python version supported by the package",
-    "author": "The author field for PyPI"
+    "project_slug": "🌈 The project name",
+    "min_python_version": "🐍 The minimum Python version supported by the package",
+    "author": "📝 The author field for PyPI"
   }
 }

--- a/interface.just
+++ b/interface.just
@@ -5,4 +5,6 @@ help:
 
 [doc('Create the files for a new charmlibs.interfaces package interactively.')]
 init *args:
-    env CHARMLIBS_TEMPLATE=$(realpath .template) uvx cookiecutter --output-dir interfaces .template _interface=True {{args}}
+    @echo '✨{{BOLD}}IMPORTANT{{NORMAL}}✨ The project name should be the canonical interface name, as used in {{CYAN}}charmcraft.yaml{{NORMAL}} files.'
+    @echo 'You can press enter to accept the default, shown in brackets.'
+    @env CHARMLIBS_TEMPLATE=$(realpath .template) uvx cookiecutter --output-dir interfaces .template _interface=True {{args}}

--- a/justfile
+++ b/justfile
@@ -18,7 +18,9 @@ _help:
 
 [doc('Create the files for a new charmlibs package interactively.')]
 init *args:
-    env CHARMLIBS_TEMPLATE=$(realpath .template) uvx cookiecutter .template {{args}}
+    @echo '✨{{BOLD}}IMPORTANT{{NORMAL}}✨ The project name should be the import package name, without the {{CYAN}}charmlibs.{{NORMAL}} namespace.'
+    @echo 'You can press enter to accept the default, shown in brackets.'
+    @env CHARMLIBS_TEMPLATE=$(realpath .template) uvx cookiecutter .template {{args}}
 
 [doc('Run `ruff` and `codespell`, failing afterwards if any errors are found.')]
 fast-lint:


### PR DESCRIPTION
When running `just init` or `just interface init`, the user is prompted for their project name. The prompt previously said it should be the package name, but this is only the case for `just init` -- with `just interface init` it's important that the user instead specifies the canonical interface name.

This PR updates the prompt displayed to account for both cases, using a short generic prompt inside `cookiecutter`, but printing extra details beforehand via the `just` recipe.

**OLD**
<img width="1125" height="119" alt="image" src="https://github.com/user-attachments/assets/e383dbcf-e36d-47cc-bd09-66df5585494a" />
<img width="1125" height="119" alt="Screenshot from 2025-10-16 12-51-51" src="https://github.com/user-attachments/assets/07cb451f-1456-4b11-86be-373fe1b001ef" />

**NEW**
<img width="997" height="140" alt="Screenshot from 2025-10-16 12-50-29" src="https://github.com/user-attachments/assets/68716ca8-072a-40f7-b0cf-1e8d2364d06a" />
<img width="1048" height="140" alt="Screenshot from 2025-10-16 12-50-58" src="https://github.com/user-attachments/assets/2adc5146-3906-4f14-b75f-ca9ed69e85e6" />
