### PR TITLE
ci: add a static local job to verify that docs build successfully

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,6 +203,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          fetch-depth: 0  # We need the git history for 'Last updated on ...'
           persist-credentials: false
       - uses: astral-sh/setup-uv@v7
       - run: uvx --from rust-just just docs html


### PR DESCRIPTION
A docs build failure was recently introduced on `main` via #333. To prevent this happening again in future, this PR adds a new check to `ci.yaml` which builds the docs locally. This will be made a required check in https://github.com/canonical/canonical-repo-automation/pull/689