### PR TITLE
fix(rollingops): dynamic cluster id integration with etcd and sync lock

### DIFF
--- a/rollingops/CHANGELOG.md
+++ b/rollingops/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.1 - 22 May 2026
+
+Fix:
+- Dynamic cluster ID integration with etcd
+- Sync lock exception handling during critical path execution
+
 # 1.1.0 - 20 May 2026
 
 Extend the `RollingOpsManager` is_waiting_* helpers to receive a unit name.

--- a/rollingops/src/charmlibs/rollingops/_etcd/_backend.py
+++ b/rollingops/src/charmlibs/rollingops/_etcd/_backend.py
@@ -20,7 +20,6 @@ from ops import Object, Relation
 from ops.charm import (
     CharmBase,
     RelationCreatedEvent,
-    RelationDepartedEvent,
 )
 
 from charmlibs import pathops
@@ -130,9 +129,6 @@ class _EtcdRollingOpsBackend(Object):  # pyright: ignore[reportUnusedClass]
         )
 
         self.framework.observe(
-            charm.on[self.peer_relation_name].relation_departed, self._on_peer_relation_departed
-        )
-        self.framework.observe(
             charm.on[self.etcd_relation_name].relation_created, self._on_etcd_relation_created
         )
 
@@ -213,19 +209,6 @@ class _EtcdRollingOpsBackend(Object):  # pyright: ignore[reportUnusedClass]
         """
         if not self.etcdctl.is_etcdctl_installed():
             logger.error('%s is not installed.', ETCDCTL_CMD)
-
-    def _on_peer_relation_departed(self, event: RelationDepartedEvent) -> None:
-        """Handle removal of a unit from the peer relation.
-
-        If the current unit is departing, the etcd worker process is stopped
-        to ensure a clean shutdown and avoid leaving a stale worker running.
-
-        Args:
-            event: The peer relation departed event.
-        """
-        unit = event.departing_unit
-        if unit == self.model.unit:
-            self.worker.stop()
 
     def request_async_lock(
         self,

--- a/rollingops/src/charmlibs/rollingops/_etcd/_relations.py
+++ b/rollingops/src/charmlibs/rollingops/_etcd/_relations.py
@@ -112,7 +112,7 @@ class SharedClientCertificateManager(Object):
         app_data = relation.data[self.model.app]
 
         if app_data.get(CERT_SECRET_FIELD):
-            logger.info(
+            logger.debug(
                 'Shared certificate already exists in the databag. No new certificate is created.'
             )
             return

--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -18,7 +18,7 @@ import logging
 from contextlib import contextmanager
 from typing import Any
 
-from ops import CharmBase, Object, Relation, RelationBrokenEvent
+from ops import CharmBase, Object, Relation
 from ops.framework import EventBase
 
 from charmlibs import pathops
@@ -188,14 +188,6 @@ class RollingOpsManager(Object):
         recovery decisions.
         """
         return _UnitBackendState(self.model, self.peer_relation_name, self.model.unit)
-
-    def _on_etcd_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Handle the etcd relation being fully removed.
-
-        This method stops the etcd worker process since the required
-        relation is no longer available.
-        """
-        self._fallback_current_unit_to_peer()
 
     def _select_processing_backend(self) -> ProcessingBackend:
         """Choose which backend should handle new operations for this unit.

--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -423,13 +423,13 @@ class RollingOpsManager(Object):
             TimeoutError: If lock acquisition through etcd or the peer backend
                 times out.
             RollingOpsSyncLockError: if there is an error when acquiring the lock.
+            Any exception raised within the protected block is propagated, and the
+            lock is released before propagation.
         """
         if self._etcd_backend is not None and self._etcd_backend.is_available():
             logger.info('Acquiring sync lock on etcd.')
             try:
                 self._etcd_backend.acquire_sync_lock(timeout)
-                yield
-                return
             except TimeoutError:
                 raise
             except Exception as e:
@@ -438,12 +438,17 @@ class RollingOpsManager(Object):
                     'Failed to request etcd sync lock; falling back to peer: %s',
                     e,
                 )
-            finally:
+            else:
                 try:
-                    self._etcd_backend.release_sync_lock()
-                    logger.info('etcd lock released.')
-                except Exception as e:
-                    logger.exception('Failed to release sync lock: %s', e)
+                    # Separate lock acquisition errors from errors raised while holding the lock.
+                    yield
+                finally:
+                    try:
+                        self._etcd_backend.release_sync_lock()
+                        logger.info('etcd lock released.')
+                    except Exception as e:
+                        logger.exception('Failed to release sync lock: %s', e)
+                return
 
         backend = self._get_sync_lock_backend(backend_id)
         logger.info('Acquiring sync lock backend %s.', backend_id)

--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -450,6 +450,9 @@ class RollingOpsManager(Object):
                 try:
                     # Separate lock acquisition errors from errors raised while holding the lock.
                     yield
+                except Exception as e:
+                    logger.exception('Error while holding etcd sync lock: %s', e)
+                    raise
                 finally:
                     try:
                         self._etcd_backend.release_sync_lock()
@@ -469,6 +472,9 @@ class RollingOpsManager(Object):
 
         try:
             yield
+        except Exception as e:
+            logger.exception('Error while holding sync lock backend %s: %s', backend_id, e)
+            raise
         finally:
             try:
                 backend.release()

--- a/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
+++ b/rollingops/src/charmlibs/rollingops/_rollingops_manager.py
@@ -168,10 +168,7 @@ class RollingOpsManager(Object):
                 callback_targets=callback_targets,
                 base_dir=base_dir,
             )
-            self.framework.observe(
-                charm.on[etcd_relation_name].relation_broken,
-                self._on_etcd_relation_broken,
-            )
+            self._etcd_backend.shared_certificates.create_and_share_certificate()
 
         self.framework.observe(charm.on.rollingops_lock_granted, self._on_rollingops_lock_granted)
         self.framework.observe(charm.on.rollingops_etcd_failed, self._on_rollingops_etcd_failed)

--- a/rollingops/src/charmlibs/rollingops/_version.py
+++ b/rollingops/src/charmlibs/rollingops/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'

--- a/rollingops/tests/unit/conftest.py
+++ b/rollingops/tests/unit/conftest.py
@@ -14,6 +14,7 @@
 
 """Fixtures for unit tests, typically mocking out parts of the external system."""
 
+import time
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -31,7 +32,7 @@ from charmlibs.interfaces.tls_certificates import (
     Certificate,
     PrivateKey,
 )
-from charmlibs.rollingops import RollingOpsManager
+from charmlibs.rollingops import RollingOpsManager, SyncLockBackend
 from charmlibs.rollingops._common._models import OperationResult
 from charmlibs.rollingops._etcd._models import SharedCertificate
 
@@ -144,6 +145,16 @@ def certificates_manager_patches() -> Generator[dict[str, MagicMock], None, None
         }
 
 
+class DummySyncLockBackend(SyncLockBackend):
+    STOP_REPLSET_MEMBER = 'stop-replset-member'
+
+    def acquire(self, timeout: int | None) -> None:
+        return None
+
+    def release(self) -> None:
+        return None
+
+
 class RollingOpsCharm(ops.CharmBase):
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
@@ -160,10 +171,15 @@ class RollingOpsCharm(ops.CharmBase):
             etcd_relation_name='etcd',
             cluster_id='cluster-12345',
             callback_targets=callback_targets,
+            sync_lock_targets={DummySyncLockBackend.STOP_REPLSET_MEMBER: DummySyncLockBackend()},
         )
         self.framework.observe(self.on.restart_action, self._on_restart_action)
         self.framework.observe(self.on.failed_restart_action, self._on_failed_restart_action)
         self.framework.observe(self.on.deferred_restart_action, self._on_deferred_restart_action)
+        self.framework.observe(
+            self.on.failed_sync_restart_action, self._on_failed_sync_restart_action
+        )
+        self.framework.observe(self.on.sync_restart_action, self.on_sync_restart_action)
 
     def _on_restart_action(self, event: ActionEvent) -> None:
         delay = event.params.get('delay')
@@ -186,6 +202,23 @@ class RollingOpsCharm(ops.CharmBase):
             kwargs={'delay': delay},
             max_retry=max_retry,
         )
+
+    def _on_failed_sync_restart_action(self, event: ActionEvent) -> None:
+        timeout = int(event.params.get('timeout', 30))
+        with self.restart_manager.acquire_sync_lock(
+            backend_id=DummySyncLockBackend.STOP_REPLSET_MEMBER,
+            timeout=timeout,
+        ):
+            raise ValueError('Simulated failure in sync lock callback')
+
+    def on_sync_restart_action(self, event: ActionEvent) -> None:
+        timeout = int(event.params.get('timeout', 30))
+        delay = int(event.params.get('delay', 0))
+        with self.restart_manager.acquire_sync_lock(
+            backend_id=DummySyncLockBackend.STOP_REPLSET_MEMBER,
+            timeout=timeout,
+        ):
+            time.sleep(delay)
 
     def _restart(self) -> None:
         pass
@@ -252,6 +285,24 @@ actions: dict[str, Any] = {
             'max-retry': {
                 'description': 'Number of times the operation should be retried.',
                 'type': 'integer',
+            },
+        },
+    },
+    'failed-sync-restart': {
+        'description': 'Example restart that simulates a failure in a sync lock callback.',
+    },
+    'sync-restart': {
+        'description': 'Example restart that acquires a sync lock. Used in testing',
+        'params': {
+            'delay': {
+                'description': 'Amount of time in seconds to sleep while holding the sync lock.',
+                'type': 'integer',
+                'default': 0,
+            },
+            'timeout': {
+                'description': 'Timeout in seconds for sync lock acquisition.',
+                'type': 'integer',
+                'default': 30,
             },
         },
     },

--- a/rollingops/tests/unit/test_etcd_rollingops_in_charm.py
+++ b/rollingops/tests/unit/test_etcd_rollingops_in_charm.py
@@ -17,7 +17,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from ops.testing import Context, PeerRelation, Secret, State
+from ops.testing import Context, PeerRelation, Relation, Secret, State
 from scenario import RawDataBagContents
 from scenario.errors import UncaughtCharmError
 from tests.unit.conftest import (
@@ -497,3 +497,152 @@ def test_is_waiting_returns_false_when_no_operations_in_unit(
     with ctx(ctx.on.update_status(), state) as mgr:
         assert mgr.charm.restart_manager.is_waiting_callback('restart', 'charm/1') is False
         assert mgr.charm.restart_manager.is_waiting('charm/1') is False
+
+
+def test_sync_lock_request_failed_critical_path_using_etcd_lock(
+    ctx: Context[RollingOpsCharm],
+):
+    peer = PeerRelation(endpoint='restart')
+    etcd_relation = Relation(
+        endpoint='etcd',
+        interface='rollingops',
+    )
+    state_in = State(leader=False, relations={peer, etcd_relation})
+
+    with (
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.is_available',
+            return_value=True,
+        ) as mock_is_available,
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.acquire_sync_lock',
+        ) as mock_acquire_sync_lock,
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.release_sync_lock',
+        ) as mock_release_sync_lock,
+    ):
+        with pytest.raises(UncaughtCharmError) as exc_info:
+            ctx.run(
+                ctx.on.action('failed-sync-restart'),
+                state_in,
+            )
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    mock_is_available.assert_called_once()
+    mock_acquire_sync_lock.assert_called_once_with(30)
+    mock_release_sync_lock.assert_called_once()
+
+
+def test_sync_lock_fallbacks_to_peer_backend_on_etcd_error(
+    ctx: Context[RollingOpsCharm],
+):
+    peer = PeerRelation(endpoint='restart')
+    etcd_relation = Relation(
+        endpoint='etcd',
+        interface='rollingops',
+    )
+    state_in = State(leader=False, relations={peer, etcd_relation})
+
+    mock_backend = MagicMock()
+    mock_backend.acquire = MagicMock()
+    mock_backend.release = MagicMock()
+
+    with (
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.is_available',
+            return_value=True,
+        ) as mock_is_available,
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.acquire_sync_lock',
+            side_effect=Exception('etcd failure'),
+        ) as mock_etcd_acquire,
+        patch(
+            'charmlibs.rollingops._rollingops_manager.RollingOpsManager._get_sync_lock_backend',
+            return_value=mock_backend,
+        ),
+    ):
+        ctx.run(
+            ctx.on.action('sync-restart'),
+            state_in,
+        )
+
+    mock_is_available.assert_called_once()
+    mock_etcd_acquire.assert_called_once()
+    mock_backend.acquire.assert_called_once_with(timeout=30)
+    mock_backend.release.assert_called_once()
+
+
+def test_sync_lock_peer_backend_and_failure_on_critical_path_is_propagated(
+    ctx: Context[RollingOpsCharm],
+):
+    peer = PeerRelation(endpoint='restart')
+    etcd_relation = Relation(
+        endpoint='etcd',
+        interface='rollingops',
+    )
+    state_in = State(leader=False, relations={peer, etcd_relation})
+
+    mock_backend = MagicMock()
+    mock_backend.acquire = MagicMock()
+    mock_backend.release = MagicMock()
+
+    with (
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.is_available',
+            return_value=True,
+        ) as mock_is_available,
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.acquire_sync_lock',
+            side_effect=Exception('etcd failure'),
+        ) as mock_etcd_acquire,
+        patch(
+            'charmlibs.rollingops._rollingops_manager.RollingOpsManager._get_sync_lock_backend',
+            return_value=mock_backend,
+        ),
+    ):
+        with pytest.raises(UncaughtCharmError) as exc_info:
+            ctx.run(
+                ctx.on.action('failed-sync-restart'),
+                state_in,
+            )
+
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    mock_is_available.assert_called_once()
+    mock_etcd_acquire.assert_called_once()
+    mock_backend.acquire.assert_called_once_with(timeout=30)
+    mock_backend.release.assert_called_once()
+
+
+def test_sync_lock_request_timeout_raises(
+    ctx: Context[RollingOpsCharm],
+):
+    peer = PeerRelation(endpoint='restart')
+    etcd_relation = Relation(
+        endpoint='etcd',
+        interface='rollingops',
+    )
+    state_in = State(leader=False, relations={peer, etcd_relation})
+
+    with (
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.is_available',
+            return_value=True,
+        ) as mock_is_available,
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.acquire_sync_lock',
+            side_effect=TimeoutError,
+        ) as mock_acquire_sync_lock,
+        patch(
+            'charmlibs.rollingops._etcd._backend._EtcdRollingOpsBackend.release_sync_lock',
+        ) as mock_release_sync_lock,
+    ):
+        with pytest.raises(UncaughtCharmError) as exc_info:
+            ctx.run(
+                ctx.on.action('sync-restart', params={'timeout': 2}),
+                state_in,
+            )
+
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+    mock_is_available.assert_called_once()
+    mock_acquire_sync_lock.assert_called_once_with(2)
+    mock_release_sync_lock.assert_not_called()


### PR DESCRIPTION
## Description

This PR fixes a couple of issues found in the rollingops library: 

1. Dynamic cluster ID integration with etcd does not work well. 

Turns out that the certificates needed to connect to etcd were not created in case the cluster ID is not provided since deployment. Now they are created when the _EtcdRollingOpsBackend is instantiated.

Fix https://github.com/issues/assigned?issue=canonical%7Ccharmlibs%7C480

2. The sync lock had a weird behavior in case of exception raised during the execution of the critical path. Now:
 - we separate the exception handling  between lock acquisition and execution of critical path
 - the certificates  to communicate to etcd are not removed during relation broken with etcd, and we do not fall back to peer relation back end on relation broken. This allows the unit to still use etcd during the teardown phase. 
 
 If the relation was removed from the application and we are not in a scale down situation, the rollingops manager will automatically fallback to peer backend later because the relation would be missing