### PR TITLE
chore: add 7-day Dependabot cooldown to version updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,8 @@ updates:
       interval: "monthly"  # This is hard-coded to the 1st of the month
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
   # Monthly update to repo wide Python testing dependencies
   # These are defined in /pyproject.toml and /test-requirements.txt
   - package-ecosystem: "pip"
@@ -17,6 +19,8 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
     groups:
       test-deps:
         patterns:


### PR DESCRIPTION
Add a 7-day cooldown to the monthly github-actions and pip version updates, matching the rest of the Charm Tech estate. The cooldown gives a window for a freshly published (then potentially yanked) release to be caught before Dependabot opens an update PR. The security-only pip entry (open-pull-requests-limit: 0) intentionally has no cooldown, since security fixes should land promptly.