### PR TITLE
fix(interfaces/gateway-metadata): correct URLs in metadata + readme

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -44,7 +44,7 @@
 /interfaces/etcd_client/ @canonical/data-nosql
 /interfaces/filesystem_info/ @canonical/hpc-team
 /interfaces/forward_auth @canonical/identity
-/interfaces/gateway_metadata/ @canonical/service-mesh
+/interfaces/gateway-metadata/ @canonical/service-mesh
 /interfaces/grafana_auth/ @canonical/observability
 /interfaces/grafana_datasource/ @canonical/observability
 /interfaces/grafana_datasource_exchange/ @canonical/observability

--- a/interfaces/gateway-metadata/CHANGELOG.md
+++ b/interfaces/gateway-metadata/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-## 1.0.0
+## 1.0.0.post0 - 16 April 2026
+
+Correct package metadata URLs.
+
+## 1.0.0 - 16 April 2026
 
 Initial release. Migrated from `charmed-service-mesh-helpers` (v0.6.0) `interfaces.gateway_metadata` module.

--- a/interfaces/gateway-metadata/README.md
+++ b/interfaces/gateway-metadata/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-gateway-metadata` to your Python dependenc
 from charmlibs.interfaces import gateway_metadata
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/gateway_metadata) for more.
+See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/gateway-metadata) for more.

--- a/interfaces/gateway-metadata/pyproject.toml
+++ b/interfaces/gateway-metadata/pyproject.toml
@@ -33,8 +33,10 @@ integration = [  # installed for `just integration interfaces/gateway-metadata`
 ]
 
 [project.urls]
-"Repository" = "https://github.com/canonical/charmlibs"
+"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/gateway-metadata"
+"Repository" = "https://github.com/canonical/charmlibs/tree/main/interfaces/gateway-metadata"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
+"Changelog" = "https://github.com/canonical/charmlibs/blob/main/interfaces/gateway-metadata/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling"]

--- a/interfaces/gateway-metadata/src/charmlibs/interfaces/gateway_metadata/_version.py
+++ b/interfaces/gateway-metadata/src/charmlibs/interfaces/gateway_metadata/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.0.0'
+__version__ = '1.0.0.post0'


### PR DESCRIPTION
This PR corrects some issues with the metadata of the new `gateway-metadata` interface library:
1. `CODEOWNERS` entry has the wrong path (that's why this PR is reviewed by Charmlibs Maintainers)
2. Docs URL in `README.md` is broken
3. Project URLs in package metadata don't follow the recent additions to the template