### PR TITLE
docs: drop block quotes for links

### DIFF
--- a/.docs/explanation/charm-libs.md
+++ b/.docs/explanation/charm-libs.md
@@ -39,9 +39,7 @@ The `lib/` directory is added to the [PYTHONPATH](https://docs.python.org/3/usin
 
 Charmhub-hosted libraries are typically committed to your charm's version control.
 
-> Read more:
-> - {ref}`manage-charmhub-libraries`
-> - {ref}`Charmcraft | Manage libraries <charmcraft:manage-libraries>`
+Read more: {ref}`manage-charmhub-libraries`, {ref}`Charmcraft | Manage libraries <charmcraft:manage-libraries>`
 
 (charm-libs-purpose)=
 ## Library purpose

--- a/.docs/explanation/charmlibs-tests.md
+++ b/.docs/explanation/charmlibs-tests.md
@@ -49,7 +49,7 @@ Before running `pytest`, `just functional <LIBRARY>` will first source `<LIBRARY
 After the tests complete, regardless of whether they passed or failed, `<LIBRARY>/tests/functional/teardown.sh` is sourced.
 Finally, the recipe exits with the return code of the `pytest` run.
 
-> Read more: {ref}`how-to-customize-functional-tests`
+Read more: {ref}`how-to-customize-functional-tests`
 
 (charmlibs-integration-tests)=
 ## Integration tests
@@ -68,4 +68,4 @@ These will run the tests under `<LIBRARY>/tests/integration`, selecting either a
 You'll need to have a Juju controller set up locally to run your integration tests.
 In CI, Juju is set up for you by [concierge](https://github.com/canonical/concierge).
 
-> Read more: {ref}`how-to-customize-integration-tests`
+Read more: {ref}`how-to-customize-integration-tests`

--- a/.docs/how-to/customize-functional-tests.md
+++ b/.docs/how-to/customize-functional-tests.md
@@ -3,7 +3,7 @@
 
 Functional tests are executed much like your unit tests, but they provide more entry points for customisation to accommodate the need to interact with external processes.
 
-> Read more: {ref}`charmlibs-tests`
+Read more: {ref}`charmlibs-tests`
 
 Functional tests are only executed if the `<LIBRARY>/tests/functional` directory exists.
 If you don't need functional tests, remove the directory.

--- a/.docs/how-to/customize-integration-tests.md
+++ b/.docs/how-to/customize-integration-tests.md
@@ -5,7 +5,7 @@ In its integration tests, your library will be packed into one or more charms, t
 You can customise your integration tests in several ways, according to the needs of your library.
 You'll determine whether it makes sense to test on both K8s and machine clouds, with one or more charms, and whether to rerun the integration tests with other permutations.
 
-> Read more: {ref}`charmlibs-tests`
+Read more: {ref}`charmlibs-tests`
 
 Integration tests are only executed if the `<LIBRARY>/tests/integration` directory exists.
 If you don't need integration tests, remove the directory.

--- a/.docs/how-to/manage-libraries.md
+++ b/.docs/how-to/manage-libraries.md
@@ -125,6 +125,4 @@ charm-libs:
     version: "0"
 ```
 
-> Read more:
-> - {ref}`charm-libs-charmhub-hosted`
-> - {ref}`Charmcraft | Manage libraries <charmcraft:manage-libraries>`
+Read more: {ref}`charm-libs-charmhub-hosted`, {ref}`Charmcraft | Manage libraries <charmcraft:manage-libraries>`

--- a/.docs/how-to/migrate.md
+++ b/.docs/how-to/migrate.md
@@ -234,13 +234,13 @@ They're intended for tests that interact with the real world, but don't require 
 
 The process for migrating them is exactly the same as for unit tests.
 
-> Read more: {ref}`tutorial-add-functional-tests`, {ref}`charmlibs-functional-tests`
+Read more: {ref}`tutorial-add-functional-tests`, {ref}`charmlibs-functional-tests`
 
 ### Integration tests
 
 Integration tests involve packing your library into a charm and deploying it on a real Juju model.
 
-> Read more: {ref}`tutorial-add-integration-tests`, {ref}`charmlibs-integration-tests`
+Read more: {ref}`tutorial-add-integration-tests`, {ref}`charmlibs-integration-tests`
 
 If you take a look at your `<library path>/tests/integration` directory, you'll see a `pack.sh` script.
 Currently it packs a simple `k8s` or `machine` charm, depending on the `CHARMLIBS_SUBSTRATE` variable that is set in CI.

--- a/.docs/how-to/python-package.md
+++ b/.docs/how-to/python-package.md
@@ -58,7 +58,7 @@ It's also very useful when developing a new library or porting a Charmhub-hosted
 
 You don't need to do anything special to make your Python package installable with `git` -- just commit it and push to your repository as usual.
 
-> Read more: {ref}`manage-git-dependencies`
+Read more: {ref}`manage-git-dependencies`
 
 (python-package-distribution-local)=
 ### Local files

--- a/.docs/tutorial.md
+++ b/.docs/tutorial.md
@@ -40,7 +40,8 @@ If you want to run the Juju integration tests locally, you'll also need `charmcr
 In CI, these are installed and set up for you using [concierge](https://github.com/canonical/concierge?tab=readme-ov-file#presets), with the `microk8s` and `machine` presets.
 The `dev` preset is suitable for local development and testing of both K8s and machine charms, but you may find it easier to run the Juju integration tests in CI when following this tutorial.
 
-See more:
+Read more:
+
 - {ref}`Charmcraft | Install charmcraft <charmcraft:manage-charmcraft>`
 - {ref}`Juju | Set up your Juju deployment <juju:set-up-your-deployment>`
 - {ref}`Juju | Set up an isolated environment <juju:set-things-up>`

--- a/.docs/tutorial.md
+++ b/.docs/tutorial.md
@@ -40,10 +40,10 @@ If you want to run the Juju integration tests locally, you'll also need `charmcr
 In CI, these are installed and set up for you using [concierge](https://github.com/canonical/concierge?tab=readme-ov-file#presets), with the `microk8s` and `machine` presets.
 The `dev` preset is suitable for local development and testing of both K8s and machine charms, but you may find it easier to run the Juju integration tests in CI when following this tutorial.
 
-> See more:
-> - {ref}`Charmcraft | Install charmcraft <charmcraft:manage-charmcraft>`
-> - {ref}`Juju | Set up your Juju deployment <juju:set-up-your-deployment>`
-> - {ref}`Juju | Set up an isolated environment <juju:set-things-up>`
+See more:
+- {ref}`Charmcraft | Install charmcraft <charmcraft:manage-charmcraft>`
+- {ref}`Juju | Set up your Juju deployment <juju:set-up-your-deployment>`
+- {ref}`Juju | Set up an isolated environment <juju:set-things-up>`
 
 If you're not already using some alternative authentication for `git push`, you'll also want to [make sure you've set up your Github account with your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
@@ -176,7 +176,7 @@ The `charmlibs` monorepo supports three distinct types of tests: unit, functiona
 The template starts you off with a simple passing test for each.
 We'll add a test of each kind for our `uptime` library in the following sections.
 
-> Read more: {ref}`charmlibs-tests`
+Read more: {ref}`charmlibs-tests`
 
 ### Add unit tests
 
@@ -251,7 +251,7 @@ In this repository, functional tests are essentially integration or end-to-end t
 In contrast to unit tests, which typically mock out external concerns, functional tests interact with real systems, external processes, and networks.
 However, they do not interact with a real Juju environment, which is reserved for tests under the `integration/` directory.
 
-> Read more: {ref}`how-to-customize-functional-tests`
+Read more: {ref}`how-to-customize-functional-tests`
 
 ````{tip}
 If you're working on an interface library, functional tests probably aren't a good fit, since the main thing the library interacts with is Juju.
@@ -288,7 +288,7 @@ Integration tests are the most complicated and most heavyweight part of the libr
 They involve packing a real charm that includes your library, and deploying it on a real Juju model.
 They can be customized in several ways depending on your library's needs.
 
-> Read more: {ref}`how-to-customize-integration-tests`
+Read more: {ref}`how-to-customize-integration-tests`
 
 For now, we'll just add an integration test for our `uptime` function.
 
@@ -376,4 +376,4 @@ Their review will cover whether the name and purpose of the library is appropria
 This type of review will be repeated for major version bumps of your library.
 All other releases will only require `CODEOWNERS` approval.
 
-> Read more: {ref}`charmlibs-publishing`
+Read more: {ref}`charmlibs-publishing`

--- a/.package/README.md
+++ b/.package/README.md
@@ -4,7 +4,7 @@ This package should not be installed - it exists solely to reserve the `charmlib
 
 This namespace is for packages designed to be used by [Juju charms](https://canonical.com/juju/charms-architecture). Visit the [charmlibs documentation site](https://canonical-charmlibs.readthedocs-hosted.com/) for more information about charm libraries.
 
-See more:
+Read more:
 
 - Get started with charm development, using [Charmcraft tutorials](https://documentation.ubuntu.com/charmcraft/stable/tutorial/) and [Ops tutorials](https://documentation.ubuntu.com/ops/latest/tutorial/)
 - Learn how to [use and write charm libraries](https://documentation.ubuntu.com/ops/latest/howto/manage-libraries/)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,14 @@ This is also run as part of `just check`. The full docs site (all packages) is b
 
 When writing or editing docstrings in `__init__.py` or other public modules, remember they appear verbatim in the published reference at [documentation.ubuntu.com/charmlibs](https://documentation.ubuntu.com/charmlibs). Keep them informative for library users, not implementation notes.
 
+Don't use block quotes (`>`) for "Read more", "See also", or similar cross-reference sections. Instead, use bare text like `Read more: {ref}\`some-page\`` or, for multiple links, a comma-separated list or a bulleted list. For example:
+
+```
+Read more: {ref}`how-to-customize-integration-tests`
+
+Read more: {ref}`charm-libs-charmhub-hosted`, {ref}`Charmcraft | Manage libraries <charmcraft:manage-libraries>`
+```
+
 ## Common pitfalls
 
 - **Don't call `uv add` directly** — use `just add <package> <dep>` to respect repo-level constraints.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,7 @@ This is also run as part of `just check`. The full docs site (all packages) is b
 
 When writing or editing docstrings in `__init__.py` or other public modules, remember they appear verbatim in the published reference at [documentation.ubuntu.com/charmlibs](https://documentation.ubuntu.com/charmlibs). Keep them informative for library users, not implementation notes.
 
-Don't use block quotes (`>`) for "Read more", "See also", or similar cross-reference sections. Instead, use bare text like `Read more: {ref}\`some-page\`` or, for multiple links, a comma-separated list or a bulleted list. For example:
+Don't use block quotes (`>`) for "Read more", "See also", or similar cross-reference sections. Instead, use bare text like `Read more: {ref}\`some-page\`` or, for two links, a comma-separated list or, for three or more links a bulleted list. For example:
 
 ```
 Read more: {ref}`how-to-customize-integration-tests`

--- a/interfaces/.package/README.md
+++ b/interfaces/.package/README.md
@@ -4,7 +4,7 @@ This package should not be installed - it exists solely to reserve the `charmlib
 
 This namespace is for packages designed to be used by [Juju charms](https://canonical.com/juju/charms-architecture) to implement [relations](https://documentation.ubuntu.com/ops/latest/howto/manage-relations/), known as charm interface libraries. Read the [charmlibs documentation](https://documentation.ubuntu.com/charmlibs) for more information about charm libraries.
 
-See more:
+Read more:
 
 - Get started with charm development, using [Charmcraft tutorials](https://documentation.ubuntu.com/charmcraft/stable/tutorial/) and [Ops tutorials](https://documentation.ubuntu.com/ops/latest/tutorial/)
 - Learn how to [use and write charm libraries](https://documentation.ubuntu.com/ops/latest/howto/manage-libraries/)


### PR DESCRIPTION
This PR updates the docs to avoid using block quotes for links, and updates our `AGENTS.md`'s documentation section accordingly.

In future we should look into how best to ensure that guidance for agents in this repository follows our team style guide.

Resolves #494