### PR TITLE
ci: use TarFile.extractall in the recommended way

### DIFF
--- a/.scripts/ls.py
+++ b/.scripts/ls.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script --no-project
 
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.12"
 # dependencies = [
 #     "PyYAML",
 # ]
@@ -284,7 +284,7 @@ def _snapshot_repo(ref: str | None):
         git = subprocess.run(['git', 'archive', ref], stdout=subprocess.PIPE, check=True)
         stream = io.BytesIO(git.stdout)
         with tarfile.open(fileobj=stream) as tar:
-            tar.extractall(path=root)  # noqa: S202
+            tar.extractall(path=root, filter='data')
         yield root
 
 


### PR DESCRIPTION
This PR updates `.scripts/ls.py` to use `TarFile.extractall` in the [recommended way](https://docs.python.org/3.12/library/tarfile.html#tarfile.TarFile.extractall) -- setting `filter='data'`. This silences a deprecation warning for using `extractall` without an explicit `filter` argument, and removes the need to `noqa` [S202](https://docs.astral.sh/ruff/rules/tarfile-unsafe-members/) (though we trust the extracted data anyway since it's a snapshot of our own repo). This raises the minimum Python version needed to run the script, as the `filter` argument was added in Python 3.12, but I believe we were running with this version in CI anyway (which is why we were getting the deprecation warnings).