### PR TITLE
chore(interface-k8s-backup-target): fix broken docs link in README

### DIFF
--- a/interfaces/k8s_backup_target/CHANGELOG.md
+++ b/interfaces/k8s_backup_target/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.0.post0 - 13 March 2026
+
+Fix docs link in README.
+
 # 0.1.0 - 5 March 2026
 
 Initial release of the `k8s_backup_target` interface library.

--- a/interfaces/k8s_backup_target/README.md
+++ b/interfaces/k8s_backup_target/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-k8s-backup-target` to your Python dependen
 from charmlibs.interfaces import k8s_backup_target
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/k8s_backup_target).
+See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/k8s-backup-target).

--- a/interfaces/k8s_backup_target/src/charmlibs/interfaces/k8s_backup_target/_version.py
+++ b/interfaces/k8s_backup_target/src/charmlibs/interfaces/k8s_backup_target/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.1.0'
+__version__ = '0.1.0.post0'


### PR DESCRIPTION
The reference documentation URL used underscores instead of hyphens, resulting in a broken link. Bump to post release for the metadata-only change.