### PR TITLE
docs: exclude another pydantic field

### DIFF
--- a/.docs/conf.py
+++ b/.docs/conf.py
@@ -242,6 +242,7 @@ autodoc_default_options = {
         '__pydantic_custom_init__,'
         '__pydantic_decorators__,'
         '__pydantic_extra__,'
+        '__pydantic_extra_info__,'
         '__pydantic_fields__,'
         '__pydantic_fields_set__,'
         '__pydantic_generic_metadata__,'


### PR DESCRIPTION
This PR excludes another (presumably new) Pydantic field from the docs rendering.

Note that we don't exclude all magic methods (the default behaviour), because we want to document some explicitly provided magic methods for libraries like `pathops`.