### PR TITLE
ci: actually use requested python with uv, and use system for functional

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -154,11 +154,11 @@ jobs:
 
       - name: Run functional tests
         if: matrix.sudo == 'no-sudo'
-        run: uvx --from rust-just just python=${{ matrix.python }} functional ${{ inputs.package }}
+        run: uvx --from rust-just just python=python3 functional ${{ inputs.package }}
 
       - name: Run functional tests with sudo
         if: matrix.sudo != 'no-sudo'
-        run: sudo env "PATH=$PATH" uvx --from rust-just just python=${{ matrix.python }} functional ${{ inputs.package }}
+        run: sudo env "PATH=$PATH" uvx --from rust-just just python=python3 functional ${{ inputs.package }}
 
   integration:
     needs: init

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ python := '3.10'
 # for integration tests, e.g. `just tag=24.04 pack-k8s` `just tag=foo integration-machine`
 tag := env('CHARMLIBS_TAG', '')
 
-_uv_run_with_test_requirements := 'uv run --with-requirements ' + quote(join(justfile_dir(), 'test-requirements.txt'))
+_uv_run_with_test_requirements := 'uv run --with-requirements ' + quote(join(justfile_dir(), 'test-requirements.txt')) + ' --python ' + python
 
 # this is the first recipe in the file, so it will run if just is called without a recipe
 [doc('Describe usage and list the available recipes.')]


### PR DESCRIPTION
This PR updates the `justfile` to actually pass the `python` variable to `uv` (!) -- we've been implicitly only using the system Python for some time now.

Additionally, it updates the `functional` tests in CI to run with the system Python -- previously we were using `matrix.python`, but at some point `python` was removed from the matrix, so this was just setting `python` to an empty string (which wasn't being passed to `uv`, so it didn't fail). Since the `functional` tests are run on a matrix of Ubuntu bases, it makes sense to just use the `python` from there.