### PR TITLE
docs(valkey_client): fix readme title (and trim whitespace)

### DIFF
--- a/interfaces/valkey_client/interface/v1/README.md
+++ b/interfaces/valkey_client/interface/v1/README.md
@@ -1,8 +1,8 @@
-# `valkey_client/v0`
+# `valkey_client/v1`
 
 ## Usage
 
-This relation interface describes the expected behaviour of any charm interfacing with [Valkey Operator](https://github.com/canonical/valkey-operator) using the `valkey-client` relation.  
+This relation interface describes the expected behaviour of any charm interfacing with [Valkey Operator](https://github.com/canonical/valkey-operator) using the `valkey-client` relation.
 
 In most cases, this will be accomplished using the [data_interfaces library](https://pypi.org/project/dpcharmlibs-interfaces/), although charm developers are free to provide alternative libraries as long as they fulfil the behavioural and schematic requirements described in this document.
 


### PR DESCRIPTION
This PR fixes the `README.md` title, which renders in the docs. This interface intentionally released as a version 1 to signal a stable release, per the `interface.yaml` file and discussion in #428.

Also trims some whitespace.