### PR TITLE
fix: (tls-certificates) store `Mode.APP` secrets as app-owned secrets

### DIFF
--- a/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_tls_certificates.py
+++ b/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_tls_certificates.py
@@ -1370,9 +1370,8 @@ class TLSCertificatesRequiresV4(Object):
                 "this function can't be used"
             )
         if self.mode == Mode.APP and not self.model.unit.is_leader():
-            raise TLSCertificatesError(
-                "Only the leader can regenerate the private key in APP mode"
-            )
+            logger.warning("Only the leader can regenerate the private key in APP mode")
+            return
         if not self._private_key_generated():
             logger.warning("No private key to regenerate")
             return


### PR DESCRIPTION
## Overview
Store private keys as an app-owned secret when using `Mode.APP`
## Rationale
In `Mode.APP`, the private key is stored using `self.charm.unit.add_secret()`, which creates a unit-owned secret. When leadership changes, the new leader generates a new private key because it can't access the previous leader's unit-owned secret. When trying to recover the app certificate, the library fails to do so with:
```
unit-k8s-2: 11:25:05 WARNING unit.k8s/2.juju-log Certificate does not match the private key. Ignoring invalid certificate.
unit-k8s-2: 11:25:05 ERROR unit.k8s/2.juju-log Waiting for the etcd client certificate
unit-k8s-2: 11:25:05 ERROR unit.k8s/2.juju-log Caught ReconcilerError
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-k8s-2/charm/venv/lib/python3.12/site-packages/charms/reconciler.py", line 45, in reconcile
    self.reconcile_function(event)
  File "/var/lib/juju/agents/unit-k8s-2/charm/src/charm.py", line 998, in _reconcile
    self._check_etcd_ready()
  File "/var/lib/juju/agents/unit-k8s-2/charm/src/charm.py", line 1256, in _check_etcd_ready
    raise ReconcilerError(msg)
charms.contextual_status.ReconcilerError: Waiting for the etcd client certificate
```
Because the certificate was issued for the CSR generated with the unit-scoped private key, so it doesn't match the new private key.

### Steps to Reproduce
1. Deploy a `tls-certificates` consumer that uses app wide certificates (i.e., `Mode.APP`).
2. Stop the `jujud` agent on the leader unit to force a leader election.
3. The new leader cannot access the `app` private key. Therefore, the certificate cannot be used by the new leader.