### PR TITLE
ci: fix old version check for adding a package to an existing interface

### DIFF
--- a/.scripts/ls.py
+++ b/.scripts/ls.py
@@ -246,9 +246,10 @@ def _get_changed_versions_only(
     with _snapshot_repo(ref) as old_root:
         old_versions: dict[str, str] = {}
         for path in dirs:
-            if not (old_root / path).exists():
+            try:
+                name = _get_name(category, old_root, path)
+            except FileNotFoundError:
                 continue
-            name = _get_name(category, old_root, path)
             version = _get_version(category, old_root, path)
             old_versions[name] = version
     changed: list[pathlib.Path] = []


### PR DESCRIPTION
In `main`, the `ls.py` script run with the `--only-if-version-changed` flag tries to get the old artefact (interface or package) version as long as the directory (e.g. `interfaces/foo`) existed in the old commit. This fails in CI when we the new commit adds a Python package to an existing interface definition, because the directory exists in the old commit, but the expected `pyproject.toml` files doesn't.

This was noticed in #294 ([example failure](https://github.com/canonical/charmlibs/actions/runs/20257104334/job/58161396240?pr=294)).

(There would be a symmetrical failure for adding an interface definition to an existing package, but we don't run anything conditional on that in CI.)


This PR fixes this bug by skipping based on the relevant `FileNotFoundError` instead of testing for the directory's presence.

I've verified locally that adding a library to an existing interface fails with the old version of the script, but works as expected with the updated version from this PR.