### PR TITLE
ci: temporarily add global codespell ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,9 @@ convention = "google"
 check-hidden = true
 quiet-level = 3  # disable warnings about (1) wrong encoding + (2) binary files
 ignore-regex = "(?:[A-Za-z0-9+/]|\\\\n){100,}"  # ignore long base64 strings (including Python \n)
+ignore-words-list = [  # temporary until we add a per-library solution
+    "aNULL"
+]
 skip = [
     ".docs",
     ".git",


### PR DESCRIPTION
This PR temporarily adds a global codespell ignore list to support landing #245 without a proliferation of in-line ignores.

#246 captures the need to solve this in a more general way in future.