### PR TITLE
ci: upload charmcraft logs

### DIFF
--- a/.github/get-changed.py
+++ b/.github/get-changed.py
@@ -52,7 +52,7 @@ def _main() -> None:
     else:
         cmd.append(args.git_base_ref)
     if args.name_only:
-        cmd.append('--name-only')
+        cmd.extend(['--output-only', 'name'])
     result = subprocess.check_output(cmd, text=True).strip()
     output = f'result={result}'
     logger.info(output)

--- a/.github/workflows/test-interface.yaml
+++ b/.github/workflows/test-interface.yaml
@@ -33,7 +33,7 @@ jobs:
         id: schema
         run: |
           set -xueo pipefail
-          SCHEMA=$(.scripts/ls.py interfaces --regex "interfaces/$INTERFACE" --output-only schema_path)
+          SCHEMA=$(.scripts/ls.py interfaces --regex "interfaces/$INTERFACE" --output-only schema_path --no-json)
           echo "result=$SCHEMA" >> "$GITHUB_OUTPUT"
       - name: Check schema can be run if it exists
         if: steps.schema.outputs.result

--- a/.github/workflows/test-interface.yaml
+++ b/.github/workflows/test-interface.yaml
@@ -33,7 +33,7 @@ jobs:
         id: schema
         run: |
           set -xueo pipefail
-          SCHEMA=$(.scripts/ls.py interfaces --regex "interfaces/$INTERFACE" --output schema_path | jq -r '.[].schema_path')
+          SCHEMA=$(.scripts/ls.py interfaces --regex "interfaces/$INTERFACE" --output-only schema_path)
           echo "result=$SCHEMA" >> "$GITHUB_OUTPUT"
       - name: Check schema can be run if it exists
         if: steps.schema.outputs.result

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -32,6 +32,7 @@ jobs:
   init:
     runs-on: ubuntu-latest
     outputs:
+      package-name: ${{ steps.package-info.outputs.name }}
       tests: ${{ steps.tests.outputs.tests }}
       python: ${{ steps.python.outputs.versions }}
       min_python_version: ${{ steps.python.outputs.min_version }}
@@ -54,6 +55,14 @@ jobs:
             */.example|*/.example/testing|*/.tutorial) echo "Examples don't have a uv.lock file, skipping ..." ;;
             *) uv lock --check ;;
           esac
+
+      - name: Get package info
+        id: package-info
+        run: |
+          set -xueo pipefail
+          NAME=$(.scripts/ls.py packages --no-json --exclude-testing --output-only name --regex "$PACKAGE")
+          echo "name=$NAME"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
 
       - name: Check which Python versions this package supports
         id: python
@@ -235,7 +244,7 @@ jobs:
         if: ${{ !cancelled() && steps.pack.conclusion != 'skipped' }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.PACKAGE }}-charmcraft-logs-${{ matrix.substrate }}-${{ matrix.tag }}
+          name: ${{ needs.init.outputs.package-name }}-charmcraft-logs-${{ matrix.substrate }}-${{ matrix.tag }}
           path: /home/runner/.local/state/charmcraft/log/charmcraft-*.log
           if-no-files-found: warn
 

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -224,8 +224,14 @@ jobs:
         if: ${{ hashFiles(format('{0}/tests/integration/pack.sh', inputs.package)) != '' }}
         id: pack
         env:
+          # TAG: ${{ matrix.tag }}
+          # SUBSTRATE: ${{ matrix.substrate }}
+        # run: uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE"
+        # Retry once to work around snap startup issues with charmcraft pack.
+        # Revert to the commented out form above when the issue is resolved.
+        # https://github.com/canonical/charmcraft/issues/2515
           PACK_CMD: uvx --from rust-just just tag="${{ matrix.tag }}" "pack-${{ matrix.substrate }}" "${{ env.PACKAGE }}"
-        run: $PACK_CMD || $PACK_CMD  # Retry once to work around snap startup issues.
+        run: $PACK_CMD || $PACK_CMD
 
       - name: Upload Charmcraft logs
         if: ${{ !cancelled() && steps.pack.conclusion != 'skipped' }}

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -224,14 +224,12 @@ jobs:
         if: ${{ hashFiles(format('{0}/tests/integration/pack.sh', inputs.package)) != '' }}
         id: pack
         env:
-          # TAG: ${{ matrix.tag }}
-          # SUBSTRATE: ${{ matrix.substrate }}
-        # run: uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE"
+          TAG: ${{ matrix.tag }}
+          SUBSTRATE: ${{ matrix.substrate }}
         # Retry once to work around snap startup issues with charmcraft pack.
-        # Revert to the commented out form above when the issue is resolved.
+        # Drop the retry when the issue is resolved.
         # https://github.com/canonical/charmcraft/issues/2515
-          PACK_CMD: uvx --from rust-just just tag="${{ matrix.tag }}" "pack-${{ matrix.substrate }}" "${{ env.PACKAGE }}"
-        run: $PACK_CMD || $PACK_CMD
+        run: uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE" || uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE"
 
       - name: Upload Charmcraft logs
         if: ${{ !cancelled() && steps.pack.conclusion != 'skipped' }}

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -222,10 +222,18 @@ jobs:
 
       - name: Pack charms
         if: ${{ hashFiles(format('{0}/tests/integration/pack.sh', inputs.package)) != '' }}
+        id: pack
         env:
-          TAG: ${{ matrix.tag }}
-          SUBSTRATE: ${{ matrix.substrate }}
-        run: uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE"
+          PACK_CMD: uvx --from rust-just just tag="${{ matrix.tag }}" "pack-${{ matrix.substrate }}" "${{ env.PACKAGE }}"
+        run: $PACK_CMD || $PACK_CMD  # Retry once to work around snap startup issues.
+
+      - name: Upload Charmcraft logs
+        if: ${{ !cancelled() && steps.pack.conclusion != 'skipped' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PACKAGE }}-charmcraft-logs-${{ matrix.substrate }}-${{ matrix.tag }}
+          path: /home/runner/.local/state/charmcraft/log/charmcraft-*.log
+          if-no-files-found: warn
 
       - name: Run Juju integration tests
         env:

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -238,6 +238,7 @@ jobs:
         run: uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE"
 
       - name: Run Juju integration tests
+        id: integration
         env:
           PYTHON: ${{ needs.init.outputs.min_python_version }}
           RECIPE: integration-${{ matrix.substrate }}
@@ -245,7 +246,7 @@ jobs:
         run: uvx --from rust-just just python="$PYTHON" tag="$TAG" "$RECIPE" "$PACKAGE"
 
       - name: Upload Charmcraft logs
-        if: ${{ !cancelled() && steps.pack.conclusion != 'skipped' }}
+        if: ${{ !cancelled() && (steps.pack.conclusion != 'skipped' || steps.integration.conclusion != 'skipped') }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ needs.init.outputs.package-name }}-charmcraft-logs-${{ matrix.substrate }}-${{ matrix.tag }}

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -237,6 +237,13 @@ jobs:
           SUBSTRATE: ${{ matrix.substrate }}
         run: uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE"
 
+      - name: Run Juju integration tests
+        env:
+          PYTHON: ${{ needs.init.outputs.min_python_version }}
+          RECIPE: integration-${{ matrix.substrate }}
+          TAG: ${{ matrix.tag }}
+        run: uvx --from rust-just just python="$PYTHON" tag="$TAG" "$RECIPE" "$PACKAGE"
+
       - name: Upload Charmcraft logs
         if: ${{ !cancelled() && steps.pack.conclusion != 'skipped' }}
         uses: actions/upload-artifact@v4
@@ -244,10 +251,3 @@ jobs:
           name: ${{ needs.init.outputs.package-name }}-charmcraft-logs-${{ matrix.substrate }}-${{ matrix.tag }}
           path: /home/runner/.local/state/charmcraft/log/charmcraft-*.log
           if-no-files-found: warn  # pack.sh scripts aren't required to produce charmcraft logs (though they do currently)
-
-      - name: Run Juju integration tests
-        env:
-          PYTHON: ${{ needs.init.outputs.min_python_version }}
-          RECIPE: integration-${{ matrix.substrate }}
-          TAG: ${{ matrix.tag }}
-        run: uvx --from rust-just just python="$PYTHON" tag="$TAG" "$RECIPE" "$PACKAGE"

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -243,7 +243,7 @@ jobs:
         with:
           name: ${{ needs.init.outputs.package-name }}-charmcraft-logs-${{ matrix.substrate }}-${{ matrix.tag }}
           path: /home/runner/.local/state/charmcraft/log/charmcraft-*.log
-          if-no-files-found: warn
+          if-no-files-found: warn  # pack.sh scripts aren't required to produce charmcraft logs (though they do currently)
 
       - name: Run Juju integration tests
         env:

--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -235,10 +235,7 @@ jobs:
         env:
           TAG: ${{ matrix.tag }}
           SUBSTRATE: ${{ matrix.substrate }}
-        # Retry once to work around snap startup issues with charmcraft pack.
-        # Drop the retry when the issue is resolved.
-        # https://github.com/canonical/charmcraft/issues/2515
-        run: uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE" || uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE"
+        run: uvx --from rust-just just tag="$TAG" "pack-$SUBSTRATE" "$PACKAGE"
 
       - name: Upload Charmcraft logs
         if: ${{ !cancelled() && steps.pack.conclusion != 'skipped' }}

--- a/.scripts/ls.py
+++ b/.scripts/ls.py
@@ -85,15 +85,13 @@ def _main() -> None:
     parser.add_argument('--only-if-version-changed', action='store_true')
     parser.add_argument('--indent-json', action='store_true')
     parser.add_argument('--regex', default=None)
+    parser.add_argument('--no-json', action='store_true')
     group = parser.add_mutually_exclusive_group()
     all_fields = [f.name for f in dataclasses.fields(Info)]
-    group.add_argument('--output', action='append', choices=all_fields)
-    group.add_argument('--output-all', action='store_const', const=all_fields, default=[])
-    group.add_argument('--name-only', action='store_true')
-    group.add_argument('--path-only', action='store_true')  # default behaviour
+    group.add_argument('--output', action='append', choices=all_fields, dest='output')
+    group.add_argument('--output-all', action='store_const', const=all_fields, dest='output')
+    group.add_argument('--output-only', action='store', default='path')  # default behaviour
     args = parser.parse_args()
-    output = args.output or args.output_all
-    single_output = 'name' if args.name_only else 'path'
     infos = _ls(
         category=args.category,
         old_ref=args.old_ref,
@@ -103,16 +101,19 @@ def _main() -> None:
         include_testing=not args.exclude_testing,
         only_if_version_changed=args.only_if_version_changed,
         regex=args.regex,
-        output=output or [single_output],
+        output=args.output or [args.output_only],
     )
-    if output:
+    if args.output:
         result = sorted(
-            (info.to_dict(*output) for info in infos),
+            (info.to_dict(*args.output) for info in infos),
             key=lambda di: tuple(di.items()),
         )
     else:
-        result = sorted(getattr(info, single_output) for info in infos)
-    print(json.dumps(result, indent=2 if args.indent_json else None))
+        result = sorted(getattr(info, args.output_only) for info in infos)
+    if args.no_json:
+        print('\n'.join(str(r) for r in result))
+    else:
+        print(json.dumps(result, indent=2 if args.indent_json else None))
 
 
 def _ls(


### PR DESCRIPTION
We see regular `charmcraft pack` failures in CI, which appear to be due to `snapd` startup issues when packing from a cold start.

Here's an [example failure](https://github.com/canonical/charmlibs/actions/runs/25139482207/job/73685763313). Here's the `charmcraft` issue: https://github.com/canonical/charmcraft/issues/2515

---

This PR  adds a follow-up step to upload the `charmcraft` logs after running integration tests (whether we succeed or fail -- so long as either the pack or integration step ran).

In order for the uploaded artifact to have a unique name, it is prefixed with the name of the package under test. The package name provided as input to the workflow may contain a slash (e.g. `interfaces/tls-certificates`), which is invalid for an artifact name. The cleanest way to get a valid and unique name is to get the distribution package name via `.scripts/ls.py`.

To avoid having to perform `jq` wizardry to extract the bare name from the JSON list that `ls.py` would output, I've updated `ls.py` with a `--no-json` argument (which prints each entry on a separate line instead -- so the output for a single field is just `<field value>\n`). As a driveby improvement, I've collapsed the `--name-only` and `--path-only` arguments into the more general `--output-only <field>`, which simplifies the handling of the various `--output` arguments and makes querying any single field possible without needing to add a custom argument.

---

There's a charmcraft issue tracking what appears to be the same failure that we see: https://github.com/canonical/charmcraft/issues/2515