### PR TITLE
ci: run on older runner temporarily to avoid integration test failures

### DIFF
--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -195,7 +195,7 @@ jobs:
   integration:
     needs: init
     if: contains(fromJson(needs.init.outputs.tests), 'integration') && !inputs.skip-juju
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR updates the `integration` job to run on `ubuntu-22.04` instead of on `ubuntu-latest` to avoid https://github.com/juju/juju/issues/22112

This is a temporary workaround and will be reverted once the upstream issue is resolved.