### PR TITLE
ci: configure dependabot for monthly updates to repo-level test deps

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,12 +2,26 @@
 
 version: 2
 updates:
+  # Monthly updates to Github actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"  # This is hard-coded to the 1st of the month
     labels:
       - "dependencies"
+  # Monthly update to repo wide Python testing dependencies
+  # These are defined in /pyproject.toml and /test-requirements.txt
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    groups:
+      test-deps:
+        patterns:
+          - "*"
+  # Daily security updates to individual Python packages
   - package-ecosystem: "pip"
     directories:
       - "/"


### PR DESCRIPTION
When we created this repository, the intention was that all packages would use the same tool versions (`ruff`, `pyright`, etc), and that these would be always be pretty recent versions. However, we don't have a process for when these should be updated. This PR configures `dependabot` to provide monthly updates to the repo-level test dependencies.