### PR TITLE
docs: expand README.md, revamp CONTRIBUTING.md, add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`charmlibs` is a monorepo of Python libraries for [Juju](https://documentation.ubuntu.com/juju/3.6/) charms.
+`charmlibs` is a monorepo of Python libraries for Juju charms.
 
 **Key concepts:**
 
@@ -18,7 +18,7 @@
 | General | `charmlibs` | `charmlibs-pathops` | `from charmlibs import pathops` |
 | Interface | `charmlibs.interfaces` | `charmlibs-interfaces-tls-certificates` | `from charmlibs.interfaces import tls_certificates` |
 
-General libraries live at the repo root (e.g. `pathops/`). Interface libraries live under `interfaces/` (e.g. `interfaces/tls-certificates/`).
+General libraries live at the repo root (e.g. `pathops/`). Interface libraries live under `interfaces/` (for example, `interfaces/tls-certificates/`).
 
 ## Repo structure
 
@@ -117,16 +117,12 @@ just add pathops 'pydantic>=2'
 just add interfaces/tls-certificates --requirements my-requirements.txt
 ```
 
-### IDE setup
-
-Point your IDE to `<package>/.venv` after running any `just` test command. The virtual environment is created there automatically.
-
 ## Test types
 
 | Type | Command | What it tests | External requirements |
 |------|---------|---------------|----------------------|
 | Unit | `just unit <package>` | Logic with mocked externals | None |
-| Functional | `just functional <package>` | Interaction with real external processes (not Juju) | Varies (e.g. pebble, sudo) |
+| Functional | `just functional <package>` | Interaction with real external processes (not Juju) | Varies (for example, pebble, sudo) |
 | Integration | `just integration-k8s/machine <package>` | Library in a real Juju deployment | charmcraft + Juju controller |
 
 A test type is only executed if the corresponding `tests/` subdirectory exists. Remove a directory to skip that test type entirely.
@@ -135,7 +131,7 @@ Read more: [types of tests in the charmlibs monorepo](https://documentation.ubun
 
 ## Commit and PR conventions
 
-**PRs are squash-merged.** The PR title becomes the single commit message on `main`. Branch commit messages don't need to follow any format.
+**PRs are squash-merged.** The PR title becomes the single commit message on `main`. Branch commit messages are for local reference, and should follow conventional commits for clarity.
 
 PR titles must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). When a PR affects a single library, use the distribution package name without the leading `charmlibs-` as the scope:
 
@@ -170,8 +166,8 @@ pathops/
 │   │   ├── conftest.py
 │   │   └── test_*.py
 │   ├── functional/
-│   │   ├── setup.sh        # Sourced before tests (e.g. start pebble)
-│   │   ├── teardown.sh     # Sourced after tests (e.g. kill pebble)
+│   │   ├── setup.sh        # Sourced before tests (for example, start pebble)
+│   │   ├── teardown.sh     # Sourced after tests (for example, kill pebble)
 │   │   └── test_*.py
 │   └── integration/
 │       ├── pack.sh         # Script to pack test charms
@@ -221,7 +217,7 @@ When writing or editing docstrings in `__init__.py` or other public modules, rem
 
 | Resource | URL |
 |----------|-----|
-| charmlibs docs | https://documentation.ubuntu.com/charmlibs |
+| charmlibs docs | .docs/index.md |
 | ops (charm framework) | https://documentation.ubuntu.com/ops/ |
 | ops.testing reference | https://documentation.ubuntu.com/ops/latest/reference/ops-testing/ |
 | Juju docs | https://documentation.ubuntu.com/juju/3.6/ |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,231 @@
+# Agent instructions for charmlibs
+
+## Overview
+
+`charmlibs` is a monorepo of Python libraries for [Juju](https://documentation.ubuntu.com/juju/3.6/) charms.
+
+**Key concepts:**
+
+- **Juju** — Canonical's open-source orchestration engine. Deploys and manages applications on Kubernetes and bare-metal/VM clouds.
+- **Charm** — a Python program that uses the [ops](https://documentation.ubuntu.com/ops/) framework to respond to Juju lifecycle events and manage a workload. Charms can be Kubernetes-based (using [Pebble](https://documentation.ubuntu.com/pebble/) to manage container processes) or machine-based.
+- **Juju relation** — a named connection between two charms, backed by shared key-value stores called *databags*. Relations are how charms communicate and exchange structured configuration.
+- **Charm library** — a reusable Python package that charm authors import. All libraries in this repo are distributed as Python packages on PyPI (not Charmhub-hosted single-file modules, which are a legacy distribution method).
+
+**Two library categories:**
+
+| Category | Namespace | Example package | Import |
+|----------|-----------|-----------------|--------|
+| General | `charmlibs` | `charmlibs-pathops` | `from charmlibs import pathops` |
+| Interface | `charmlibs.interfaces` | `charmlibs-interfaces-tls-certificates` | `from charmlibs.interfaces import tls_certificates` |
+
+General libraries live at the repo root (e.g. `pathops/`). Interface libraries live under `interfaces/` (e.g. `interfaces/tls-certificates/`).
+
+## Repo structure
+
+```
+charmlibs/
+├── <library>/              # One directory per general library (e.g. pathops/, apt/, snap/)
+│   ├── src/charmlibs/<library>/   # Source (namespace package)
+│   ├── tests/
+│   │   ├── unit/
+│   │   ├── functional/     # Optional; omit directory to skip
+│   │   └── integration/    # Optional; Juju-based tests
+│   ├── pyproject.toml
+│   ├── uv.lock             # Commit this
+│   ├── README.md
+│   └── CHANGELOG.md
+├── interfaces/             # Interface libraries
+│   └── <interface>/        # Named exactly as in charmcraft.yaml (e.g. tls-certificates)
+│       ├── src/charmlibs/interfaces/<interface>/
+│       ├── testing/        # Optional testing subpackage for charm unit tests
+│       ├── pyproject.toml
+│       └── ...
+├── .docs/                  # Sphinx source for documentation.ubuntu.com/charmlibs
+├── .template/              # Cookiecutter template used by `just init`
+├── .github/workflows/      # CI: ci.yaml, test-package.yaml, test-interface.yaml, publish.yaml
+├── justfile                # Task runner recipes
+├── docs.just               # Docs-specific recipes
+├── interface.just          # Interface-specific recipes
+├── pyproject.toml          # Repo-level config: ruff, coverage, shared linting settings
+└── test-requirements.txt   # Pinned versions of pytest, coverage, and other test tools
+```
+
+## Development workflow
+
+### Prerequisites
+
+`uv` and `just` are required. Verify they're available before proceeding:
+
+```bash
+uv --version && just --version
+```
+
+If either is missing, they can be installed like this:
+
+```bash
+sudo snap install --classic astral-uv   # installs uv
+uv tool install rust-just               # installs just (once uv is available)
+```
+
+Run `just` or `just help` from anywhere in the repo to see all available commands. All `just` commands execute from the repo root regardless of where they're invoked.
+
+### Inner loop
+
+The command you'll run most often is:
+
+```bash
+just check <package>
+```
+
+This runs `just lint <package>`, `just unit <package>`, and `just docs html <package>`. **Run this before every commit on the affected package.**
+
+The `<package>` argument is the path from the repo root, e.g. `pathops` or `interfaces/tls-certificates`.
+
+### Command reference
+
+| Command | Description |
+|---------|-------------|
+| `just check <package>` | Lint + unit tests + docs (the standard pre-commit check) |
+| `just lint <package>` | ruff + codespell + pyright |
+| `just fast-lint [path]` | ruff only, across the whole repo or a specific path |
+| `just format [package]` | Auto-fix ruff and formatting errors |
+| `just static <package>` | pyright only |
+| `just unit <package>` | Run unit tests |
+| `just functional <package>` | Run functional tests (may need external software available, or to be run with sudo -- and note that this probably indicates a test that's destructive to the local environment (e.g. adding or removing packages)) |
+| `just pack-k8s <package>` | Pack K8s test charm(s) for integration tests, running the libraries `tests/integration/pack.sh` script with environment variables set |
+| `just pack-machine <package>` | Pack machine test charm(s) for integration tests, as above |
+| `just integration-k8s <package>` | Run Juju integration tests, excluding `pytest.mark.machine_only` tests |
+| `just integration-machine <package>` | Run Juju integration tests against machine, excluding `pytest.mark.k8s_only` tests |
+| `just docs html [packages]` | Build docs (including reference docs for all packages by default, or named ones -- run `just docs html -` to exclude all package reference docs (faster when working on docs only) |
+| `just docs` | Alias for `just docs html` |
+| `just add <package> <dep>` | Add a dependency to a library |
+| `just init` | Scaffold a new general library |
+| `just interface init` | Scaffold a new interface library |
+
+Extra arguments to `just unit`, `just functional`, and `just integration-*` are passed through to pytest:
+
+```bash
+just unit pathops -x -k test_copy   # stop on first failure, filter by name
+```
+
+### Adding dependencies
+
+**Always use `just add <package> <dep>` instead of calling `uv add` directly.** This applies repo-level version constraints from `test-requirements.txt`, which is necessary to keep the lockfile consistent:
+
+```bash
+just add pathops 'pydantic>=2'
+just add interfaces/tls-certificates --requirements my-requirements.txt
+```
+
+### IDE setup
+
+Point your IDE to `<package>/.venv` after running any `just` test command. The virtual environment is created there automatically.
+
+## Test types
+
+| Type | Command | What it tests | External requirements |
+|------|---------|---------------|----------------------|
+| Unit | `just unit <package>` | Logic with mocked externals | None |
+| Functional | `just functional <package>` | Interaction with real external processes (not Juju) | Varies (e.g. pebble, sudo) |
+| Integration | `just integration-k8s/machine <package>` | Library in a real Juju deployment | charmcraft + Juju controller |
+
+A test type is only executed if the corresponding `tests/` subdirectory exists. Remove a directory to skip that test type entirely.
+
+Read more: [types of tests in the charmlibs monorepo](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-tests/).
+
+## Commit and PR conventions
+
+**PRs are squash-merged.** The PR title becomes the single commit message on `main`. Branch commit messages don't need to follow any format.
+
+PR titles must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). When a PR affects a single library, use the distribution package name without the leading `charmlibs-` as the scope:
+
+```
+feat(pathops): add copytree and rmtree
+fix(apt): handle multiarch package names correctly
+chore(interfaces-tls-certificates): update to Pydantic v2
+docs: improve tutorial for adding integration tests
+```
+
+**One PR should normally touch only one library.** The CI uses changed files to determine which packages to test and, on merge, which packages to publish.
+
+### Versioning
+
+- Libraries use semantic versioning (`MAJOR.MINOR.PATCH`).
+- Dev versions (`X.Y.Z.devN`) are excluded from release CI — safe for in-progress work.
+- When bumping to a non-dev version, you **must** also update `CHANGELOG.md`. CI will block the merge otherwise.
+- The CI automatically publishes to PyPI on merge when a non-dev version bump is detected.
+
+## Package anatomy
+
+A typical general library looks like this:
+
+```
+pathops/
+├── src/charmlibs/pathops/
+│   ├── __init__.py         # Exports public API; module docstring appears in reference docs
+│   ├── _pathops.py         # Private implementation module(s)
+│   └── _version.py         # __version__ string (auto-generated)
+├── tests/
+│   ├── unit/
+│   │   ├── conftest.py
+│   │   └── test_*.py
+│   ├── functional/
+│   │   ├── setup.sh        # Sourced before tests (e.g. start pebble)
+│   │   ├── teardown.sh     # Sourced after tests (e.g. kill pebble)
+│   │   └── test_*.py
+│   └── integration/
+│       ├── pack.sh         # Script to pack test charms
+│       ├── conftest.py     # Juju fixtures (jubilant)
+│       ├── test_*.py
+│       └── charms/         # Test charm source
+├── pyproject.toml          # Package metadata, dependencies, tool config
+├── uv.lock                 # Locked dependencies — commit this
+├── README.md
+└── CHANGELOG.md            # Must be updated before each release
+```
+
+The source uses a namespace package structure: `src/charmlibs/<name>/`. Public API is exported from `__init__.py` via `__all__`. Implementation lives in private submodules (prefixed with `_`). The module docstring in `__init__.py` appears as the top-level description in the generated reference docs.
+
+## Interface libraries
+
+Interface libraries manage the structured data that charms exchange over a Juju relation databag. Key differences from general libraries:
+
+- Live under `interfaces/<interface-name>/`, named exactly as the interface name appears in `charmcraft.yaml`.
+- Source under `src/charmlibs/interfaces/<interface_name>/`.
+- Usually include a `testing/` subdirectory with a separate `charmlibs-interfaces-<name>-testing` package. This provides `relation_for_provider()` and `relation_for_requirer()` helpers for charm unit tests.
+- Typically have unit and integration tests but no functional tests (all meaningful interaction is through Juju).
+- Use `just interface init` to scaffold.
+
+Read more: [how to design relation interfaces](https://documentation.ubuntu.com/charmlibs/how-to/design-relation-interfaces/), [how to provide relation data for charm tests](https://documentation.ubuntu.com/charmlibs/how-to/provide-relation-data-for-charm-tests/).
+
+## Documentation
+
+Reference docs are auto-generated from Python docstrings via Sphinx autodoc. The docs source lives in `.docs/`. Build reference docs for a specific package with:
+
+```bash
+just docs html pathops
+```
+
+This is also run as part of `just check`. The full docs site (all packages) is built with `just docs`.
+
+When writing or editing docstrings in `__init__.py` or other public modules, remember they appear verbatim in the published reference at [documentation.ubuntu.com/charmlibs](https://documentation.ubuntu.com/charmlibs). Keep them informative for library users, not implementation notes.
+
+## Common pitfalls
+
+- **Don't call `uv add` directly** — use `just add <package> <dep>` to respect repo-level constraints.
+- **Don't bump the package you're working on to a non-dev version without updating `CHANGELOG.md`** — CI will block the merge.
+- **Making changes to multiple libraries in the same PR** — the CI matrix runs per changed package, and review requirements are determined by `CODEOWNERS`.
+- **Don't add unnecessary features or refactor code beyond what's asked** — this is a multi-team monorepo with careful versioning; unintended public API changes require major version bumps.
+
+## External resources
+
+| Resource | URL |
+|----------|-----|
+| charmlibs docs | https://documentation.ubuntu.com/charmlibs |
+| ops (charm framework) | https://documentation.ubuntu.com/ops/ |
+| ops.testing reference | https://documentation.ubuntu.com/ops/latest/reference/ops-testing/ |
+| Juju docs | https://documentation.ubuntu.com/juju/3.6/ |
+| Charmcraft docs | https://documentation.ubuntu.com/charmcraft/stable/ |
+| Jubilant (integration test client) | https://documentation.ubuntu.com/jubilant/ |
+| Pebble | https://documentation.ubuntu.com/pebble/ |
+| Concierge (CI Juju setup) | https://github.com/canonical/concierge |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,8 +220,8 @@ When writing or editing docstrings in `__init__.py` or other public modules, rem
 | charmlibs docs | .docs/index.md |
 | ops (charm framework) | https://documentation.ubuntu.com/ops/ |
 | ops.testing reference | https://documentation.ubuntu.com/ops/latest/reference/ops-testing/ |
-| Juju docs | https://documentation.ubuntu.com/juju/3.6/ |
+| Juju docs | https://documentation.ubuntu.com/juju/latest/llms.txt |
 | Charmcraft docs | https://documentation.ubuntu.com/charmcraft/stable/ |
 | Jubilant (integration test client) | https://documentation.ubuntu.com/jubilant/ |
 | Pebble | https://documentation.ubuntu.com/pebble/ |
-| Concierge (CI Juju setup) | https://github.com/canonical/concierge |
+| Concierge (CI Juju setup) | https://raw.githubusercontent.com/canonical/concierge/refs/heads/main/README.md |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+# Contributing to charmlibs
+
+This monorepo contains Python libraries for [Juju](https://documentation.ubuntu.com/juju/3.6/) charms. General libraries are defined in top-level subdirectories, and interface libraries and/or metadata are defined under the interfaces directory.
+
 # Quick start
 
 This project uses [just](https://github.com/casey/just) as a task runner, backed by [uv](https://github.com/astral-sh/uv).
@@ -9,7 +13,7 @@ sudo snap install --classic astral-uv
 uv tool install rust-just
 ```
 
-Then run `just` from anywhere in the repository for usage.
+Then run `just` or `just help` from anywhere in the repository for usage.
 
 # Adding a new library
 
@@ -19,27 +23,48 @@ If you're migrating a library that was published elsewhere, read the [how-to gui
 
 # Working on an existing library
 
-Run `just check <my package>` to run the following tests for your package:
+Run `just check <my package>` to run the primary checks for your package. This runs linting, unit tests, and builds the reference docs:
 
-- `just lint <my package>` runs linters and static type checkers.
-    - `just fast-lint` will run fast linters for all packages.
-    - `just format <my package>` or `just format` will try to automatically fix errors.
-- `just docs html <my package>` builds the docs, only including reference docs for `<my package>` (for speed).
-    - `just docs html` or `just docs` will build docs for all packages.
+- `just lint <my package>` runs `ruff`, `codespell`, and `pyright` on your package.
+    - `just fast-lint` runs ruff across the whole repository.
+    - `just format [package]` will try to automatically fix formatting errors.
+    - `just static <package>` runs pyright only.
 - `just unit <my package>` runs unit tests.
+- `just docs html <my package>` builds the reference docs for `<my package>` only (for speed).
+    - `just docs html` or `just docs` will build docs for all packages.
 
-`functional` and `integration` tests are also executed in CI, and can be executed locally too.
+## Adding dependencies
 
-Read more:
+Use `just add <package> <dep>` to add a dependency to a library, rather than calling `uv add` directly. This applies repo-level version constraints from `test-requirements.txt`, keeping the lockfile consistent.
 
-- [The different types of tests](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-tests/).
-- [Publishing packages](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-publishing/).
+```bash
+just add pathops 'pydantic>=2'
+```
+
+## Functional and integration tests
+
+`functional` and `integration` tests are also executed in CI, and can be run locally too. They're excluded from `just check` as they may require additional setup:
+
+- `just functional <package>` runs functional tests, which interact with real external processes (but not Juju itself). Some functional test suites may require additional software installed locally, like `pebble` or `sudo` access.
+- Integration tests involve packing real test charms and deploying them on a Juju cloud. Pack first with `just pack-k8s <package>` or `just pack-machine <package>`, then run `just integration-k8s <package>` or `just integration-machine <package>`.
+
+Read more: [the different types of tests](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-tests/).
 
 # Pull requests
 
-Pull request titles must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
+PRs are squash-merged, so your PR title becomes the single commit message that lands on `main`. Commit messages on your branch don't need to follow any particular format.
 
-When a PR affects a single library, use the distribution package name without the leading `charmlibs-` as the conventional commit scope.
+PR titles must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). When a PR affects a single library, use the distribution package name without the leading `charmlibs-` or `charmlibs-interfaces` as the scope:
 
-For example:
-`feat(pathops): ...` or `chore(interfaces-tls-certificates): ...`.
+```
+feat(pathops): add copytree and rmtree
+chore(tls-certificates): update to Pydantic v2
+```
+
+## Versioning and releases
+
+Libraries are automatically published to PyPI when a merged PR bumps the version to a non-dev version. Dev versions (like `1.0.0.dev0`) are excluded from the release CI, so you can safely merge in-progress work with a dev version.
+
+Any PR that would trigger a release must also update the library's `CHANGELOG.md` — CI will block the merge otherwise.
+
+Read more: [publishing packages from the monorepo](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-publishing/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to charmlibs
 
-This monorepo contains Python libraries for [Juju](https://documentation.ubuntu.com/juju/3.6/) charms. General libraries are defined in top-level subdirectories, and interface libraries and/or metadata are defined under the interfaces directory.
+This monorepo contains Python libraries for [Juju](https://canonical.com/juju) charms. General libraries are defined in top-level subdirectories, and interface libraries and/or metadata are defined under the interfaces directory.
 
 # Quick start
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,61 @@
 # charmlibs
 
-This monorepo hosts the source code for Canonical's charm libraries. Read the [docs](https://documentation.ubuntu.com/charmlibs) for more.
+`charmlibs` is the home of Canonical's charm libraries -- Python packages used by [Juju](https://canonical.com/juju) charms.
 
-To get started with contributing, read [CONTRIBUTING.md](./CONTRIBUTING.md).
+Charms are Python programs that use the [Ops](https://documentation.ubuntu.com/ops/) framework to manage workloads on Kubernetes or bare-metal clouds. Charm libraries package up common functionality so that teams don't have to reinvent the wheel. Each library in this monorepo is distributed as a separate Python package on PyPI.
+
+There are two kinds of charm libraries:
+
+- **General libraries** (e.g. [`charmlibs-apt`](apt/), [`charmlibs-pathops`](pathops/)) provide utility APIs for charms. Imported as `from charmlibs import apt`.
+- **Interface libraries** (e.g. [`charmlibs-interfaces-tls-certificates`](interfaces/tls-certificates/)) manage the structured data that charms exchange over a Juju relation. Imported as `from charmlibs.interfaces import tls_certificates`.
+
+## Contributing to this monorepo
+
+`charmlibs` is for libraries that are broadly useful across different charms and teams. A library is a good fit if it:
+
+- **Solves a common problem**, and is useful to charms across multiple products or teams, not just your own.
+- **Has a design or a proven track record** — either a specification with cross-team buy-in, or a pattern already tested in production. (Migrating an existing, widely-used Charmhub-hosted library doesn't need a separate specification.)
+
+All public interfaces intended for use by other charms should have a corresponding `charmlibs.interfaces` library.
+
+If your library is more of a team-internal utility, [Distribute charm libraries](https://documentation.ubuntu.com/charmlibs/how-to/python-package/) covers the alternatives.
+
+Got something in mind? You can talk to us on [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com) before opening a PR — we'd love to hear about it.
+
+**Ready to dive in?** Follow the **[tutorial](https://documentation.ubuntu.com/charmlibs/tutorial)** to add a new library, or the **[migration guide](https://documentation.ubuntu.com/charmlibs/how-to/migrate/)** to port a Charmhub-hosted library. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the developer quick-reference.
+
+For the details of how the monorepo works:
+
+- [Types of tests](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-tests/): unit, functional, and Juju integration tests
+- [Publishing from the monorepo](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-publishing/): semantic versioning, dev versions, trusted publishing
+- Customizing your [functional](https://documentation.ubuntu.com/charmlibs/how-to/customize-functional-tests/) and [integration](https://documentation.ubuntu.com/charmlibs/how-to/customize-integration-tests/) tests.
+
+## Writing charm libraries
+
+[Distribute charm libraries](https://documentation.ubuntu.com/charmlibs/how-to/python-package/) walks through the distribution options for a new library — git dependencies, PyPI, and this monorepo — and how to choose between them.
+
+For interface libraries specifically:
+
+- [Design relation interfaces](https://documentation.ubuntu.com/charmlibs/how-to/design-relation-interfaces/) — rules and patterns for backwards-compatible relation data formats
+- [Provide relation data for charm tests](https://documentation.ubuntu.com/charmlibs/how-to/provide-relation-data-for-charm-tests/) — how to write the testing subpackage for your interface library
+
+## Using libraries in a charm
+
+Browse the library listings to find what you need:
+
+- [General library listing](https://documentation.ubuntu.com/charmlibs/reference/general-libs/)
+- [Interface library listing](https://documentation.ubuntu.com/charmlibs/reference/interface-libs/)
+
+The [Manage charm libraries](https://documentation.ubuntu.com/charmlibs/how-to/manage-libraries/) guide covers adding a library to your charm, version constraints, git dependencies, and using legacy Charmhub-hosted libraries.
+
+We also host the library reference docs:
+
+- [charmlibs package reference](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/) — `apt`, `pathops`, `snap`, and more
+- [charmlibs.interfaces package reference](https://documentation.ubuntu.com/charmlibs/reference/charmlibs-interfaces/) — `tls_certificates`, `tracing`, and more
+- [Interface specifications](https://documentation.ubuntu.com/charmlibs/reference/interfaces/) — relation data schemas and docs for each interface
+
+Read more in the docs: [Charm libraries explained](https://documentation.ubuntu.com/charmlibs/explanation/charm-libs/)
+
+---
+
+New to charming? The [ops documentation](https://documentation.ubuntu.com/ops/) is the best place to start.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,22 @@
 
 `charmlibs` is the home of Canonical's charm libraries -- Python packages used by [Juju](https://canonical.com/juju) charms.
 
-Charms are Python programs that use the [Ops](https://documentation.ubuntu.com/ops/) framework to manage workloads on Kubernetes or bare-metal clouds. Charm libraries package up common functionality so that teams don't have to reinvent the wheel. Each library in this monorepo is distributed as a separate Python package on PyPI.
+Charms are Python programs that use the [Ops](https://documentation.ubuntu.com/ops/) framework to manage workloads on Kubernetes or machine clouds. Charm libraries package up common functionality so that teams don't have to reinvent the wheel.
+
+> [!IMPORTANT]
+> Each library in this monorepo is distributed as a separate Python package on PyPI, so you charms only include what they actually need.
 
 There are two kinds of charm libraries:
 
-- **General libraries** (e.g. [`charmlibs-apt`](apt/), [`charmlibs-pathops`](pathops/)) provide utility APIs for charms. Imported as `from charmlibs import apt`.
-- **Interface libraries** (e.g. [`charmlibs-interfaces-tls-certificates`](interfaces/tls-certificates/)) manage the structured data that charms exchange over a Juju relation. Imported as `from charmlibs.interfaces import tls_certificates`.
+- **General libraries** (such as [`charmlibs-apt`](apt/), [`charmlibs-pathops`](pathops/)) provide utility APIs for charms. Imported as `from charmlibs import apt`.
+- **Interface libraries** (such as [`charmlibs-interfaces-tls-certificates`](interfaces/tls-certificates/)) manage the structured data that charms exchange over a Juju relation. Imported as `from charmlibs.interfaces import tls_certificates`.
 
 ## Contributing to this monorepo
 
-`charmlibs` is for libraries that are broadly useful across different charms and teams. A library is a good fit if it:
+`charmlibs` is for libraries that are broadly useful across different charms and teams. A library is a good fit if it both:
 
-- **Solves a common problem**, and is useful to charms across multiple products or teams, not just your own.
-- **Has a design or a proven track record** — either a specification with cross-team buy-in, or a pattern already tested in production. (Migrating an existing, widely-used Charmhub-hosted library doesn't need a separate specification.)
+- **Solves a common problem**: It is useful to charms across multiple products or teams, not just your own.
+- **Has a design or a proven track record**: Either a specification with cross-team buy-in, or a pattern already tested in production. (Migrating an existing, widely-used Charmhub-hosted library doesn't need a separate specification.)
 
 All public interfaces intended for use by other charms should have a corresponding `charmlibs.interfaces` library.
 


### PR DESCRIPTION
This PR improves the experience for new users of the repository by updating the top-level developer-facing documentation.

The repository level `README.md` has been expanded to clearly introduce the repository concepts (Juju, charms, charm libraries), and provide entrypoints for contributing to the monorepo, writing libraries more generally, and for using libraries in charms.

The `CONTRIBUTING.md` includes a clearer introduction and documents missing parts of the contribution workflow.

Additionally, an `AGENTS.md` file is added to explain the key concepts, monorepo organisation, developer tooling, commands to run whenever making changes, and so on.

Resolves #486.