### PR TITLE
test(pathops): fix functional test breakage when running locally

### DIFF
--- a/pathops/tests/functional/conftest.py
+++ b/pathops/tests/functional/conftest.py
@@ -46,7 +46,7 @@ def pebble_resolves_groups(container: ops.Container, session_dir: pathlib.Path) 
 
     Pebble uses Go's os/user package which doesn't support NSS/SSSD, so group
     resolution fails when groups come from LDAP rather than /etc/group.
-    See: https://github.com/canonical/pebble/issues/XXX
+    See: https://github.com/canonical/pebble/issues/868
     """
     info = container.list_files(str(session_dir), itself=True)[0]
     return info.group != ''

--- a/pathops/tests/functional/conftest.py
+++ b/pathops/tests/functional/conftest.py
@@ -41,6 +41,18 @@ def container() -> ops.Container:
 
 
 @pytest.fixture(scope='session')
+def pebble_resolves_groups(container: ops.Container, session_dir: pathlib.Path) -> bool:
+    """Whether Pebble can resolve GIDs to group names on this system.
+
+    Pebble uses Go's os/user package which doesn't support NSS/SSSD, so group
+    resolution fails when groups come from LDAP rather than /etc/group.
+    See: https://github.com/canonical/pebble/issues/XXX
+    """
+    info = container.list_files(str(session_dir), itself=True)[0]
+    return info.group != ''
+
+
+@pytest.fixture(scope='session')
 def another_container() -> ops.Container:
     return _make_container('test2')
 

--- a/pathops/tests/functional/test_container_path.py
+++ b/pathops/tests/functional/test_container_path.py
@@ -262,8 +262,14 @@ class TestGlob:
 @pytest.mark.parametrize('filename', utils.FILENAMES_PLUS)
 @pytest.mark.parametrize('method', ['owner', 'group'])
 def test_owner_and_group(
-    container: ops.Container, session_dir: pathlib.Path, method: str, filename: str
+    container: ops.Container,
+    session_dir: pathlib.Path,
+    pebble_resolves_groups: bool,
+    method: str,
+    filename: str,
 ):
+    if method == 'group' and not pebble_resolves_groups:
+        pytest.xfail('Pebble cannot resolve LDAP/SSSD groups')
     path = session_dir / filename
     pathlib_method = getattr(path, method)
     container_path = ContainerPath(path, container=container)
@@ -493,8 +499,14 @@ class TestWrite:
         assert (path.owner(), path.group()) == (user, group)
 
     def test_user_and_group_ok(
-        self, container: ops.Container, tmp_path: pathlib.Path, method: Callable[..., None]
+        self,
+        container: ops.Container,
+        tmp_path: pathlib.Path,
+        pebble_resolves_groups: bool,
+        method: Callable[..., None],
     ):
+        if not pebble_resolves_groups:
+            pytest.xfail('Pebble cannot resolve LDAP/SSSD groups')
         user = getpass.getuser()
         group = grp.getgrgid(pwd.getpwnam(user).pw_gid).gr_name
         path = tmp_path / 'filename'

--- a/pathops/tests/functional/test_functions.py
+++ b/pathops/tests/functional/test_functions.py
@@ -83,8 +83,15 @@ def test_ensure_contents(
 @pytest.mark.parametrize('follow_symlinks', [True, False])
 @pytest.mark.parametrize('filename', utils.FILENAMES_PLUS)
 def test_get_fileinfo(
-    container: ops.Container, session_dir: pathlib.Path, filename: str, follow_symlinks: bool
+    container: ops.Container,
+    session_dir: pathlib.Path,
+    pebble_resolves_groups: bool,
+    filename: str,
+    follow_symlinks: bool,
 ):
+    exclude: list[str] = []
+    if not pebble_resolves_groups:
+        exclude.append('group')
     path = session_dir / filename
     try:
         pebble_result = _get_fileinfo(
@@ -95,4 +102,6 @@ def test_get_fileinfo(
             _get_fileinfo(path, follow_symlinks=follow_symlinks)
     else:
         synthetic_result = _get_fileinfo(path, follow_symlinks=follow_symlinks)
-        assert utils.info_to_dict(synthetic_result) == utils.info_to_dict(pebble_result)
+        synthetic_dict = utils.info_to_dict(synthetic_result, exclude=exclude)
+        pebble_dict = utils.info_to_dict(pebble_result, exclude=exclude)
+        assert synthetic_dict == pebble_dict

--- a/pathops/tests/functional/test_local_path.py
+++ b/pathops/tests/functional/test_local_path.py
@@ -142,6 +142,7 @@ class TestChown:
 def test_write_methods_chmod(
     container: ops.Container,
     tmp_path: pathlib.Path,
+    pebble_resolves_groups: bool,
     method: str,
     data: str | bytes,
     mode_str: str | None,
@@ -175,7 +176,9 @@ def test_write_methods_chmod(
     local_info = _get_fileinfo(local_path)
     # cleanup
     _unlink(path)
-    exclude = 'last_modified'
+    exclude = ['last_modified']
+    if not pebble_resolves_groups:
+        exclude.append('group')
     container_dict = utils.info_to_dict(container_info, exclude=exclude)
     local_dict = utils.info_to_dict(local_info, exclude=exclude)
     assert local_dict == container_dict
@@ -189,7 +192,13 @@ def test_write_methods_chmod(
 
 @pytest.mark.parametrize('mode_str', [*ALL_MODES, None])
 class TestMkdirChmod:
-    def test_ok(self, container: ops.Container, tmp_path: pathlib.Path, mode_str: str | None):
+    def test_ok(
+        self,
+        container: ops.Container,
+        tmp_path: pathlib.Path,
+        pebble_resolves_groups: bool,
+        mode_str: str | None,
+    ):
         mode = int(mode_str, base=8) if mode_str is not None else None
         path = tmp_path / 'directory'
         # container
@@ -217,13 +226,21 @@ class TestMkdirChmod:
         # cleanup -- pytest is bad at cleaning up when permissions are funky
         _rmdirs(path)
         # comparison
-        exclude = ('last_modified', 'permissions')
+        exclude = ['last_modified', 'permissions']
+        if not pebble_resolves_groups:
+            exclude.append('group')
         container_dict = utils.info_to_dict(container_info, exclude=exclude)
         local_dict = utils.info_to_dict(local_info, exclude=exclude)
         assert local_dict == container_dict
         assert _oct(local_info.permissions) == _oct(container_info.permissions)
 
-    def test_exists(self, container: ops.Container, tmp_path: pathlib.Path, mode_str: str | None):
+    def test_exists(
+        self,
+        container: ops.Container,
+        tmp_path: pathlib.Path,
+        pebble_resolves_groups: bool,
+        mode_str: str | None,
+    ):
         mode = int(mode_str, base=8) if mode_str is not None else None
         path = tmp_path / 'directory'
         path.mkdir()
@@ -244,7 +261,9 @@ class TestMkdirChmod:
         # cleanup -- pytest is bad at cleaning up when permissions are funky
         _rmdirs(path)
         # comparison
-        exclude = ('last_modified', 'permissions')
+        exclude = ['last_modified', 'permissions']
+        if not pebble_resolves_groups:
+            exclude.append('group')
         container_dict = utils.info_to_dict(container_info, exclude=exclude)
         local_dict = utils.info_to_dict(local_info, exclude=exclude)
         assert local_dict == container_dict
@@ -255,6 +274,7 @@ class TestMkdirChmod:
         self,
         container: ops.Container,
         tmp_path: pathlib.Path,
+        pebble_resolves_groups: bool,
         mode_str: str | None,
         subdir_path: str,
     ):
@@ -298,7 +318,9 @@ class TestMkdirChmod:
         # cleanup -- pytest is bad at cleaning up when permissions are funky
         _rmdirs(path, *parents)
         # comparison
-        exclude = ('last_modified', 'permissions')
+        exclude = ['last_modified', 'permissions']
+        if not pebble_resolves_groups:
+            exclude.append('group')
         container_dict = utils.info_to_dict(container_info, exclude=exclude)
         local_dict = utils.info_to_dict(local_info, exclude=exclude)
         assert local_dict == container_dict


### PR DESCRIPTION
The `charmlibs.pathops` functional tests are failing locally on my system due to users / groups being managed by NSS. This won't be an issue in production, as `pathops` is only used to access file info via Pebble for charms managing K8s workload containers (where Pebble runs as root rather than as an NSS-managed user), so this PR updates the tests to pass locally.

Resolves #487.