### PR TITLE
docs: fix schema links

### DIFF
--- a/interfaces/certificate_transfer/interface/v1/README.md
+++ b/interfaces/certificate_transfer/interface/v1/README.md
@@ -31,9 +31,9 @@ Both the Requirer and the Provider need to adhere to criteria to be considered c
 
 ## Relation Data
 
-### Provider
+[\[Pydantic Schema\]](./schema.py)
 
-[\[JSON Schema\]](./schema.py)
+### Provider
 
 The provider writes any number of certficates to its relation data.
 
@@ -51,8 +51,6 @@ relation-info:
 ```
 
 ### Requirer
-
-[\[JSON Schema\]](./schema.py)
 
 The requirer writes the version number of the interface to its application databag as soon as feasible.
 

--- a/interfaces/cos_agent/interface/v0/README.md
+++ b/interfaces/cos_agent/interface/v0/README.md
@@ -38,9 +38,9 @@ As all Juju relations, the `cos_agent` interface consists of a provider and a re
 
 ## Relation Data
 
-### Provider
+[\[Pydantic Schema\]](./schema.py)
 
-[\[JSON Schema\]]
+### Provider
 
 
 #### Unit data

--- a/interfaces/ldap/interface/v0/README.md
+++ b/interfaces/ldap/interface/v0/README.md
@@ -53,6 +53,8 @@ through the relation databag(s).
 
 ## Relation Data
 
+[\[Pydantic Schema\]](./schema.py)
+
 ### Provider
 
 The `provider` provides LDAP URL, base DN, and bind DN, and LDAP

--- a/interfaces/tls-certificates/interface/v1/README.md
+++ b/interfaces/tls-certificates/interface/v1/README.md
@@ -43,6 +43,8 @@ compatible with the interface.
 
 ## Relation Data
 
+[\[Pydantic Schema\]](./schema.py)
+
 ### Requirer
 
 The requirer specifies a set of certificate signing requests (CSR's).


### PR DESCRIPTION
This small PR fixes some schema links in interface readmes, requiring codeowner review to merge:
- `certificate-transfer`, `cos_agent`: links were described as JSON schema, corrected to Pydantic
- `ldap`, `tls-certificates`: added missing links to existing schema files

Resolves #371