### PR TITLE
fix: correct default CODEOWNERS specification

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # default
-. @canonical/charmlibs-maintainers
+* @canonical/charmlibs-maintainers
 /interfaces/ @canonical/charmlibs-maintainers
 
 # codeowners


### PR DESCRIPTION
The `CODEOWNERS` file in the `20.04-maintenance` branch has a mistake that was fixed in `main` (in #180). This PR adds the same fix to this branch.