### PR TITLE
feat: sync lock input is an object not a class

### DIFF
--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -72,7 +72,7 @@ class RollingOpsManager(Object):
         peer_relation_name: str,
         etcd_relation_name: str | None = None,
         cluster_id: str | None = None,
-        sync_lock_targets: dict[str, type[SyncLockBackend]] | None = None,
+        sync_lock_targets: dict[str, SyncLockBackend] | None = None,
         base_dir: pathops.LocalPath | None = None,
     ):
         """Create a rolling operations manager with etcd and peer backends.
@@ -365,7 +365,7 @@ class RollingOpsManager(Object):
         if backend_cls is None:
             raise RollingOpsSyncLockError(f'Unknown sync lock backend: {backend_id}.')
 
-        return backend_cls()
+        return backend_cls
 
     @contextmanager
     def acquire_sync_lock(self, backend_id: str, timeout: int):

--- a/rollingops/tests/integration/charms/common.py
+++ b/rollingops/tests/integration/charms/common.py
@@ -62,6 +62,7 @@ class Charm(CharmBase):
             '_deferred_restart': self._deferred_restart,
         }
 
+        a_sync_backend = MySyncBackend()
         self.restart_manager = RollingOpsManager(
             charm=self,
             peer_relation_name='restart',
@@ -69,7 +70,7 @@ class Charm(CharmBase):
             cluster_id='cluster-12345',
             callback_targets=callback_targets,
             sync_lock_targets={
-                'stop': MySyncBackend,
+                'stop': a_sync_backend,
             },
         )
 

--- a/rollingops/tests/integration/charms/common.py
+++ b/rollingops/tests/integration/charms/common.py
@@ -62,7 +62,7 @@ class Charm(CharmBase):
             '_deferred_restart': self._deferred_restart,
         }
 
-        a_sync_backend = MySyncBackend()
+        sync_backend = MySyncBackend()
         self.restart_manager = RollingOpsManager(
             charm=self,
             peer_relation_name='restart',
@@ -70,7 +70,7 @@ class Charm(CharmBase):
             cluster_id='cluster-12345',
             callback_targets=callback_targets,
             sync_lock_targets={
-                'stop': a_sync_backend,
+                'stop': sync_backend,
             },
         )
 

--- a/rollingops/tests/integration/test_etcd_rolling_ops.py
+++ b/rollingops/tests/integration/test_etcd_rolling_ops.py
@@ -43,7 +43,7 @@ def etcdctl_file_exits(juju: jubilant.Juju, unit: str) -> bool:
     return True
 
 
-@retry(wait=wait_fixed(10), stop=stop_after_delay(60), reraise=True)
+@retry(wait=wait_fixed(10), stop=stop_after_delay(120), reraise=True)
 def wait_for_etcdctl_config_file(juju: jubilant.Juju, unit: str) -> None:
     if not etcdctl_file_exits(juju, unit):
         raise RuntimeError('etcdctl config file not ready')
@@ -73,12 +73,11 @@ def test_charm_is_integrated_with_etcd(juju: jubilant.Juju, app_name: str):
     juju.integrate(f'{app_name}:etcd', 'etcd:etcd-client')
     juju.wait(jubilant.all_active, error=jubilant.any_error, timeout=TIMEOUT)
 
-    wait_for_etcdctl_config_file(juju, f'{app_name}/0')
-
 
 @pytest.mark.machine_only
 def test_restart_action_one_unit_single_app(juju: jubilant.Juju, app_name: str):
     unit = f'{app_name}/0'
+    wait_for_etcdctl_config_file(juju, unit)
 
     juju.run(unit, 'restart', {'delay': 1}, wait=TIMEOUT)
     juju.wait(jubilant.all_active, error=jubilant.any_error, timeout=TIMEOUT)


### PR DESCRIPTION
This PR change the type of the  `sync_lock_targets` parameter.

```
sync_lock_targets: dict[str, SyncLockBackend] | None = None,
```

if we pass instantiated objects, charm users can build their objects using as many arguments as they wish 