### PR TITLE
ci: expand the files considered global

### DIFF
--- a/.github/get-changed.py
+++ b/.github/get-changed.py
@@ -24,7 +24,14 @@ import os
 import pathlib
 import subprocess
 
-_GLOBAL_FILES = {'.github', '.scripts', 'justfile', 'pyproject.toml'}
+_GLOBAL_FILES = {
+    '.github',
+    '.scripts',
+    'justfile',
+    'pyproject.toml',
+    'uv.lock',
+    'test-requirements.txt',
+}
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 
 logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
This PR expands the files considered global, meaning they require tests for all packages to run when modified. The files added to the global list in this PR are the top-level `uv.lock` and `test-requirements.txt` files. This will ensure that we test our infra properly when updating global test dependencies.