### PR TITLE
ci: use an environment for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,6 +53,7 @@ jobs:
   build-n-publish:
     needs: [unify-inputs,test-package]
     if: ${{ needs.unify-inputs.outputs.include != '[]' }}
+    environment: pypi
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,7 +53,7 @@ jobs:
   build-n-publish:
     needs: [unify-inputs,test-package]
     if: ${{ needs.unify-inputs.outputs.include != '[]' }}
-    environment: pypi
+    environment: publish-pypi
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR updates the `build-n-publish` job of the `publish` workflow to use a Github environment.

CI in the PR can't really test this, but I'll be making a library release shortly after landing this PR which will test it.