### PR TITLE
docs(rollingops): improve rollingops documentation

### DIFF
--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -41,6 +41,23 @@ Typical use cases:
 - Maintenance tasks that must not run concurrently
 - Cluster-wide operations coordinated via etcd
 
+Limitations
+-----------
+
+- **Peer-only mode**
+  Supported for both machine (VM) and Kubernetes charms.
+
+- **Etcd-based mode**
+  Supported only for machine (VM) charms.
+
+This is due to current ecosystem constraints:
+
+- The etcd charm is only available for VM deployments
+- Cross-model relations between Kubernetes and VM charms have limitations,
+  particularly when sharing secrets over relations.
+
+As a result, Kubernetes charms should use the peer-based backend only.
+
 Execution model
 ---------------
 

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -347,6 +347,13 @@ In v0, coordination issues could lead to unexpected or unsafe behavior:
 - Multiple lock requests could overwrite each other, silently dropping operations
 - Exceptions during callbacks could leave the system in a stuck state.
 
+The new version introduces:
+
+- Safe handling of deferred callbacks, preserving lock guarantees
+- A per-unit operation queue, ensuring all requests are preserved and executed
+- Explicit retry semantics, allowing controlled and predictable failure handling
+- Support for rolling operations across multiple applications (via etcd)
+
 Key migration changes:
 
 - New ``RollingOpsManager`` constructor
@@ -388,6 +395,7 @@ Each callback is identified by a string key::
         },
     )
 
+
 ### Requesting an asynchronous lock
 
 Before, lock acquisition was triggered by emitting the library event::
@@ -400,8 +408,9 @@ Before, lock acquisition was triggered by emitting the library event::
             callback_override="_custom_restart"
     )
 
+
 Now, request the lock directly through ``request_async_lock`` and pass the
-callback identifier:
+callback identifier::
 
     def _on_restart_action(self, event):
         delay = event.params.get("delay")
@@ -417,6 +426,7 @@ callback identifier:
             callback_id="custom-restart",
             kwargs={"delay": delay},
         )
+
 
 Now, arguments can be passed directly through kwargs when requesting the lock.
 You can also use ``max_retry`` when requesting the lock to limit the number of

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -41,8 +41,8 @@ Typical use cases:
 - Maintenance tasks that must not run concurrently
 - Cluster-wide operations coordinated via etcd
 
-Limitations
------------
+Known current limitations
+------------------------
 
 - **Peer-only mode**
   Supported for both machine (VM) and Kubernetes charms.
@@ -57,6 +57,8 @@ This is due to current ecosystem constraints:
   particularly when sharing secrets over relations.
 
 As a result, Kubernetes charms should use the peer-based backend only.
+
+We are aware of these limitations and are actively working to address them.
 
 Execution model
 ---------------

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -42,7 +42,7 @@ Typical use cases:
 - Cluster-wide operations coordinated via etcd
 
 Known current limitations
-------------------------
+--------------------------
 
 - **Peer-only mode**
   Supported for both machine (VM) and Kubernetes charms.

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -251,7 +251,7 @@ operate using the peer backend until the identifier becomes available.
 Once the ``cluster_id`` is set, etcd-backed coordination will be used
 automatically if the etcd relation is configured.
 
-Do not provide a ``cluster_id`` without a `etcd_relation_name`.
+Do not provide a ``cluster_id`` without a ``etcd_relation_name``.
 
 
 Integrations
@@ -276,7 +276,7 @@ with etcd.
 Usage
 ----------
 
-Provide an implementation of `SyncLockBackend`::
+Provide an implementation of ``SyncLockBackend``::
 
     from charmlibs.rollingops import SyncLockBackend
 
@@ -332,8 +332,8 @@ Use the rollingops library in your charm::
 
             # Lock is automatically released
 
-If you want to used it on peer-only mode, skip the `etcd_relation_name` and
-`cluster_id` parameters in the `RollingOpsManager` constructor::
+If you want to used it on peer-only mode, skip the ``etcd_relation_name`` and
+``cluster_id`` parameters in the ``RollingOpsManager`` constructor::
 
     from charmlibs.rollingops import RollingOpsManager
 
@@ -353,7 +353,7 @@ If you want to used it on peer-only mode, skip the `etcd_relation_name` and
                 },
             )
 
-Beware that the `sync_lock_targets` is also optional, but if no provided, the
+Beware that the ``sync_lock_targets`` is also optional, but if no provided, the
 sync lock cannot be used
 
 Migration from v0
@@ -378,8 +378,8 @@ The new version introduces:
 Key migration changes:
 
 - New ``RollingOpsManager`` constructor
-  Replace `relation` and `callback` with `peer_relation_name` and
-  `callback_targets` (mapping of callback IDs to methods).
+  Replace ``relation`` and ``callback`` with ``peer_relation_name`` and
+  ``callback_targets`` (mapping of callback IDs to methods).
 
 - New callback signature and contract
   Callbacks no longer receive an event, must accept ``**kwargs``, and must

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -35,6 +35,7 @@ errors, the library automatically falls back to the peer-based backend to ensure
 operations can continue.
 
 Typical use cases::
+
 - Rolling restarts of application units
 - Safe configuration changes requiring sequential execution
 - Maintenance tasks that must not run concurrently

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -234,6 +234,8 @@ operate using the peer backend until the identifier becomes available.
 Once the ``cluster_id`` is set, etcd-backed coordination will be used
 automatically if the etcd relation is configured.
 
+Do not provide a ``cluster_id`` without a `etcd_relation_name`.
+
 
 Integrations
 --------------

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -140,7 +140,8 @@ Callbacks must return an `OperationResult`:
 The callback arguments (``kwargs``) must be JSON-serializable, as they are
 stored in the peer relation databag.
 
-## Peer-based scheduling
+Peer-based scheduling
+^^^^^^^^^^^^^^^^^^^^^
 
 In peer-based mode, the leader unit acts as scheduler and grants the lock.
 
@@ -157,7 +158,8 @@ Rules:
 
 The selected unit executes the head of its queue.
 
-### Etcd-based coordination
+Etcd-based coordination
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 When etcd is used:
 
@@ -172,7 +174,7 @@ To use etcd-backed operations:
 
 1. Deploy an ``charmed-etcd`` application
 2. Integrate it with a TLS certificates provider that implements the
-``tls-certificates`` interface
+   `tls-certificates`` interface
 3. Relate ``charmed-etcd`` to your charm
 
 The etcd-based functionality requires the etcdctl binary to be present
@@ -249,7 +251,8 @@ Nothe that the peer relation is mandatory even if we are integrating
 with etcd.
 
 
-## Usage
+Usage
+----------
 
 Provide an implementation of `SyncLockBackend`::
 
@@ -330,6 +333,126 @@ If you want to used it on peer-only mode, skip the `etcd_relation_name` and
 
 Beware that the `sync_lock_targets` is also optional, but if no provided, the
 sync lock cannot be used
+
+Migration from v0
+-----------------
+
+The charmlibs-rollingops library introduces a more robust and predictable execution model,
+addressing several limitations of the previous implementation.
+
+In v0, coordination issues could lead to unexpected or unsafe behavior:
+
+- Deferred callbacks could break mutual exclusion, causing operations to run without a lock
+- Multiple lock requests could overwrite each other, silently dropping operations
+- Exceptions during callbacks could leave the system in a stuck state.
+
+Key migration changes:
+
+- New ``RollingOpsManager`` constructor
+  Replace `relation` and `callback` with `peer_relation_name` and
+  `callback_targets` (mapping of callback IDs to methods).
+
+- New callback signature and contract
+  Callbacks no longer receive an event, must accept ``**kwargs``, and must
+  return an ``OperationResult``.
+
+- New async lock request API
+  Replace event emission (``acquire_lock.emit``) with
+  ``request_async_lock(callback_id=..., kwargs=..., max_retry=...)``.
+
+
+### Manager initialization
+
+Before, the manager accepted a single relation name and a single callback::
+
+    from charms.rolling_ops.v0.rollingops import RollingOpsManager
+
+    self.restart_manager = RollingOpsManager(
+        charm=self,
+        relation="restart",
+        callback=self._restart,
+    )
+
+Now, callbacks are registered explicitly using callback_targets.
+Each callback is identified by a string key::
+
+    from charmlibs.rollingops import RollingOpsManager
+
+    self.rollingops = RollingOpsManager(
+        charm=self,
+        peer_relation_name="restart",
+        callback_targets={
+            "restart": self._restart,
+            "custom-restart": self._custom_restart,
+        },
+    )
+
+### Requesting an asynchronous lock
+
+Before, lock acquisition was triggered by emitting the library event::
+
+    def _on_restart_action(self, event):
+        self.on[self.restart_manager.name].acquire_lock.emit()
+
+    def _on_custom_restart_action(self, event):
+        self.on[self.restart_manager.name].acquire_lock.emit(
+            callback_override="_custom_restart"
+    )
+
+Now, request the lock directly through ``request_async_lock`` and pass the
+callback identifier:
+
+    def _on_restart_action(self, event):
+        delay = event.params.get("delay")
+        self.rollingops.request_async_lock(
+            callback_id="restart",
+            kwargs={"delay": delay},
+            max-retry=1,
+        )
+
+    def _on_custom_restart_action(self, event):
+        delay = event.params.get("delay")
+        self.rollingops.request_async_lock(
+            callback_id="custom-restart",
+            kwargs={"delay": delay},
+        )
+
+Now, arguments can be passed directly through kwargs when requesting the lock.
+You can also use ``max_retry`` when requesting the lock to limit the number of
+retry attempts in case of failure.
+
+### Retries and callback return value
+
+Callbacks must now return an ``OperationResult`` so the library knows whether
+to release the lock or retry the operation.
+
+Before::
+
+    def _restart(self, event):
+        if self._stored.delay:
+            time.sleep(int(self._stored.delay))
+
+        self.model.get_relation(self.restart_manager.name).data[self.unit].update({
+            "restart-type": "restart"
+        })
+
+Now::
+
+    from charmlibs.rollingops import OperationResult
+
+    def _restart(self, delay=None) -> OperationResult:
+        if not self.is_ready():
+            return OperationResult.RETRY_RELEASE
+        if delay:
+            time.sleep(int(delay))
+
+        self._stored.restarted = True
+
+        self.model.get_relation("restart").data[self.unit].update({
+            "restart-type": "restart"
+        })
+
+        return OperationResult.RELEASE
 
 """
 

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -34,7 +34,7 @@ relation for internal state management. If etcd becomes unavailable or encounter
 errors, the library automatically falls back to the peer-based backend to ensure
 operations can continue.
 
-Typical use cases::
+Typical use cases:
 
 - Rolling restarts of application units
 - Safe configuration changes requiring sequential execution
@@ -120,7 +120,8 @@ retried due to failures or hook replays. They must not interact directly with
 the locking mechanism (e.g. requesting locks, mutating the peer relation
 databag used by the library, emitting relation events, or deferring execution).
 
-### Operation result
+Operation result
+~~~~~~~~~~~~~~~~
 
 Callbacks must return an `OperationResult`:
 
@@ -136,7 +137,8 @@ Callbacks must return an `OperationResult`:
 - If the callback returns None or an invalid value, the lock is released.
 - If the callback raises an exception, it is considered as a `RETRY_RELEASE`.
 
-### Arguments
+Arguments:
+~~~~~~~~~~
 
 The callback arguments (``kwargs``) must be JSON-serializable, as they are
 stored in the peer relation databag.
@@ -369,7 +371,8 @@ Key migration changes:
   ``request_async_lock(callback_id=..., kwargs=..., max_retry=...)``.
 
 
-### Manager initialization
+Manager initialization
+^^^^^^^^^^^^^^^^^^^^^^
 
 Before, the manager accepted a single relation name and a single callback::
 
@@ -396,7 +399,8 @@ Each callback is identified by a string key::
     )
 
 
-### Requesting an asynchronous lock
+Requesting an asynchronous lock
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Before, lock acquisition was triggered by emitting the library event::
 
@@ -432,7 +436,8 @@ Now, arguments can be passed directly through kwargs when requesting the lock.
 You can also use ``max_retry`` when requesting the lock to limit the number of
 retry attempts in case of failure.
 
-### Retries and callback return value
+Retries and callback return value
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Callbacks must now return an ``OperationResult`` so the library knows whether
 to release the lock or retry the operation.

--- a/rollingops/src/charmlibs/rollingops/__init__.py
+++ b/rollingops/src/charmlibs/rollingops/__init__.py
@@ -15,20 +15,24 @@
 """RollingOps: coordinated rolling operations for Juju charms.
 
 This library provides a unified API to coordinate rolling operations across
-units of a Juju application. It supports two execution modes:
+units of a Juju application.
+
+It supports two execution modes:
 
 1. Peer-based (application level)
    Uses peer relations to coordinate operations within a single application.
-   Ensures that disruptive actions (e.g. restarts, reconfigurations) are
-   executed sequentially, with at most one unit operating at a time.
-   The leader schedules work and guarantees fairness and safe progression.
+   The leader unit schedules execution and ensures that operations are
+   performed sequentially (at most one unit at a time).
 
 2. Etcd-based (cluster level)
-   Uses etcd as a distributed coordination backend to provide asynchronous,
-   non-blocking mutual exclusion across units. Each unit runs a background
-   worker that manages lock acquisition, lease renewal, and execution of
-   operations without blocking Juju hooks. This is suitable for long-running
-   tasks across a cluster.
+   Uses etcd as a distributed coordination backend. Units independently
+   compete for the lock using etcd primitives, enabling coordination across
+   applications or clusters.
+
+When etcd is configured, it is the primary backend, but it depends on the peer
+relation for internal state management. If etcd becomes unavailable or encounters
+errors, the library automatically falls back to the peer-based backend to ensure
+operations can continue.
 
 Typical use cases::
 - Rolling restarts of application units
@@ -36,21 +40,50 @@ Typical use cases::
 - Maintenance tasks that must not run concurrently
 - Cluster-wide operations coordinated via etcd
 
+Execution model
+---------------
+
+RollingOps is based on a **lock-driven execution model**.
+
+Units do not execute operations immediately. Instead, they:
+
+- Request a lock
+- Provide a callback identifier and arguments
+- The operation is queued locally
+- When the lock is granted, the callback is executed asynchronously
+
+At any time, only one unit holds the lock and executes one operation.
+
+Operation queue
+---------------
+
+Each unit maintains a queue of pending operations. Only the head of the queue
+is executed when the lock is granted.
+
+New operations follow these deduplication rules:
+
+- Same operation + same arguments
+  → If the latest queued operation has the same `callback_id` and arguments,
+  the new request is ignored.
+
+- Same operation + different arguments
+  → The new operation is added to the queue.
+
+- Different operation
+  → The new operation is added to the queue.
+
 
 Core concepts
 -------------
 
-Asynchronous lock (primary mechanism)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Asynchronous lock (recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The main functionality of this library is the asynchronous lock.
-Callers enqueue an operation by providing a callback target. The library
-ensures that the operation is executed later, in mutual exclusion,
-without blocking the current Juju hook. This is the recommended approach
-for most operations.
+The primary mechanism. Operations are enqueued and executed later when the
+lock is granted. This avoids blocking Juju hooks.
 
-Synchronous lock (special-case mechanism)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Synchronous lock (special-case)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A synchronous lock is provided for scenarios where deferring is not
 possible (e.g. teardown or finalization paths). In this mode, the hook is
@@ -69,105 +102,87 @@ lock backends via the ``sync_lock_targets`` parameter when initializing
 ``RollingOpsManager``. Each backend must implement ``SyncLockBackend``.
 
 
-Basic usage::
+Callback contract
+^^^^^^^^^^^^^^^^^
 
-    from charmlibs.rollingops import RollingOpsManager, SyncLockBackend, OperationResult
+Asynchronous operations are defined as callbacks and registered via the
+``callback_targets`` parameter when initializing ``RollingOpsManager``.
+This parameter is a mapping of string identifiers to bound methods on the
+charm.
 
-    class MySyncLockBackend(SyncLockBackend):
-        def __init__(self, path: str = "/tmp/rollingops.lock"):
-            self._path = path
+Callbacks must follow this signature::
 
-        def acquire(self, timeout: int | None) -> None:
-            # Provide implementation
+    def <callback>(self, **kwargs) -> OperationResult
 
-        def release(self) -> None:
-            # Provide implementation
+Callbacks must be idempotent and safe to run multiple times, as they may be
+retried due to failures or hook replays. They must not interact directly with
+the locking mechanism (e.g. requesting locks, mutating the peer relation
+databag used by the library, emitting relation events, or deferring execution).
 
-    class MyCharm(CharmBase):
-        def __init__(self, *args):
-            super().__init__(*args)
+### Operation result
 
-            my_sync_backend = MySyncLockBackend()
-            self.rollingops = RollingOpsManager(
-                charm=self,
-                callback_targets={
-                    "restart": self._restart_unit,
-                },
-                peer_relation_name="my-peers",
-                etcd_relation_name="etcd",
-                cluster_id="my-cluster",
-                sync_lock_targets={
-                    "my-lock" : my_sync_backend,
-                },
-            )
+Callbacks must return an `OperationResult`:
 
-        def _restart_unit(self) -> OperationResult:
-            # logic executed under rolling coordination
-            return OperationResult.RELEASE
+- `RELEASE`
+  → Execution succeeded, release the lock
 
-        def _on_config_changed(self, event):
-            # asynchronous (recommended)
-            self.rollingops.request_async_lock("restart")
+- `RETRY_RELEASE`
+  → Execution failed, retry later after releasing the lock (other units may proceed)
 
-        def _on_stop(self, event):
-            # synchronous (only when deferring is not possible)
-            with self.rollingops.acquire_sync_lock(
-                backend_id="my-lock",
-                timeout=300,
-            ):
-                self._restart_unit()
+- `RETRY_HOLD`
+  → Execution failed, retry while keeping the lock
 
+- If the callback returns None or an invalid value, the lock is released.
+- If the callback raises an exception, it is considered as a `RETRY_RELEASE`.
+
+### Arguments
+
+The callback arguments (``kwargs``) must be JSON-serializable, as they are
+stored in the peer relation databag.
+
+## Peer-based scheduling
+
+In peer-based mode, the leader unit acts as scheduler and grants the lock.
+
+Scheduling is priority-based, from highest to lowest:
+
+1. Retry-hold operations
+2. First-time requests
+3. Retry-release operations
+
+Rules:
+
+- If a unit holds the lock → no new grant
+- Otherwise → select next unit based on priority
+
+The selected unit executes the head of its queue.
+
+### Etcd-based coordination
+
+When etcd is used:
+
+- Units independently attempt to acquire the lock via etcd
+- There is no central scheduler
+- Execution remains mutually exclusive (one lock holder)
 
 Etcd setup
 ----------
 
-To use etcd-backed rolling operations, deploy an etcd application and a
-certificates provider that implements the ``tls-certificates`` interface
-according to your deployment requirements.
+To use etcd-backed operations:
 
-The certificates provider must be integrated with etcd first. Then integrate
-etcd with the charm using this library.
+1. Deploy an ``charmed-etcd`` application
+2. Integrate it with a TLS certificates provider that implements the
+``tls-certificates`` interface
+3. Relate ``charmed-etcd`` to your charm
 
-At the moment, etcd is available as a VM operator only. There is no Kubernetes
-etcd operator. If your charm is a VM charm, etcd can be deployed in the same
-model and related directly to your charm. If your charm runs on Kubernetes,
-deploy etcd in another VM model/cloud/controller, offer the etcd relation,
-consume the offer from the Kubernetes model, and integrate your charm with
-that consumed offer.
-
-Integrations
---------------------------
-
-Integration with etcd is optional. If you only need application-level
-coordination, you can rely on the peer relation alone and omit both
-``etcd_relation_name`` and ``cluster_id`` when initializing
-``RollingOpsManager``.
-
-Note that the etcd-based functionality still depends on the peer relation
-for internal coordination and state management, so the peer relation must
-always be configured.
-
-When etcd is configured, the library will prefer etcd-backed coordination
-and fall back to the peer-based mechanism if etcd is unavailable.
-
-The relations can be added to the charm as follows::
-
-
-    peers:
-      rollingops-peers:
-        interface: rollingops-peers
-
-    requires:
-      etcd:
-        interface: etcd_client
-        limit: 1
-        optional: true
+The etcd-based functionality requires the etcdctl binary to be present
+in the charm.
 
 Including etcdctl in your charm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The etcd-backed functionality relies on the ``etcdctl`` binary being available
-inside the charm container/machine. This binary is not provided automatically
+inside the charm machine. This binary is not provided automatically
 and must be included as part of your charm build.
 
 You can add it in your ``charmcraft.yaml`` using a build part::
@@ -187,17 +202,26 @@ You can add it in your ``charmcraft.yaml`` using a build part::
         prime:
           - usr/bin/etcdctl
 
-This will make ``etcdctl`` available at runtime under ``<charm-dir>/usr/bin/etcdctl``
-inside the charm.
+This makes ``etcdctl`` available at runtime under
+``<charm-dir>/usr/bin/etcdctl``.
+
+This path is expected by the library, so do not install the binary in a
+different location.
 
 Make sure the binary is present and executable, as it is required for
 communication with the etcd backend.
+
 
 Cluster identifier
 ^^^^^^^^^^^^^^^^^^
 
 The ``cluster_id`` parameter is used to scope etcd-backed coordination.
-It does not need to be hardcoded and may be provided dynamically at runtime.
+
+All applications using the same ``cluster_id`` will share the same lock,
+allowing rolling operations to be coordinated across multiple applications.
+
+The ``cluster_id`` does not need to be hardcoded and may be provided dynamically
+at runtime.
 
 The ``RollingOpsManager`` can be initialized without a ``cluster_id`` and will
 operate using the peer backend until the identifier becomes available.
@@ -205,33 +229,108 @@ operate using the peer backend until the identifier becomes available.
 Once the ``cluster_id`` is set, etcd-backed coordination will be used
 automatically if the etcd relation is configured.
 
-Callback definition and registration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Asynchronous operations are defined as callbacks and registered through the
-``callback_targets`` parameter when initializing ``RollingOpsManager``.
-This parameter is a mapping of string identifiers to bound methods on the
-charm. Each identifier is used when requesting a lock and determines which
-callback will be executed once the lock is granted.
+Integrations
+--------------
 
-Callbacks are invoked on the unit holding the lock and must follow this
-signature::
+Example relations::
 
-    def <callback>(self, **kwargs) -> OperationResult
+    peers:
+      rollingops-peers:
+        interface: rollingops-peers
 
-The ``kwargs`` provided when requesting the lock are passed to the callback
-at execution time. These arguments must be JSON-serializable, as they are
-stored in the peer relation databag.
+    requires:
+      etcd:
+        interface: etcd_client
+        limit: 1
+        optional: true
 
-Callbacks must be idempotent and safe to run multiple times, as they may be
-retried due to failures or hook replays. They must not interact directly with
-the locking mechanism (e.g. requesting locks, mutating the peer relation
-databag used by the library, emitting relation events, or deferring execution).
+Nothe that the peer relation is mandatory even if we are integrating
+with etcd.
 
-The callback must return an ``OperationResult`` indicating how the library
-should proceed (e.g. release the lock or retry execution). If the callback
-raises an unexpected exception or returns an invalid value, the library will
-log the issue and release the lock.
+
+## Usage
+
+Provide an implementation of `SyncLockBackend`::
+
+    from charmlibs.rollingops import SyncLockBackend
+
+    class MySyncLockBackend(SyncLockBackend):
+        def __init__(self, path: str = "/tmp/rollingops.lock"):
+            self._path = path
+
+        def acquire(self, timeout: int | None) -> None:
+            # Provide implementation
+
+        def release(self) -> None:
+            # Provide implementation
+
+Use the rollingops library in your charm::
+
+    from charmlibs.rollingops import RollingOpsManager, OperationResult
+
+    class MyCharm(CharmBase):
+        def __init__(self, *args):
+            super().__init__(*args)
+
+            my_sync_backend = MySyncLockBackend()
+            self.rollingops = RollingOpsManager(
+                charm=self,
+                callback_targets={
+                    "restart": self._restart_unit,
+                },
+                peer_relation_name="my-peers",
+                etcd_relation_name="etcd",
+                cluster_id="my-cluster",
+                sync_lock_targets={
+                    "my-lock" : my_sync_backend,
+                },
+            )
+
+        # This is a callback
+        def _restart_unit(self) -> OperationResult:
+            # logic executed under rolling coordination
+            return OperationResult.RELEASE
+
+        # This is an async lock request
+        def _on_config_changed(self, event):
+            self.rollingops.request_async_lock("restart", kwargs={'delay': delay}, max_retry=2)
+
+        # This is a sync lock request (to be used only when deferring is not possible)
+        def _on_stop(self, event):
+            with self.rollingops.acquire_sync_lock(
+                backend_id="my-lock",
+                timeout=300,
+            ):
+                # Execute the critial section
+                self._restart_unit()
+
+            # Lock is automatically released
+
+If you want to used it on peer-only mode, skip the `etcd_relation_name` and
+`cluster_id` parameters in the `RollingOpsManager` constructor::
+
+    from charmlibs.rollingops import RollingOpsManager
+
+    class MyCharm(CharmBase):
+        def __init__(self, *args):
+            super().__init__(*args)
+
+            my_sync_backend = MySyncLockBackend()
+            self.rollingops = RollingOpsManager(
+                charm=self,
+                callback_targets={
+                    "restart": self._restart_unit,
+                },
+                peer_relation_name="my-peers",
+                sync_lock_targets={
+                    "my-lock" : my_sync_backend,
+                },
+            )
+
+Beware that the `sync_lock_targets` is also optional, but if no provided, the
+sync lock cannot be used
+
 """
 
 from ._common._exceptions import (

--- a/rollingops/src/charmlibs/rollingops/_common/_models.py
+++ b/rollingops/src/charmlibs/rollingops/_common/_models.py
@@ -96,8 +96,7 @@ class RollingOpsStatus(StrEnum):
 
     States:
 
-    - NOT_READY:
-        Rolling-ops cannot be used on this unit. This typically occurs when
+    - NOT_READY: Rolling-ops cannot be used on this unit. This typically occurs when
         required relations are missing or the selected backend is not reachable.
 
         - peer backend: peer relation does not exist
@@ -445,11 +444,11 @@ class RollingOpsState:
 
     This state is intended for decision-making in charm logic
 
-    The `processing_backend` reflects the backend currently selected
+    The ``processing_backend`` reflects the backend currently selected
         for execution. It may change dynamically (e.g. fallback from etcd
         to peer).
 
-    When `status` is NOT_READY, the unit cannot currently participate
+    When ``status`` is NOT_READY, the unit cannot currently participate
         in rolling operations due to missing relations or backend failures.
 
     status: High-level rolling-ops status for the unit.

--- a/rollingops/src/charmlibs/rollingops/_common/_models.py
+++ b/rollingops/src/charmlibs/rollingops/_common/_models.py
@@ -99,8 +99,9 @@ class RollingOpsStatus(StrEnum):
     - NOT_READY:
         Rolling-ops cannot be used on this unit. This typically occurs when
         required relations are missing or the selected backend is not reachable.
-        * peer backend: peer relation does not exist
-        * etcd backend: peer or etcd relation missing, or etcd not reachable
+
+        - peer backend: peer relation does not exist
+        - etcd backend: peer or etcd relation missing, or etcd not reachable
 
     - WAITING: The unit has pending operations but does not currently hold the lock.
 

--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -241,7 +241,7 @@ class RollingOpsManager(Object):
                 operation is granted the rolling lock.
             kwargs: Optional keyword arguments passed to the callback target.
             max_retry: Optional maximum number of retries allowed for the
-                operation. None means infinte retries.
+                operation. None means infinite retries.
 
         Raises:
             RollingOpsInvalidLockRequestError: If the callback identifier is

--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -61,6 +61,25 @@ class RollingOpsManager(Object):
     available, mirrors operation state into the peer relation, and falls
     back to peer-based processing when etcd becomes unavailable or
     inconsistent.
+
+    Args:
+        charm: The charm instance owning this manager.
+        callback_targets: Mapping of callback identifiers to callables
+            executed when the unit is granted the lock.
+        peer_relation_name: Name of the peer relation used for fallback
+            state and operation mirroring.
+        etcd_relation_name: Name of the relation providing etcd access.
+            If not provided, only peer backend is used.
+        cluster_id: Identifier used to scope etcd-backed state for this
+            rolling-ops instance. All applications using the same ``cluster_id``
+            will share the same lock, allowing rolling operations to be coordinated
+            across multiple applications.  Do not provide a ``cluster_id`` without
+            a `etcd_relation_name`.
+        sync_lock_targets: Optional mapping of sync lock backend
+            identifiers to backend implementations used when acquiring
+            synchronous locks through the peer backend.
+        base_dir: base directory where all files related to rollingops will be written.
+            Written to ``/var/lib/rollingops`` by default.
     """
 
     def __init__(
@@ -89,16 +108,19 @@ class RollingOpsManager(Object):
         Args:
             charm: The charm instance owning this manager.
             callback_targets: Mapping of callback identifiers to callables
-                executed when queued operations are granted the lock.
+                executed when the unit is granted the lock.
             peer_relation_name: Name of the peer relation used for fallback
                 state and operation mirroring.
             etcd_relation_name: Name of the relation providing etcd access.
                 If not provided, only peer backend is used.
             cluster_id: Identifier used to scope etcd-backed state for this
-                rolling-ops instance.
+                rolling-ops instance. All applications using the same ``cluster_id``
+                will share the same lock, allowing rolling operations to be coordinated
+                across multiple applications.  Do not provide a ``cluster_id`` without
+                a `etcd_relation_name`.
             sync_lock_targets: Optional mapping of sync lock backend
                 identifiers to backend implementations used when acquiring
-                synchronous locks through the peer fallback path.
+                synchronous locks through the peer backend.
             base_dir: base directory where all files related to rollingops will be written.
                 Written to ``/var/lib/rollingops`` by default.
         """


### PR DESCRIPTION
This PR improves the documentation for the new rollingops lib.

I also includes a migration guide after deprecation of the rollingops living in the `charm-rolling-ops` repo

Deprecation notice added here https://github.com/canonical/charm-rolling-ops/pull/185