### PR TITLE
feat(rollingops): check for waiting condition in other units

### DIFF
--- a/rollingops/CHANGELOG.md
+++ b/rollingops/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.0 - 20 May 2026
+
+Extend the `RollingOpsManager` is_waiting_* helpers to receive a unit name.
+
 # 1.0.1 - 04 May 2026
 
 Fix the `ModelError` messages generated during rollback operations.

--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -18,7 +18,7 @@ import logging
 from contextlib import contextmanager
 from typing import Any
 
-from ops import CharmBase, Object, Relation, RelationBrokenEvent
+from ops import CharmBase, Object, Relation, RelationBrokenEvent, Unit
 from ops.framework import EventBase
 
 from charmlibs import pathops
@@ -386,6 +386,14 @@ class RollingOpsManager(Object):
             self._peer_backend.ensure_processing()
             logger.info('Fell back to peer backend.')
 
+    def _get_peer_unit(self, unit_name: str) -> Unit:
+        """Return the peer unit having the provided name."""
+        for peer_unit in iter_peer_units(self.model, self.peer_relation_name):
+            if peer_unit.name == unit_name:
+                return peer_unit
+
+        raise ValueError('unit_name provided does not belong to the peer relation.')
+
     def _get_sync_lock_backend(self, backend_id: str) -> SyncLockBackend:
         """Instantiate the configured peer sync lock backend.
 
@@ -512,51 +520,50 @@ class RollingOpsManager(Object):
         )
 
     def is_waiting_callback(self, callback_id: str, unit_name: str | None = None) -> bool:
-        """Return whether the desired unit has a pending operation matching callback."""
+        """Return whether the desired unit has a pending operation matching callback.
+
+        Args:
+            callback_id: callback ID to search for in the unit list of operations.
+            unit_name: name of the unit to search for specific callback ID operations.
+                If not specified, defaults to this unit.
+
+        Raises:
+            ValueError: If the unit name is not found within the peer relation units.
+        """
         if self._peer_relation is None:
             return False
 
         if unit_name is None:
             unit_name = self.model.unit.name
 
-        unit = None
-        for peer_unit in iter_peer_units(self.model, self._peer_relation.name):
-            if peer_unit.name == unit_name:
-                unit = peer_unit
-                break
-
-        if unit is None:
-            raise ValueError('unit_name provided does not belong to the peer relation.')
-
         operations = PeerUnitOperations(
             self.model,
             self.peer_relation_name,
-            unit,
+            self._get_peer_unit(unit_name),
         ).queue.operations
 
         return any(op.callback_id == callback_id for op in operations)
 
     def is_waiting(self, unit_name: str | None = None) -> bool:
-        """Return whether the desired unit has a pending operations."""
+        """Return whether the desired unit has pending operations.
+
+        Args:
+            unit_name: name of the unit to search for operations.
+                If not specified, defaults to this unit.
+
+        Raises:
+            ValueError: If the unit name is not found within the peer relation units.
+        """
         if self._peer_relation is None:
             return False
 
         if unit_name is None:
             unit_name = self.model.unit.name
 
-        unit = None
-        for peer_unit in iter_peer_units(self.model, self._peer_relation.name):
-            if peer_unit.name == unit_name:
-                unit = peer_unit
-                break
-
-        if unit is None:
-            raise ValueError('unit_name provided does not belong to the peer relation.')
-
         operations = PeerUnitOperations(
             self.model,
             self.peer_relation_name,
-            unit,
+            self._get_peer_unit(unit_name),
         ).queue.operations
 
         return bool(operations)

--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -40,7 +40,7 @@ from charmlibs.rollingops._common._models import (
 from charmlibs.rollingops._common._utils import ETCD_FAILED_HOOK_NAME, LOCK_GRANTED_HOOK_NAME
 from charmlibs.rollingops._etcd._backend import _EtcdRollingOpsBackend
 from charmlibs.rollingops._peer._backend import _PeerRollingOpsBackend
-from charmlibs.rollingops._peer._models import PeerUnitOperations
+from charmlibs.rollingops._peer._models import PeerUnitOperations, iter_peer_units
 
 logger = logging.getLogger(__name__)
 
@@ -511,28 +511,52 @@ class RollingOpsManager(Object):
             processing_backend=self._backend_state.backend,
         )
 
-    def is_waiting_callback(self, callback_id: str) -> bool:
-        """Return whether the current unit has a pending operation matching callback."""
+    def is_waiting_callback(self, callback_id: str, unit_name: str | None = None) -> bool:
+        """Return whether the desired unit has a pending operation matching callback."""
         if self._peer_relation is None:
             return False
+
+        if unit_name is None:
+            unit_name = self.model.unit.name
+
+        unit = None
+        for peer_unit in iter_peer_units(self.model, self._peer_relation.name):
+            if peer_unit.name == unit_name:
+                unit = peer_unit
+                break
+
+        if unit is None:
+            raise ValueError('unit_name provided does not belong to the peer relation.')
 
         operations = PeerUnitOperations(
             self.model,
             self.peer_relation_name,
-            self.model.unit,
+            unit,
         ).queue.operations
 
         return any(op.callback_id == callback_id for op in operations)
 
-    def is_waiting(self) -> bool:
-        """Return whether the current unit has a pending operations."""
+    def is_waiting(self, unit_name: str | None = None) -> bool:
+        """Return whether the desired unit has a pending operations."""
         if self._peer_relation is None:
             return False
+
+        if unit_name is None:
+            unit_name = self.model.unit.name
+
+        unit = None
+        for peer_unit in iter_peer_units(self.model, self._peer_relation.name):
+            if peer_unit.name == unit_name:
+                unit = peer_unit
+                break
+
+        if unit is None:
+            raise ValueError('unit_name provided does not belong to the peer relation.')
 
         operations = PeerUnitOperations(
             self.model,
             self.peer_relation_name,
-            self.model.unit,
+            unit,
         ).queue.operations
 
         return bool(operations)

--- a/rollingops/src/charmlibs/rollingops/_version.py
+++ b/rollingops/src/charmlibs/rollingops/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/rollingops/tests/integration/test_etcd_rolling_ops.py
+++ b/rollingops/tests/integration/test_etcd_rolling_ops.py
@@ -205,6 +205,7 @@ def test_retry_hold_operation_two_units_single_app(juju: jubilant.Juju, app_name
     unit_b = units[3]
 
     juju.run(unit_a, 'deferred-restart', {'delay': 15, 'max-retry': 2}, wait=TIMEOUT)
+    time.sleep(2)
     juju.run(unit_b, 'restart', {'delay': 2}, wait=TIMEOUT)
 
     juju.wait(
@@ -253,9 +254,8 @@ def test_retry_release_two_units_single_app(juju: jubilant.Juju, app_name: str):
     juju.run(unit_a, 'failed-restart', {'delay': 10, 'max-retry': 2}, wait=TIMEOUT)
     juju.run(unit_b, 'failed-restart', {'delay': 15, 'max-retry': 2}, wait=TIMEOUT)
 
-    time.sleep(
-        60 * 3
-    )  # wait for operation execution. TODO: in charm use lock state to clear status.
+    # TODO: in charm use lock state to clear status.
+    time.sleep(60 * 3)
 
     all_events: list[dict[str, str]] = []
     all_events.extend(get_unit_events(juju, unit_a))

--- a/rollingops/tests/unit/test_etcd_rollingops_in_charm.py
+++ b/rollingops/tests/unit/test_etcd_rollingops_in_charm.py
@@ -419,10 +419,7 @@ def test_is_waiting_returns_true_when_matching_operation_exists_in_unit(
         local_app_data={},
         local_unit_data={
             'state': 'request',
-            'operations': _OperationQueue([
-                _Operation.create('restart', {'delay': 1}),
-                _Operation.create('restart', {'delay': 2}),
-            ]).to_string(),
+            'operations': _OperationQueue([]).to_string(),
             'executed_at': '',
             'processing_backend': 'peer',
             'etcd_cleanup_needed': 'false',
@@ -456,9 +453,7 @@ def test_is_waiting_returns_false_when_callback_does_not_match_in_unit(
         local_app_data={},
         local_unit_data={
             'state': 'request',
-            'operations': _OperationQueue([
-                _Operation.create('restart', {'delay': 1}),
-            ]).to_string(),
+            'operations': _OperationQueue([]).to_string(),
             'executed_at': '',
             'processing_backend': 'peer',
             'etcd_cleanup_needed': 'false',
@@ -489,7 +484,9 @@ def test_is_waiting_returns_false_when_no_operations_in_unit(
         local_app_data={},
         local_unit_data={
             'state': 'request',
-            'operations': _OperationQueue([]).to_string(),
+            'operations': _OperationQueue([
+                _Operation.create('restart', {'delay': 1}),
+            ]).to_string(),
             'executed_at': '',
             'processing_backend': 'peer',
             'etcd_cleanup_needed': 'false',

--- a/rollingops/tests/unit/test_etcd_rollingops_in_charm.py
+++ b/rollingops/tests/unit/test_etcd_rollingops_in_charm.py
@@ -396,3 +396,107 @@ def test_is_waiting_returns_false_when_no_operations(ctx: Context[RollingOpsChar
     with ctx(ctx.on.update_status(), state) as mgr:
         assert mgr.charm.restart_manager.is_waiting_callback('restart') is False
         assert mgr.charm.restart_manager.is_waiting() is False
+
+
+def test_is_waiting_returns_true_when_matching_operation_exists_in_unit(
+    ctx: Context[RollingOpsCharm],
+):
+    peer_rel = PeerRelation(
+        peers_data={
+            1: {
+                'state': 'request',
+                'operations': _OperationQueue([
+                    _Operation.create('restart', {'delay': 1}),
+                    _Operation.create('restart', {'delay': 2}),
+                ]).to_string(),
+                'executed_at': '',
+                'processing_backend': 'peer',
+                'etcd_cleanup_needed': 'false',
+            },
+        },
+        endpoint='restart',
+        interface='rollingops',
+        local_app_data={},
+        local_unit_data={
+            'state': 'request',
+            'operations': _OperationQueue([
+                _Operation.create('restart', {'delay': 1}),
+                _Operation.create('restart', {'delay': 2}),
+            ]).to_string(),
+            'executed_at': '',
+            'processing_backend': 'peer',
+            'etcd_cleanup_needed': 'false',
+        },
+    )
+
+    state = State(leader=False, relations={peer_rel})
+
+    with ctx(ctx.on.update_status(), state) as mgr:
+        assert mgr.charm.restart_manager.is_waiting_callback('restart', 'charm/1') is True
+        assert mgr.charm.restart_manager.is_waiting('charm/1') is True
+
+
+def test_is_waiting_returns_false_when_callback_does_not_match_in_unit(
+    ctx: Context[RollingOpsCharm],
+):
+    peer_rel = PeerRelation(
+        peers_data={
+            1: {
+                'state': 'request',
+                'operations': _OperationQueue([
+                    _Operation.create('restart', {'delay': 1}),
+                ]).to_string(),
+                'executed_at': '',
+                'processing_backend': 'peer',
+                'etcd_cleanup_needed': 'false',
+            },
+        },
+        endpoint='restart',
+        interface='rollingops',
+        local_app_data={},
+        local_unit_data={
+            'state': 'request',
+            'operations': _OperationQueue([
+                _Operation.create('restart', {'delay': 1}),
+            ]).to_string(),
+            'executed_at': '',
+            'processing_backend': 'peer',
+            'etcd_cleanup_needed': 'false',
+        },
+    )
+    state = State(leader=False, relations={peer_rel})
+
+    with ctx(ctx.on.update_status(), state) as mgr:
+        assert mgr.charm.restart_manager.is_waiting_callback('other-callback', 'charm/1') is False
+        assert mgr.charm.restart_manager.is_waiting('charm/1') is True
+
+
+def test_is_waiting_returns_false_when_no_operations_in_unit(
+    ctx: Context[RollingOpsCharm],
+):
+    peer_rel = PeerRelation(
+        peers_data={
+            1: {
+                'state': 'request',
+                'operations': _OperationQueue([]).to_string(),
+                'executed_at': '',
+                'processing_backend': 'peer',
+                'etcd_cleanup_needed': 'false',
+            },
+        },
+        endpoint='restart',
+        interface='rollingops',
+        local_app_data={},
+        local_unit_data={
+            'state': 'request',
+            'operations': _OperationQueue([]).to_string(),
+            'executed_at': '',
+            'processing_backend': 'peer',
+            'etcd_cleanup_needed': 'false',
+        },
+    )
+    state = State(leader=False, relations={peer_rel})
+
+    with ctx(ctx.on.update_status(), state) as mgr:
+        assert mgr.charm.restart_manager.is_waiting_callback('restart', 'charm/1') is False
+        assert mgr.charm.restart_manager.is_waiting('charm/1') is False


### PR DESCRIPTION
This PR extends the arguments on the `RollingOpsManager` is_waiting_* methods in order to check for waiting conditions in other units aside from the one where the code gets executed. These checks can be leveraged in the client applications in order to verify that, at a given moment, only a subset of units have received the event.