### PR TITLE
docs: drop mention of pathops specifically in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ The easiest way to report a security issue is through
 vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
 for instructions on reporting using GitHub's security advisory feature.
 
-The pathops GitHub admins will be notified of the issue and will work with you
+The GitHub repository admins will be notified of the issue and will work with you
 to determine whether the issue qualifies as a security issue and, if so, in
 which component. We will then figure out a fix, get a CVE assigned, and coordinate
 the release of the fix.


### PR DESCRIPTION
This PR updates the `SECURITY.md` file to not refer to just `pathops` specifically -- this is leftover from when this project was just a repository for `charmlibs.pathops`.