### PR TITLE
ci: disable concurrency in Docs CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,9 +15,10 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# Disable concurrency for convenience while the link checker is disabled.
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
 
 jobs:
   docchecks:


### PR DESCRIPTION
This PR disables the Github `concurrency` block in Docs CI. With the link checker disabled, I don't think there's a good reason not to just run each job to completion. This will avoid receiving a cancellation email when pushing multiple commits in quick succession.