### PR TITLE
ci: use a more recent version of actions/upload-artifact

### DIFF
--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -247,7 +247,7 @@ jobs:
 
       - name: Upload Charmcraft logs
         if: ${{ !cancelled() && (steps.pack.conclusion != 'skipped' || steps.integration.conclusion != 'skipped') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ needs.init.outputs.package-name }}-charmcraft-logs-${{ matrix.substrate }}-${{ matrix.tag }}
           path: /home/runner/.local/state/charmcraft/log/charmcraft-*.log


### PR DESCRIPTION
In #456 I accidentally used an old version of `actions/upload-artifact`. This PR bumps it to a more recent version.