### PR TITLE
test(apt): expect currently failing test to fail

### DIFF
--- a/apt/tests/functional/test_apt.py
+++ b/apt/tests/functional/test_apt.py
@@ -10,6 +10,8 @@ import subprocess
 from pathlib import Path
 from urllib.request import urlopen
 
+import pytest
+
 import charmlibs.apt as apt
 
 logger = logging.getLogger(__name__)
@@ -136,6 +138,7 @@ def test_install_higher_version_package_from_external_repository():
     assert not shutil.which('fish')
 
 
+@pytest.mark.xfail  # https://github.com/canonical/charmlibs/issues/282
 def test_install_hardware_observer_ssacli():
     """Test the ability to install a package used by the hardware-observer charm.
 


### PR DESCRIPTION
One of the `apt` functional tests is currently failing, presumably due to changes in the external repository we were using for this test. This is tracked in #282. As a temporary quality of life improvement for everyone who merges in this repository (as this test is run on every merge to `main`) this PR marks this test with `pytest.mark.xfail`.