### PR TITLE
chore: bump copyright year in the templates

### DIFF
--- a/.example/src/charmlibs/example/__init__.py
+++ b/.example/src/charmlibs/example/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/src/charmlibs/example/_version.py
+++ b/.example/src/charmlibs/example/_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/functional/conftest.py
+++ b/.example/tests/functional/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/functional/test_version.py
+++ b/.example/tests/functional/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/integration/charms/common.py
+++ b/.example/tests/integration/charms/common.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/integration/charms/k8s/src/charm.py
+++ b/.example/tests/integration/charms/k8s/src/charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/integration/charms/machine/src/charm.py
+++ b/.example/tests/integration/charms/machine/src/charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/integration/conftest.py
+++ b/.example/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/integration/test_version.py
+++ b/.example/tests/integration/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/unit/conftest.py
+++ b/.example/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/unit/test_version.py
+++ b/.example/tests/unit/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.example/tests/unit/test_version_in_charm.py
+++ b/.example/tests/unit/test_version_in_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/hooks/post_gen_project.py
+++ b/.template/hooks/post_gen_project.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/hooks/post_gen_project.py
+++ b/.template/hooks/post_gen_project.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/src/charmlibs/{{ cookiecutter.__pkg }}/__init__.py
+++ b/.template/{{ cookiecutter.project_slug }}/src/charmlibs/{{ cookiecutter.__pkg }}/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/src/charmlibs/{{ cookiecutter.__pkg }}/_version.py
+++ b/.template/{{ cookiecutter.project_slug }}/src/charmlibs/{{ cookiecutter.__pkg }}/_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/functional/conftest.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/functional/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/functional/test_version.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/functional/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/integration/charms/common.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/integration/charms/common.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/integration/charms/k8s/src/charm.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/integration/charms/k8s/src/charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/integration/charms/machine/src/charm.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/integration/charms/machine/src/charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/integration/conftest.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/integration/test_version.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/integration/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/unit/conftest.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/unit/test_version.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/unit/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.template/{{ cookiecutter.project_slug }}/tests/unit/test_version_in_charm.py
+++ b/.template/{{ cookiecutter.project_slug }}/tests/unit/test_version_in_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/src/charmlibs/interfaces/example_interface/__init__.py
+++ b/interfaces/.example/src/charmlibs/interfaces/example_interface/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/src/charmlibs/interfaces/example_interface/_version.py
+++ b/interfaces/.example/src/charmlibs/interfaces/example_interface/_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/functional/conftest.py
+++ b/interfaces/.example/tests/functional/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/functional/test_version.py
+++ b/interfaces/.example/tests/functional/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/integration/charms/common.py
+++ b/interfaces/.example/tests/integration/charms/common.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/integration/charms/k8s/src/charm.py
+++ b/interfaces/.example/tests/integration/charms/k8s/src/charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/integration/charms/machine/src/charm.py
+++ b/interfaces/.example/tests/integration/charms/machine/src/charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/integration/conftest.py
+++ b/interfaces/.example/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/integration/test_version.py
+++ b/interfaces/.example/tests/integration/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/unit/conftest.py
+++ b/interfaces/.example/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/unit/test_version.py
+++ b/interfaces/.example/tests/unit/test_version.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/interfaces/.example/tests/unit/test_version_in_charm.py
+++ b/interfaces/.example/tests/unit/test_version_in_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Normally we don't bump copyright year in source code files.

These however are copied to newly initialised libraries, and should correspond to when that's done.

We could parametrise it, or fix it up like this and buy us another year.