### PR TITLE
feat: path to etcdctl

### DIFF
--- a/rollingops/src/charmlibs/rollingops/_etcd/_backend.py
+++ b/rollingops/src/charmlibs/rollingops/_etcd/_backend.py
@@ -86,7 +86,8 @@ class _EtcdRollingOpsBackend(Object):  # pyright: ignore[reportUnusedClass]
         self.callback_targets = callback_targets
         self._base_dir = base_dir
 
-        self.etcdctl = Etcdctl(self._base_dir)
+        charm_dir = pathops.LocalPath(charm.charm_dir)
+        self.etcdctl = Etcdctl(self._base_dir, charm_dir)
 
         owner = f'{self.model.uuid}-{self.model.unit.name}'.replace('/', '-')
         self.worker = EtcdRollingOpsAsyncWorker(
@@ -112,13 +113,21 @@ class _EtcdRollingOpsBackend(Object):  # pyright: ignore[reportUnusedClass]
             base_dir=self._base_dir,
         )
         self._async_lock = EtcdLock(
-            lock_key=self.keys.lock_key, owner=owner, base_dir=self._base_dir
+            lock_key=self.keys.lock_key,
+            owner=owner,
+            base_dir=self._base_dir,
+            charm_dir=charm_dir,
         )
         self._sync_lock = EtcdLock(
-            lock_key=self.keys.lock_key, owner=f'{owner}:sync', base_dir=self._base_dir
+            lock_key=self.keys.lock_key,
+            owner=f'{owner}:sync',
+            base_dir=self._base_dir,
+            charm_dir=charm_dir,
         )
         self._lease: EtcdLease | None = None
-        self.operations_store = ManagerOperationStore(self.keys, owner, base_dir=self._base_dir)
+        self.operations_store = ManagerOperationStore(
+            self.keys, owner, base_dir=self._base_dir, charm_dir=charm_dir
+        )
 
         self.framework.observe(
             charm.on[self.peer_relation_name].relation_departed, self._on_peer_relation_departed
@@ -353,7 +362,8 @@ class _EtcdRollingOpsBackend(Object):  # pyright: ignore[reportUnusedClass]
             TimeoutError: If the lock could not be acquired before the timeout.
             RollingOpsSyncLockError: if there was an error obtaining the lock.
         """
-        self._lease = EtcdLease(self._base_dir)
+        charm_dir = pathops.LocalPath(self._charm.charm_dir)
+        self._lease = EtcdLease(self._base_dir, charm_dir)
 
         deadline = None if timeout is None else time.monotonic() + timeout
 

--- a/rollingops/src/charmlibs/rollingops/_etcd/_etcd.py
+++ b/rollingops/src/charmlibs/rollingops/_etcd/_etcd.py
@@ -37,11 +37,11 @@ LOCK_LEASE_TTL = '60'
 class EtcdLease:
     """Manage the lifecycle of an etcd lease and its keep-alive process."""
 
-    def __init__(self, base_dir: pathops.LocalPath):
+    def __init__(self, base_dir: pathops.LocalPath, charm_dir: pathops.LocalPath):
         self.id: str | None = None
         self.keepalive_proc: subprocess.Popen[str] | None = None
         self._pipe_write_fd: int | None = None
-        self._etcdctl = Etcdctl(base_dir)
+        self._etcdctl = Etcdctl(base_dir, charm_dir)
 
     def grant(self) -> None:
         """Create a new lease and start the keep-alive process."""
@@ -156,10 +156,12 @@ class EtcdLock:
     automatically released if the owner stops refreshing the lease.
     """
 
-    def __init__(self, lock_key: str, owner: str, base_dir: pathops.LocalPath):
+    def __init__(
+        self, lock_key: str, owner: str, base_dir: pathops.LocalPath, charm_dir: pathops.LocalPath
+    ):
         self.lock_key = lock_key
         self.owner = owner
-        self._etcdctl = Etcdctl(base_dir)
+        self._etcdctl = Etcdctl(base_dir, charm_dir)
 
     def try_acquire(self, lease_id: str) -> bool:
         """Attempt to acquire the lock.
@@ -222,11 +224,18 @@ class EtcdOperationQueue:
     the value contains the serialized operation data.
     """
 
-    def __init__(self, prefix: str, lock_key: str, owner: str, base_dir: pathops.LocalPath):
+    def __init__(
+        self,
+        prefix: str,
+        lock_key: str,
+        owner: str,
+        base_dir: pathops.LocalPath,
+        charm_dir: pathops.LocalPath,
+    ):
         self.prefix = prefix
         self.lock_key = lock_key
         self.owner = owner
-        self._etcdctl = Etcdctl(base_dir)
+        self._etcdctl = Etcdctl(base_dir, charm_dir)
 
     def peek(self) -> _Operation | None:
         """Return the first operation in the queue without removing it."""
@@ -382,13 +391,21 @@ class WorkerOperationStore:
     - requeue or delete completed operations
     """
 
-    def __init__(self, keys: RollingOpsKeys, owner: str, base_dir: pathops.LocalPath):
-        self._pending = EtcdOperationQueue(keys.pending, keys.lock_key, owner, base_dir=base_dir)
+    def __init__(
+        self,
+        keys: RollingOpsKeys,
+        owner: str,
+        base_dir: pathops.LocalPath,
+        charm_dir: pathops.LocalPath,
+    ):
+        self._pending = EtcdOperationQueue(
+            keys.pending, keys.lock_key, owner, base_dir=base_dir, charm_dir=charm_dir
+        )
         self._inprogress = EtcdOperationQueue(
-            keys.inprogress, keys.lock_key, owner, base_dir=base_dir
+            keys.inprogress, keys.lock_key, owner, base_dir=base_dir, charm_dir=charm_dir
         )
         self._completed = EtcdOperationQueue(
-            keys.completed, keys.lock_key, owner, base_dir=base_dir
+            keys.completed, keys.lock_key, owner, base_dir=base_dir, charm_dir=charm_dir
         )
 
     def has_pending(self) -> bool:
@@ -483,13 +500,21 @@ class ManagerOperationStore:
     Queue transitions and storage details remain encapsulated behind this API.
     """
 
-    def __init__(self, keys: RollingOpsKeys, owner: str, base_dir: pathops.LocalPath):
-        self._pending = EtcdOperationQueue(keys.pending, keys.lock_key, owner, base_dir=base_dir)
+    def __init__(
+        self,
+        keys: RollingOpsKeys,
+        owner: str,
+        base_dir: pathops.LocalPath,
+        charm_dir: pathops.LocalPath,
+    ):
+        self._pending = EtcdOperationQueue(
+            keys.pending, keys.lock_key, owner, base_dir=base_dir, charm_dir=charm_dir
+        )
         self._inprogress = EtcdOperationQueue(
-            keys.inprogress, keys.lock_key, owner, base_dir=base_dir
+            keys.inprogress, keys.lock_key, owner, base_dir=base_dir, charm_dir=charm_dir
         )
         self._completed = EtcdOperationQueue(
-            keys.completed, keys.lock_key, owner, base_dir=base_dir
+            keys.completed, keys.lock_key, owner, base_dir=base_dir, charm_dir=charm_dir
         )
 
     def request(self, operation: _Operation) -> None:

--- a/rollingops/src/charmlibs/rollingops/_etcd/_etcdctl.py
+++ b/rollingops/src/charmlibs/rollingops/_etcd/_etcdctl.py
@@ -22,7 +22,6 @@ convenience functions for executing commands and retrieving structured results.
 import json
 import logging
 import os
-import shutil
 import subprocess
 from dataclasses import asdict
 
@@ -47,21 +46,22 @@ from charmlibs.rollingops._etcd._models import CERT_MODE, EtcdConfig, EtcdKV
 
 logger = logging.getLogger(__name__)
 
-ETCDCTL_CMD = 'etcdctl'
+ETCDCTL_CMD = 'usr/bin/etcdctl'
 ETCDCTL_TIMEOUT_SECONDS = 15
 ETCDCTL_RETRY_ATTEMPTS = 12
 ETCDCTL_RETRY_WAIT_SECONDS = 5
 
 
 class Etcdctl:
-    def __init__(self, base_dir: pathops.LocalPath):
+    def __init__(self, base_dir: pathops.LocalPath, charm_dir: pathops.LocalPath):
         self.base_dir = base_dir / 'etcd'
         self.server_ca_path = self.base_dir / 'server-ca.pem'
         self.config_file_path = self.base_dir / 'etcdctl.json'
+        self.etcdctl_path = charm_dir / ETCDCTL_CMD
 
     def is_etcdctl_installed(self) -> bool:
-        """Return whether the snap-provided etcdctl command is available."""
-        return shutil.which(ETCDCTL_CMD) is not None
+        """Return whether the charm-shipped etcdctl binary is available."""
+        return self.etcdctl_path.exists() and self.etcdctl_path.is_file()
 
     def write_trusted_server_ca(self, tls_ca_pem: str) -> None:
         """Persist the etcd server CA certificate to disk.

--- a/rollingops/src/charmlibs/rollingops/_etcd/_relations.py
+++ b/rollingops/src/charmlibs/rollingops/_etcd/_relations.py
@@ -204,7 +204,8 @@ class EtcdRequiresV1(Object):
         self.cluster_id = cluster_id
         self.shared_certificates = shared_certificates
         self.certificates_store = CertificateStore(base_dir)
-        self.etcdctl = Etcdctl(base_dir)
+        charm_dir = pathops.LocalPath(charm.charm_dir)
+        self.etcdctl = Etcdctl(base_dir, charm_dir)
 
         self.etcd_interface = ResourceRequirerEventHandler(
             self.charm,

--- a/rollingops/src/charmlibs/rollingops/_etcd/_rollingops.py
+++ b/rollingops/src/charmlibs/rollingops/_etcd/_rollingops.py
@@ -79,7 +79,7 @@ def main():
     )
     parser.add_argument(
         '--charm-dir',
-        type=str,
+        type=pathops.LocalPath,
         required=True,
         help='Path to the charm directory',
     )
@@ -111,9 +111,9 @@ def main():
     time.sleep(INITIAL_SLEEP)
 
     keys = RollingOpsKeys.for_owner(args.cluster_id, args.owner)
-    lock = EtcdLock(keys.lock_key, args.owner, base_dir)
-    lease = EtcdLease(base_dir)
-    operations = WorkerOperationStore(keys, args.owner, base_dir)
+    lock = EtcdLock(keys.lock_key, args.owner, base_dir, args.charm_dir)
+    lease = EtcdLease(base_dir, args.charm_dir)
+    operations = WorkerOperationStore(keys, args.owner, base_dir, args.charm_dir)
 
     try:
         while True:

--- a/rollingops/tests/integration/charms/k8s/charmcraft.yaml
+++ b/rollingops/tests/integration/charms/k8s/charmcraft.yaml
@@ -16,6 +16,20 @@ parts:
     plugin: uv
     build-snaps: [astral-uv]
 
+  etcdctl:
+    plugin: make
+    source: https://git.launchpad.net/etcd
+    source-type: git
+    source-tag: lp-v3.6.7
+    build-snaps:
+      - go/latest/stable
+    override-build: |
+      set -eux
+      make build
+      install -Dm755 bin/etcdctl "${CRAFT_PART_INSTALL}/usr/bin/etcdctl"
+    prime:
+      - usr/bin/etcdctl
+
 containers:
   workload:
     resource: workload

--- a/rollingops/tests/integration/charms/k8s/charmcraft.yaml
+++ b/rollingops/tests/integration/charms/k8s/charmcraft.yaml
@@ -20,7 +20,7 @@ parts:
     plugin: make
     source: https://git.launchpad.net/etcd
     source-type: git
-    source-tag: lp-v3.6.7
+    source-tag: lp-v3.6.10
     build-snaps:
       - go/latest/stable
     override-build: |

--- a/rollingops/tests/integration/charms/machine/charmcraft.yaml
+++ b/rollingops/tests/integration/charms/machine/charmcraft.yaml
@@ -16,6 +16,20 @@ parts:
     plugin: uv
     build-snaps: [astral-uv]
 
+  etcdctl:
+    plugin: make
+    source: https://git.launchpad.net/etcd
+    source-type: git
+    source-tag: lp-v3.6.7
+    build-snaps:
+      - go/latest/stable
+    override-build: |
+      set -eux
+      make build
+      install -Dm755 bin/etcdctl "${CRAFT_PART_INSTALL}/usr/bin/etcdctl"
+    prime:
+      - usr/bin/etcdctl
+
 peers:
   restart:
       interface: rolling_op

--- a/rollingops/tests/integration/charms/machine/charmcraft.yaml
+++ b/rollingops/tests/integration/charms/machine/charmcraft.yaml
@@ -20,7 +20,7 @@ parts:
     plugin: make
     source: https://git.launchpad.net/etcd
     source-type: git
-    source-tag: lp-v3.6.7
+    source-tag: lp-v3.6.10
     build-snaps:
       - go/latest/stable
     override-build: |

--- a/rollingops/tests/integration/charms/machine/src/charm.py
+++ b/rollingops/tests/integration/charms/machine/src/charm.py
@@ -19,8 +19,6 @@ import logging
 import common
 import ops
 
-from charmlibs import apt
-
 logger = logging.getLogger(__name__)
 
 
@@ -30,19 +28,10 @@ class RollingOpsCharm(common.Charm):
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
         framework.observe(self.on.start, self._on_start)
-        framework.observe(self.on.install, self._on_install)
 
     def _on_start(self, event: ops.StartEvent):
         """Handle start event."""
         self.unit.status = ops.ActiveStatus()
-
-    def _on_install(self, event: ops.InstallEvent) -> None:
-        """Handle the install. Install the etcd-client."""
-        try:
-            apt.update()
-            apt.add_package('etcd-client')
-        except apt.PackageError as e:
-            logger.error('could not install package. Reason: %s', e.message)
 
 
 if __name__ == '__main__':  # pragma: nocover

--- a/rollingops/tests/unit/conftest.py
+++ b/rollingops/tests/unit/conftest.py
@@ -113,7 +113,7 @@ def temp_certificates(tmp_path: Path) -> certificates.CertificateStore:
 @pytest.fixture
 def temp_etcdctl(tmp_path: Path) -> etcdctl.Etcdctl:
     path = pathops.LocalPath(str(tmp_path))
-    client = etcdctl.Etcdctl(path)
+    client = etcdctl.Etcdctl(path, path)
     client.base_dir.mkdir(parents=True, exist_ok=True)
     return client
 


### PR DESCRIPTION
We add a part in the charmcraft file to include the etcdctl. 
We install it in the <charm-dir>/usr/bin/etcdctl so we need to retrieve that path in the ETCD related classes