### PR TITLE
ci: add workflow to complain if PR titles don't follow conventional commits

### DIFF
--- a/.github/workflows/conventional-pr-title.yaml
+++ b/.github/workflows/conventional-pr-title.yaml
@@ -1,0 +1,18 @@
+name: 'PR title follows conventional commits'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow that validates PR titles, using the same action as [we use in ops](https://github.com/canonical/operator/blob/main/.github/workflows/validate-pr-title.yaml).

I've used the same commit hash for the action as `ops` uses, but otherwise followed [the actions recommended configuration](https://github.com/marketplace/actions/semantic-pull-request#installation) which differs slightly from `ops` (default commit types, read permission at step scope instead of workflow scope, slightly different `pull_request_target` triggers).

Because the workflow runs on `pull_request_target`, it won't run on this PR -- it will only run on PRs after it's merged to `main`.

---

The interface test failures are unrelated.