### PR TITLE
ci: allow skipping building reference docs locally

### DIFF
--- a/docs.just
+++ b/docs.just
@@ -21,9 +21,11 @@ to be combined into the final docs in a separate pass.
 """)]
 _packages *packages:
     #!/usr/bin/env -S uv run --script --no-project
-    import json, pathlib, subprocess
+    import json, pathlib, subprocess, sys
     ROOT = pathlib.Path('{{justfile_directory()}}')
     packages = '{{packages}}'.split()
+    if packages == ['-']:
+        sys.exit()
     if not packages:
         cmd = [ROOT / '.scripts/ls.py', 'packages', '--exclude-examples', '--exclude-placeholders']
         packages = json.loads(subprocess.check_output(cmd, text=True))


### PR DESCRIPTION
This PR adds the ability to skip building the package reference docs by passing `-` as the package argument. This speeds up the docs build a ton, which is very useful when working on non-package reference docs like how-to guides.