### PR TITLE
ci: use normalised package name in template and example

### DIFF
--- a/.template/{{ cookiecutter.project_slug }}/README.md
+++ b/.template/{{ cookiecutter.project_slug }}/README.md
@@ -8,4 +8,4 @@ To install, add `{{ cookiecutter.__dist_pkg }}` to your Python dependencies. The
 from {{ cookiecutter.__ns }} import {{ cookiecutter.__pkg }}
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/{{ cookiecutter.__path_prefix }}{{cookiecutter.__pkg}}) for more.
+See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/{{ cookiecutter.__path_prefix }}{{cookiecutter.__canonical_name}}) for more.

--- a/interfaces/.example/README.md
+++ b/interfaces/.example/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-example-interface` to your Python dependen
 from charmlibs.interfaces import example_interface
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/example_interface) for more.
+See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/example-interface) for more.


### PR DESCRIPTION
When we normalised all the URLs in the docs, we missed updating the template and example. This PR updates the template and example accordingly.