### PR TITLE
docs: better example of Ops dependency bounds in template and examples

### DIFF
--- a/.example/pyproject.toml
+++ b/.example/pyproject.toml
@@ -17,9 +17,11 @@ dynamic = ["version"]
 dependencies = [
     # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
     # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
-    # Ops 3 has new features not present in Ops 2.
-    # To review the changes in Ops 3, see https://github.com/canonical/operator/releases.
-    # Set the dependency bounds according to the features your library needs.
+    # Ops 3 has new features not present in Ops 2.23 (the last Ops 2 feature release).
+    # See the Ops 2.23 maintenance branch changelog and the Ops 3 changelog for current information:
+    # - https://github.com/canonical/operator/blob/2.23-maintenance/CHANGES.md
+    # - https://github.com/canonical/operator/blob/main/CHANGES.md
+    # Set the dependency bounds according to the features and fixes your library needs.
     # "ops>=2.23.1,<4",
 ]
 

--- a/.example/pyproject.toml
+++ b/.example/pyproject.toml
@@ -16,9 +16,10 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
-    # Set the dependency bounds according to the features your library needs.
     # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
-    # Ops 3 may have new features not present in Ops 2.
+    # Ops 3 has new features not present in Ops 2.
+    # To review the changes in Ops 3, see https://github.com/canonical/operator/releases.
+    # Set the dependency bounds according to the features your library needs.
     # "ops>=2.23.1,<4",
 ]
 

--- a/.example/pyproject.toml
+++ b/.example/pyproject.toml
@@ -15,7 +15,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    # "ops",
+    # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
+    # Set the dependency bounds according to the features your library needs.
+    # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
+    # Ops 3 may have new features not present in Ops 2.
+    # "ops>=2.23.1,<4",
 ]
 
 [dependency-groups]

--- a/.template/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/.template/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -17,9 +17,11 @@ dynamic = ["version"]
 dependencies = [
     # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
     # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
-    # Ops 3 has new features not present in Ops 2.
-    # To review the changes in Ops 3, see https://github.com/canonical/operator/releases.
-    # Set the dependency bounds according to the features your library needs.
+    # Ops 3 has new features not present in Ops 2.23 (the last Ops 2 feature release).
+    # See the Ops 2.23 maintenance branch changelog and the Ops 3 changelog for current information:
+    # - https://github.com/canonical/operator/blob/2.23-maintenance/CHANGES.md
+    # - https://github.com/canonical/operator/blob/main/CHANGES.md
+    # Set the dependency bounds according to the features and fixes your library needs.
     # "ops>=2.23.1,<4",
 ]
 {% if cookiecutter._interface %}

--- a/.template/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/.template/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -15,7 +15,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    # "ops",
+    # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
+    # Set the dependency bounds according to the features your library needs.
+    # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
+    # Ops 3 may have new features not present in Ops 2.
+    # "ops>=2.23.1,<4",
 ]
 {% if cookiecutter._interface %}
 [project.optional-dependencies]

--- a/.template/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/.template/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -16,9 +16,10 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
-    # Set the dependency bounds according to the features your library needs.
     # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
-    # Ops 3 may have new features not present in Ops 2.
+    # Ops 3 has new features not present in Ops 2.
+    # To review the changes in Ops 3, see https://github.com/canonical/operator/releases.
+    # Set the dependency bounds according to the features your library needs.
     # "ops>=2.23.1,<4",
 ]
 {% if cookiecutter._interface %}

--- a/interfaces/.example/pyproject.toml
+++ b/interfaces/.example/pyproject.toml
@@ -15,7 +15,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    # "ops",
+    # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
+    # Set the dependency bounds according to the features your library needs.
+    # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
+    # Ops 3 may have new features not present in Ops 2.
+    # "ops>=2.23.1,<4",
 ]
 
 [project.optional-dependencies]

--- a/interfaces/.example/pyproject.toml
+++ b/interfaces/.example/pyproject.toml
@@ -17,9 +17,11 @@ dynamic = ["version"]
 dependencies = [
     # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
     # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
-    # Ops 3 has new features not present in Ops 2.
-    # To review the changes in Ops 3, see https://github.com/canonical/operator/releases.
-    # Set the dependency bounds according to the features your library needs.
+    # Ops 3 has new features not present in Ops 2.23 (the last Ops 2 feature release).
+    # See the Ops 2.23 maintenance branch changelog and the Ops 3 changelog for current information:
+    # - https://github.com/canonical/operator/blob/2.23-maintenance/CHANGES.md
+    # - https://github.com/canonical/operator/blob/main/CHANGES.md
+    # Set the dependency bounds according to the features and fixes your library needs.
     # "ops>=2.23.1,<4",
 ]
 

--- a/interfaces/.example/pyproject.toml
+++ b/interfaces/.example/pyproject.toml
@@ -16,9 +16,10 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     # Libraries should use clear but wide dependency bounds to avoid overly constraining charms.
-    # Set the dependency bounds according to the features your library needs.
     # Ops 3 is backwards compatible with Ops 2, but drops Python 3.8 support.
-    # Ops 3 may have new features not present in Ops 2.
+    # Ops 3 has new features not present in Ops 2.
+    # To review the changes in Ops 3, see https://github.com/canonical/operator/releases.
+    # Set the dependency bounds according to the features your library needs.
     # "ops>=2.23.1,<4",
 ]
 


### PR DESCRIPTION
This PR updates the template and examples with better (but still commented out) dependency bounds for Ops, along with an explanation of the general principle, and the specifics for Ops.