### PR TITLE
ci: disable docs link checking for now

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,12 +45,14 @@ jobs:
         uses: canonical/documentation-workflows/spellcheck@6f9c05eae99ca9fff05250810bba2a71a380ebd1  # main
         with:
           working-directory: .docs
-      - name: Links
-        id: linkcheck-step
-        if: success() || failure()
-        run: |
-          set -xueo pipefail
-          uvx --from rust-just just docs linkcheck ${{ github.event_name != 'pull_request' && '--tag check-github-links' || '' }}
+      # Disable link checking until we get a more robust solution.
+      # The current approach often fails due to rate limiting and timeouts.
+      # - name: Links
+      #   id: linkcheck-step
+      #   if: success() || failure()
+      #   run: |
+      #     set -xueo pipefail
+      #     uvx --from rust-just just docs linkcheck ${{ github.event_name != 'pull_request' && '--tag check-github-links' || '' }}
       - name: Markdown lint
         id: markdown-step
         if: success() || failure()


### PR DESCRIPTION
Recently, the docs checks have been failing a lot due to the link checker getting rate limited. This is annoying and unhelpful for contributors, so let's just disable it for now. #336 tracks implementing a better solution in future.