### PR TITLE
ci: add maintenance branch to workflows triggers to minimise diff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,11 @@ name: CI
 on:
   push:
     branches:
-      - main
+      # NOTE: the workflow runs from the current branch
+      # only the branch name matching the current branch actually matters
+      # but we list them all to minimise the diff across branches
+      - 'main'
+      - '*-maintenance'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,7 +4,11 @@ name: Docs
 on:
   push:
     branches:
-      - main
+      # NOTE: the workflow runs from the current branch
+      # only the branch name matching the current branch actually matters
+      # but we list them all to minimise the diff across branches
+      - 'main'
+      - '*-maintenance'
   pull_request:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,11 @@ name: Publish
 on:
   push:
     branches:
+      # NOTE: the workflow runs from the current branch
+      # only the branch name matching the current branch actually matters
+      # but we list them all to minimise the diff across branches
       - 'main'
+      - '*-maintenance'
   workflow_dispatch:
     inputs:
       package:


### PR DESCRIPTION
This PR adds the `*-maintenance` branches to the list of branches we trigger workflows from on `push`. This is in preparation for updating the CI for the `20.04-maintenance` branch, which is necessary if we want to publish from that branch, since we've switched from using Github releases to releasing via the `publish.yaml` workflow (#287).