### PR TITLE
docs: charmcraft fetch-libs deprecation

### DIFF
--- a/.docs/explanation/charmhub-libraries-deprecation.md
+++ b/.docs/explanation/charmhub-libraries-deprecation.md
@@ -16,14 +16,14 @@ Charms originally shared code by distributing single-file Python modules on Char
 ## Timeline
 
 - `charmcraft` emits a deprecation warning on library operations (we are here).
-- Charmhub disables uploading *new* libraries (26.04 cycle).
+- Charmhub disables uploading *new* libraries (26.10 cycle).
 - Charmhub disables updates to existing libraries.
 
 ## Why the change?
 
 ### No dependency resolution
 
-Charmhub-hosted libraries have no mechanism for declaring or resolving dependencies on other Python packages. If a library needs a dependency, it lists the package name in a `PYDEPS` variable, and the charm author must manually add each dependency to their charm's own requirements. That is, transitive dependencies of Charmhub-hosted libraries are tracked manually, and the charm author is also responsible for resolving a compatible version for the different libraries that might require that dependency.
+Charmhub-hosted libraries have no mechanism for resolving dependencies on other Python packages. If a library needs a dependency, it lists the package name in a `PYDEPS` variable, and the charm author must manually add each dependency to their charm's own requirements. That is, transitive dependencies of Charmhub-hosted libraries are tracked manually, and the charm author is also responsible for resolving a compatible version for the different libraries that might require that dependency.
 
 Standard Python packages, by contrast, declare their dependencies in metadata that tools like `pip` and `uv` resolve automatically.
 
@@ -44,24 +44,24 @@ Libraries of broad interest are published under the `charmlibs` namespace from t
 
 ## What should I do?
 
-**If you maintain a Charmhub-hosted library:**
+### If you maintain a Charmhub-hosted library
 
-Consider migrating it to a Python package. If it implements a widely-used interface or provides broadly useful functionality, it belongs in the `charmlibs` monorepo.
+Migrate it to a Python package. If it implements a widely-used interface or provides broadly useful functionality, it belongs in the `charmlibs` monorepo.
 
 > See {ref}`how-to-migrate` for a step-by-step guide.
 
-**If you use Charmhub-hosted libraries in your charm:**
+### If you use Charmhub-hosted libraries in your charm
 
 When a Python package replacement is available, switch to it:
 
-1. Remove the library from the `charm-libs` section of your `charmcraft.yaml` and delete the vendored file from `lib/`.
+1. Remove the library from the `charm-libs` section of your `charmcraft.yaml` and delete the vendored directory from `lib/`.
 2. Remove any manually added transitive dependencies that are no longer needed.
-3. Add the replacement package to your charm's dependencies (e.g. in `pyproject.toml`).
+3. Add the replacement package to your charm's dependencies.
 4. Update your imports to use the new package's import path.
 
 > See {ref}`how-to-manage-charm-libraries` for guidance on managing Python package dependencies in your charm.
 
-**If you are writing a new library:**
+### If you are writing a new library
 
 Create it as a Python package from the start. Do not publish new libraries on Charmhub.
 

--- a/.docs/explanation/charmhub-libraries-deprecation.md
+++ b/.docs/explanation/charmhub-libraries-deprecation.md
@@ -40,7 +40,7 @@ Charmhub libraries do not participate in standard Python tooling. This makes it 
 Charm libraries should be distributed as regular Python packages, typically on PyPI.
 Libraries of broad interest are published under the `charmlibs` namespace from the [`charmlibs` monorepo](https://github.com/canonical/charmlibs). Team-specific libraries can be distributed on PyPI under their own namespace, as Git dependencies, or as local packages in a charm monorepo.
 
-> See {ref}`how-to-python-package` for full details on distribution options.
+Read more: {ref}`how-to-python-package`
 
 ## What should I do?
 
@@ -48,7 +48,7 @@ Libraries of broad interest are published under the `charmlibs` namespace from t
 
 Migrate it to a Python package. If it implements a widely-used interface or provides broadly useful functionality, it belongs in the `charmlibs` monorepo.
 
-> See {ref}`how-to-migrate` for a step-by-step guide.
+Read more: {ref}`how-to-migrate`
 
 ### If you use Charmhub-hosted libraries in your charm
 
@@ -59,10 +59,10 @@ When a Python package replacement is available, switch to it:
 3. Add the replacement package to your charm's dependencies.
 4. Update your imports to use the new package's import path.
 
-> See {ref}`how-to-manage-charm-libraries` for guidance on managing Python package dependencies in your charm.
+Read more: {ref}`how-to-manage-charm-libraries`
 
 ### If you are writing a new library
 
 Create it as a Python package from the start. Do not publish new libraries on Charmhub.
 
-> See {ref}`how-to-python-package` for advice on where and how to publish.
+Read more: {ref}`how-to-python-package`

--- a/.docs/explanation/charmhub-libraries-deprecation.md
+++ b/.docs/explanation/charmhub-libraries-deprecation.md
@@ -7,6 +7,12 @@ Charmhub-hosted charm libraries -- single-file Python modules fetched with `char
 
 Charms originally shared code by distributing single-file Python modules on Charmhub. Each module was associated with a specific charm. Charms fetched libraries using the `charmcraft fetch-lib` and `charmcraft fetch-libs` commands, and typically checked them into their version control. These libraries were stored under `lib/`, which was added to `PYTHONPATH` at runtime, allowing the module to be imported by charm name and API version. For example `from operator_libs_linux.v2 import snap`.
 
+## Timeline
+
+- `charmcraft` emits a deprecation warning on library operations (we are here).
+- Charmhub disables uploading *new* libraries (26.04 cycle).
+- Charmhub disables updates to existing libraries.
+
 ## Why the change?
 
 ### No dependency resolution

--- a/.docs/explanation/charmhub-libraries-deprecation.md
+++ b/.docs/explanation/charmhub-libraries-deprecation.md
@@ -1,0 +1,56 @@
+(charmhub-libraries-deprecation)=
+# Charmhub-hosted libraries are being phased out
+
+Charmhub-hosted charm libraries -- single-file Python modules fetched with `charmcraft fetch-libs` -- are being phased out in favour of standard Python packages distributed on PyPI.
+
+## Background
+
+Charms originally shared code by distributing single-file Python modules on Charmhub. Each module was associated with a specific charm. Charms fetched libraries using the `charmcraft fetch-lib` and `charmcraft fetch-libs` commands, and typically checked them into their version control. These libraries were stored under `lib/`, which was added to `PYTHONPATH` at runtime, allowing the module to be imported by charm name and API version. For example `from operator_libs_linux.v2 import snap`.
+
+## Why the change?
+
+### No dependency resolution
+
+Charmhub-hosted libraries have no mechanism for declaring or resolving dependencies on other Python packages. If a library needs a dependency, it lists the package name in a `PYDEPS` variable, and the charm author must manually add each dependency to their charm's own requirements. That is, transitive dependencies of Charmhub-hosted libraries are tracked manually, and the charm author is also responsible for resolving a compatible version for the different libraries that might require that dependency.
+
+Standard Python packages, by contrast, declare their dependencies in metadata that tools like `pip` and `uv` resolve automatically.
+
+### Vendored code is hard to maintain
+
+Because Charmhub libraries are committed into each charm's repository, updating a library means re-running `charmcraft fetch-libs` and committing the result. Across many charms, this creates a maintenance burden and increases the risk of running outdated code.
+
+### Limited tooling integration
+
+Charmhub libraries do not participate in standard Python tooling. This makes it trickier to ensure their visibility for dependency scanners and vulnerability checkers, leads to the library itself not being visible in the charm's lock file, and requires extra work to make the library visible in IDEs.
+
+## What replaces it?
+
+Charm libraries should be distributed as regular Python packages, typically on PyPI.
+Libraries of broad interest are published under the `charmlibs` namespace from the [`charmlibs` monorepo](https://github.com/canonical/charmlibs). Team-specific libraries can be distributed on PyPI under their own namespace, as Git dependencies, or as local packages in a charm monorepo.
+
+> See {ref}`how-to-python-package` for full details on distribution options.
+
+## What should I do?
+
+**If you maintain a Charmhub-hosted library:**
+
+Consider migrating it to a Python package. If it implements a widely-used interface or provides broadly useful functionality, it belongs in the `charmlibs` monorepo.
+
+> See {ref}`how-to-migrate` for a step-by-step guide.
+
+**If you use Charmhub-hosted libraries in your charm:**
+
+When a Python package replacement is available, switch to it:
+
+1. Remove the library from the `charm-libs` section of your `charmcraft.yaml` and delete the vendored file from `lib/`.
+2. Remove any manually added transitive dependencies that are no longer needed.
+3. Add the replacement package to your charm's dependencies (e.g. in `pyproject.toml`).
+4. Update your imports to use the new package's import path.
+
+> See {ref}`how-to-manage-charm-libraries` for guidance on managing Python package dependencies in your charm.
+
+**If you are writing a new library:**
+
+Create it as a Python package from the start. Do not publish new libraries on Charmhub.
+
+> See {ref}`how-to-python-package` for advice on where and how to publish.

--- a/.docs/explanation/charmhub-libraries-deprecation.md
+++ b/.docs/explanation/charmhub-libraries-deprecation.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Charmhub-hosted charm libraries fetched with charmcraft fetch-libs are being phased out in favour of standard Python packages.
+---
+
 (charmhub-libraries-deprecation)=
 # Charmhub-hosted libraries are being phased out
 

--- a/.docs/explanation/index.md
+++ b/.docs/explanation/index.md
@@ -4,6 +4,7 @@
 :maxdepth: 1
 
 charm-libs
+charmhub-libraries-deprecation
 charmlibs: Types of tests<charmlibs-tests>
 charmlibs: Publishing packages<charmlibs-publishing>
 ```


### PR DESCRIPTION
This PR adds a docs page about the upcoming deprecation of the Charmhub-hosted library machinery. This page will be pointed to from all `charmcraft` library operations in an upcoming Charmcraft release (https://github.com/canonical/charmcraft/pull/2691).

Due to the upcoming docs migration, I suggest we stick with the `ubu.link` approach suggested by Alex. So Charmcraft will show `https://ubu.link/charmhub-libraries-deprecation`, linking to `https://documentation.ubuntu.com/charmlibs/explanation/charmhub-libraries-deprecation/`. When we migrate the docs, we can delete the `ubu.link` and recreate it pointing to the new location.