### PR TITLE
docs: fix silent failure to load doctree

### DIFF
--- a/.docs/extensions/package_docs.py
+++ b/.docs/extensions/package_docs.py
@@ -75,7 +75,7 @@ def _save_on_doctree_resolved(
     package = app.config.package
     # only save when building docs for a specific package
     # only save package reference docs
-    if package is None or docname != f'reference/charmlibs/{package}':
+    if package is None or docname != f'reference/charmlibs/{_normalize(package)}':
         return
     objects = app.env.domains['py'].data['objects']
     modules = app.env.domains['py'].data['modules']


### PR DESCRIPTION
This PR fixes a bug in the local `package_docs` Sphinx extension, introduced when we started normalizing the URLs to use the canonical distribution package name -- the package argument also needs to be normalized when comparing to doctree names, otherwise we don't correctly save the doctree for the current package docs being built. This results in a blank page for that package.

[Live](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/nginx-k8s/) (blank)
[Preview build](https://canonical-ubuntu-documentation-library--248.com.readthedocs.build/charmlibs/reference/charmlibs/nginx-k8s/) (fixed)