### PR TITLE
feat: add --preview to pyproject.toml

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,9 +46,9 @@ init *args:
 fast-lint path='.':
     #!/usr/bin/env -S bash -xueo pipefail
     FAILURES=0
-    uv run --only-group=fast-lint ruff check --preview '{{path}}' || ((FAILURES+=1))
-    uv run --only-group=fast-lint ruff check --preview --diff '{{path}}' || : 'Printed diff of changes to fix `ruff check` issues.'
-    uv run --only-group=fast-lint ruff format --preview --diff '{{path}}' || ((FAILURES+=1))
+    uv run --only-group=fast-lint ruff check '{{path}}' || ((FAILURES+=1))
+    uv run --only-group=fast-lint ruff check --diff '{{path}}' || : 'Printed diff of changes to fix `ruff check` issues.'
+    uv run --only-group=fast-lint ruff format --diff '{{path}}' || ((FAILURES+=1))
     : "$FAILURES command(s) failed."
     exit $FAILURES
 
@@ -57,8 +57,8 @@ check package: (lint package) (unit package) (docs::html package)
 
 [doc('Run `ruff check --fix` and `ruff --format`, modifying files in place.')]
 format package='.':
-    uv run --only-group=fast-lint ruff format --preview '{{package}}'
-    uv run --only-group=fast-lint ruff check --preview --fix '{{package}}'
+    uv run --only-group=fast-lint ruff format '{{package}}'
+    uv run --only-group=fast-lint ruff check --fix '{{package}}'
 
 [doc("Run `uv add` for package, respecting repo-level version constraints, e.g. `just add pathops 'pydantic>=2'`.")]
 [positional-arguments]  # pass recipe args to recipe script positionally (so we can get correct quoting)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ exclude_also = [
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
+required-version = "==0.11.0"
 target-version = "py310"
 exclude = [
     # These are the default values of ruff's exclude
@@ -64,9 +65,11 @@ exclude = [
 
 # Ruff formatter configuration
 [tool.ruff.format]
+preview = true
 quote-style = "single"
 
 [tool.ruff.lint]
+preview = true
 select = [
     # flake8-builtins
     "A",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ exclude_also = [
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
-required-version = "==0.11.0"
 target-version = "py310"
 exclude = [
     # These are the default values of ruff's exclude


### PR DESCRIPTION
Following our conversation with @james-garner-canonical in #411 

This change adds the preview = true flag to the pyproject.toml file, removing the need to pass it as a cli variable in the just file. This lets LSP's also automatically pick up that configuration and run it while formatting on save.

One issue with that remains is some LSP's don't respect the ruff version declaration in the configuration, which may produce a different output depending on which one is used. The project uses 0.11, and mine coincidentally was using 0.15, which produced inconsistent outputs.

The solutions to that are:
* pinning the editor's ruff version to 0.11 
* updating to the most recent version 
* dropping the preview all together