### PR TITLE
ci: fix post-publish tag push failure by persisting credentials

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          persist-credentials: true  # needed to push tag
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:


### PR DESCRIPTION
After publishing a library to PyPI, we push a tag to the repository. Pushing the tag currently fails. This PR fixes this by persisting the necessary credentials.

[Example failure](https://github.com/canonical/charmlibs/actions/runs/19717950519/job/56494464775):
```
+ git config user.name github-actions
+ git config user.email github-actions@github.com
+ git tag systemd-v1.0.0
+ git push origin systemd-v1.0.0
fatal: could not read Username for 'https://github.com/': No such device or address
Error: Process completed with exit code 128.
```

Note that I've manually pushed the `systemd-v1.0.0` tag in the meantime.