### PR TITLE
ci: update pyright version to latest

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 coverage==7.6.1
-pyright==1.1.397
+pyright==1.1.408
 pytest==8.3.5


### PR DESCRIPTION
This PR updates the `pyright` version used in CI to 1.1.408, which resolves some issues with type checking of namespace packages. In future updating the `pyright` version will be handled automatically via `dependabot` thanks to #329.