### PR TITLE
docs: describe how pathops uses tag

### DIFF
--- a/pathops/pyproject.toml
+++ b/pathops/pyproject.toml
@@ -57,4 +57,6 @@ pebble = ["v1.1.1","master"]
 ubuntu = ["22.04", "latest"]
 
 [tool.charmlibs.integration]
+# tags to run integration tests with (defaults to running once with no tag, i.e. tags = [''])
+# Available in CI in tests/integration/pack.sh and integration tests as CHARMLIBS_TAG
 tags = ["22.04", "24.04"]  # The pathops pack.sh script uses CHARMLIBS_TAG to determine which base to pack for.

--- a/pathops/pyproject.toml
+++ b/pathops/pyproject.toml
@@ -57,4 +57,4 @@ pebble = ["v1.1.1","master"]
 ubuntu = ["22.04", "latest"]
 
 [tool.charmlibs.integration]
-tags = ["22.04", "24.04"]
+tags = ["22.04", "24.04"]  # The pathops pack.sh script uses CHARMLIBS_TAG to determine which base to pack for.


### PR DESCRIPTION
This PR adds the two line-comments from the template to the pathops pyproject.toml file, and an inline comment explaining what pathops uses the tag variable for.