### PR TITLE
ci: pass `package` arg from `lint` to `fast-lint` to scope linting

### DIFF
--- a/justfile
+++ b/justfile
@@ -43,12 +43,12 @@ init *args:
     @env CHARMLIBS_TEMPLATE=$(realpath .template) uvx cookiecutter .template {{args}}
 
 [doc('Run `ruff`, failing afterwards if any errors are found.')]
-fast-lint:
+fast-lint path='.':
     #!/usr/bin/env -S bash -xueo pipefail
     FAILURES=0
-    uv run --only-group=fast-lint ruff check --preview || ((FAILURES+=1))
-    uv run --only-group=fast-lint ruff check --preview --diff || : 'Printed diff of changes to fix `ruff check` issues.'
-    uv run --only-group=fast-lint ruff format --preview --diff || ((FAILURES+=1))
+    uv run --only-group=fast-lint ruff check --preview '{{path}}' || ((FAILURES+=1))
+    uv run --only-group=fast-lint ruff check --preview --diff '{{path}}' || : 'Printed diff of changes to fix `ruff check` issues.'
+    uv run --only-group=fast-lint ruff format --preview --diff '{{path}}' || ((FAILURES+=1))
     : "$FAILURES command(s) failed."
     exit $FAILURES
 
@@ -68,13 +68,13 @@ add package +args:
     cd '{{package}}'
     uv add --constraints {{quote(join(justfile_dir(), 'test-requirements.txt'))}} "${@}"
 
-[doc('Run global `fast-lint` and package specific `static` analysis, e.g. `just python=3.10 lint pathops`.')]
+[doc('Run linting and static analysis for a specific package, e.g. `just python=3.10 lint interfaces/tls-certificates`.')]
 [positional-arguments]  # pass recipe args to recipe script positionally (so we can get correct quoting)
 lint package *pyright_args:
     #!/usr/bin/env -S bash -xueo pipefail
     shift 1  # drop $1 (package) from $@ it's just *args
     FAILURES=0
-    just --justfile='{{justfile()}}' python='{{python}}' fast-lint || ((FAILURES+=$?))
+    just --justfile='{{justfile()}}' python='{{python}}' fast-lint '{{package}}' || ((FAILURES+=$?))
     just --justfile='{{justfile()}}' python='{{python}}' static '{{package}}' "${@}" || ((FAILURES+=1))
     : "$FAILURES command(s) failed."
 


### PR DESCRIPTION
`just fast-lint` runs fast linting checks for all files in the repo. `just lint <package>` runs `fast-lint`, as well as the slower type checking jobs for a `<package>`.

This means that `just lint <package>` can show fast linting errors from other packages or global files. This isn't a problem in CI since we keep it green (bugs aside!), but it can be annoying locally.

This PR updates the `fast-lint` to take a path argument, defaulting to `.`, the `justfile` directory (the repository root). Since `ruff` runs recursively on subdirectories, this preserves the existing behaviour. The `lint` recipe has been updated to pass the `<package>` argument to `fast-lint`, scoping the fast linting checks to the package actually being targeted.