### PR TITLE
fix: use locked dependencies to run interface tests

### DIFF
--- a/interfaces/tracing/interface/v2/interface.yaml
+++ b/interfaces/tracing/interface/v2/interface.yaml
@@ -8,7 +8,7 @@ providers:
     url: https://github.com/canonical/tempo-operators
     test_setup:
       charm_root: coordinator
-      pre_run: uv pip compile pyproject.toml --quiet --output-file requirements.txt
+      pre_run: uv export --frozen --format requirements.txt --output-file requirements.txt
       location: tests/interface/conftest.py
       identifier: tracing_tester
 
@@ -17,7 +17,7 @@ requirers:
     url: https://github.com/canonical/pyroscope-operators
     test_setup:
       charm_root: coordinator
-      pre_run: uv pip compile pyproject.toml --quiet --output-file requirements.txt
+      pre_run: uv export --frozen --format requirements.txt --output-file requirements.txt
       location: tests/interface/conftest.py
       identifier: tracing_tester
 


### PR DESCRIPTION
This PR fixes the failing `tracing` interface tests by updating the `tempo-coordinator-k8s` and `pyroscope-coordinator-k8s` interface test configuration to respect the charms' locked dependencies, by using `uv export` instead of `uv pip compile` in their `pre_run`.

Thanks @PietroPasotti for identifying the fix!