### PR TITLE
docs: link to the migration guide on the homepage

### DIFF
--- a/.docs/index.md
+++ b/.docs/index.md
@@ -41,6 +41,7 @@ If you're new to charms, see {ref}`Juju | Charm <juju:charm>`.
 **Step-by-step guides**
 - {ref}`Manage charm libraries <how-to-manage-charm-libraries>`
 - {ref}`Distribute charm libraries <how-to-python-package>`
+- {ref}`Migrate your library to the monorepo <how-to-migrate>`
 - {ref}`Customize functional tests <how-to-customize-functional-tests>`
 - {ref}`Customize integration tests <how-to-customize-integration-tests>`
 ```


### PR DESCRIPTION
This PR adds a link to the migration guide in the how-to section of the homepage.