### PR TITLE
test: add workshop support to make functional tests easier to run locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ cython_debug/
 .example/**/uv.lock
 .tutorial/**/uv.lock
 interfaces/.example/**/uv.lock
+
+# Workshop lock file (machine-local state)
+.workshop.lock

--- a/.workshop/charmlibs/hooks/setup-base
+++ b/.workshop/charmlibs/hooks/setup-base
@@ -1,5 +1,7 @@
 # Install development tools.
-snap install --classic astral-uv just pebble
+snap install --classic astral-uv
+snap install --classic just
+snap install --classic pebble
 
 # uv hardlinks by default, which fails across the workshop mount boundary.
 echo UV_LINK_MODE=copy >> /etc/environment

--- a/.workshop/charmlibs/hooks/setup-base
+++ b/.workshop/charmlibs/hooks/setup-base
@@ -1,11 +1,5 @@
-# Make uv/uvx available on sudo's secure_path (the SDK dir isn't on it).
-ln -sf /var/lib/workshop/sdk/uv/bin/uv /usr/local/bin/uv
-ln -sf /var/lib/workshop/sdk/uv/bin/uvx /usr/local/bin/uvx
-
-# Install just via uv, then copy the binary somewhere accessible.
-# uv puts it under /root/ which the workshop user can't traverse.
-uv tool install rust-just
-cp /root/.local/bin/just /usr/local/bin/just
+# Install development tools.
+snap install --classic astral-uv just pebble
 
 # uv hardlinks by default, which fails across the workshop mount boundary.
 echo UV_LINK_MODE=copy >> /etc/environment
@@ -14,6 +8,3 @@ echo UV_PROJECT_ENVIRONMENT=/tmp/workshop-uv-venv >> /etc/environment
 
 # Install fish shell for interactive use.
 apt-get update -qq && apt-get install -yqq fish
-
-# Install pebble for pathops functional tests.
-snap install pebble --classic

--- a/.workshop/charmlibs/hooks/setup-base
+++ b/.workshop/charmlibs/hooks/setup-base
@@ -9,4 +9,4 @@ echo UV_LINK_MODE=copy >> /etc/environment
 echo UV_PROJECT_ENVIRONMENT=/tmp/workshop-uv-venv >> /etc/environment
 
 # Install fish shell for interactive use.
-apt-get update -qq && apt-get install -yqq fish
+apt-get update -qq && apt-get install -yqq fish || echo "Couldn't install fish for interactive use."

--- a/.workshop/charmlibs/hooks/setup-base
+++ b/.workshop/charmlibs/hooks/setup-base
@@ -1,0 +1,19 @@
+# Make uv/uvx available on sudo's secure_path (the SDK dir isn't on it).
+ln -sf /var/lib/workshop/sdk/uv/bin/uv /usr/local/bin/uv
+ln -sf /var/lib/workshop/sdk/uv/bin/uvx /usr/local/bin/uvx
+
+# Install just via uv, then copy the binary somewhere accessible.
+# uv puts it under /root/ which the workshop user can't traverse.
+uv tool install rust-just
+cp /root/.local/bin/just /usr/local/bin/just
+
+# uv hardlinks by default, which fails across the workshop mount boundary.
+echo UV_LINK_MODE=copy >> /etc/environment
+# Avoid clashes with the host's .venv in the mounted project directory.
+echo UV_PROJECT_ENVIRONMENT=/tmp/workshop-uv-venv >> /etc/environment
+
+# Install fish shell for interactive use.
+apt-get update -qq && apt-get install -yqq fish
+
+# Install pebble for pathops functional tests.
+snap install pebble --classic

--- a/.workshop/charmlibs/sdk.yaml
+++ b/.workshop/charmlibs/sdk.yaml
@@ -1,2 +1,3 @@
 name: charmlibs
+version: "0.1"
 summary: Development tools for the charmlibs monorepo.

--- a/.workshop/charmlibs/sdk.yaml
+++ b/.workshop/charmlibs/sdk.yaml
@@ -1,0 +1,2 @@
+name: charmlibs
+summary: Development tools for the charmlibs monorepo.

--- a/.workshop/jammy.yaml
+++ b/.workshop/jammy.yaml
@@ -1,7 +1,6 @@
 name: jammy
 base: ubuntu@22.04
 sdks:
-  - name: uv
   - name: project-charmlibs
 actions:
   functional: |

--- a/.workshop/jammy.yaml
+++ b/.workshop/jammy.yaml
@@ -4,4 +4,4 @@ sdks:
   - name: project-charmlibs
 actions:
   functional: |
-    sudo just functional "$@"
+    sudo just python=python3 functional "$@"

--- a/.workshop/jammy.yaml
+++ b/.workshop/jammy.yaml
@@ -1,0 +1,8 @@
+name: jammy
+base: ubuntu@22.04
+sdks:
+  - name: uv
+  - name: project-charmlibs
+actions:
+  functional: |
+    sudo just functional "$@"

--- a/.workshop/jammy.yaml
+++ b/.workshop/jammy.yaml
@@ -4,4 +4,5 @@ sdks:
   - name: project-charmlibs
 actions:
   functional: |
-    sudo just python=python3 functional "$@"
+    # Override Python with: workshop run --env PYTHON=python3.12 jammy -- functional ...
+    sudo just python="${PYTHON:-python3}" functional "$@"

--- a/.workshop/noble.yaml
+++ b/.workshop/noble.yaml
@@ -4,4 +4,5 @@ sdks:
   - name: project-charmlibs
 actions:
   functional: |
-    sudo just python=python3 functional "$@"
+    # Override Python with: workshop run --env PYTHON=python3.12 noble -- functional ...
+    sudo just python="${PYTHON:-python3}" functional "$@"

--- a/.workshop/noble.yaml
+++ b/.workshop/noble.yaml
@@ -1,0 +1,8 @@
+name: noble
+base: ubuntu@24.04
+sdks:
+  - name: uv
+  - name: project-charmlibs
+actions:
+  functional: |
+    sudo just functional "$@"

--- a/.workshop/noble.yaml
+++ b/.workshop/noble.yaml
@@ -4,4 +4,4 @@ sdks:
   - name: project-charmlibs
 actions:
   functional: |
-    sudo just functional "$@"
+    sudo just python=python3 functional "$@"

--- a/.workshop/noble.yaml
+++ b/.workshop/noble.yaml
@@ -1,7 +1,6 @@
 name: noble
 base: ubuntu@24.04
 sdks:
-  - name: uv
   - name: project-charmlibs
 actions:
   functional: |

--- a/.workshop/resolute.yaml
+++ b/.workshop/resolute.yaml
@@ -4,4 +4,5 @@ sdks:
   - name: project-charmlibs
 actions:
   functional: |
-    sudo just python=python3 functional "$@"
+    # Override Python with: workshop run --env PYTHON=python3.13 resolute -- functional ...
+    sudo just python="${PYTHON:-python3}" functional "$@"

--- a/.workshop/resolute.yaml
+++ b/.workshop/resolute.yaml
@@ -4,4 +4,4 @@ sdks:
   - name: project-charmlibs
 actions:
   functional: |
-    sudo just functional "$@"
+    sudo just python=python3 functional "$@"

--- a/.workshop/resolute.yaml
+++ b/.workshop/resolute.yaml
@@ -1,7 +1,6 @@
 name: resolute
 base: ubuntu@26.04
 sdks:
-  - name: uv
   - name: project-charmlibs
 actions:
   functional: |

--- a/.workshop/resolute.yaml
+++ b/.workshop/resolute.yaml
@@ -1,0 +1,8 @@
+name: resolute
+base: ubuntu@26.04
+sdks:
+  - name: uv
+  - name: project-charmlibs
+actions:
+  functional: |
+    sudo just functional "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ The `<package>` argument is the path from the repo root, e.g. `pathops` or `inte
 | `just format [package]` | Auto-fix ruff and formatting errors |
 | `just static <package>` | pyright only |
 | `just unit <package>` | Run unit tests |
-| `just functional <package>` | Run functional tests (may need external software available, or to be run with sudo -- and note that this probably indicates a test that's destructive to the local environment (e.g. adding or removing packages)) |
+| `just functional <package>` | Run functional tests (may need external software available, or to be run with sudo -- and note that this probably indicates a test that's destructive to the local environment (e.g. adding or removing packages)). **Do not run functional tests directly on the host.** Use Workshop instead (see below). |
 | `just pack-k8s <package>` | Pack K8s test charm(s) for integration tests, running the libraries `tests/integration/pack.sh` script with environment variables set |
 | `just pack-machine <package>` | Pack machine test charm(s) for integration tests, as above |
 | `just integration-k8s <package>` | Run Juju integration tests, excluding `pytest.mark.machine_only` tests |
@@ -128,6 +128,22 @@ just add interfaces/tls-certificates --requirements my-requirements.txt
 A test type is only executed if the corresponding `tests/` subdirectory exists. Remove a directory to skip that test type entirely.
 
 Read more: [types of tests in the charmlibs monorepo](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-tests/).
+
+### Running functional tests with Workshop
+
+Functional tests often require `sudo` and may be destructive to the local environment (e.g. installing or removing system packages). **Never run functional tests directly on the host machine.** Always use [Workshop](https://snapcraft.io/workshop) to run them in an isolated VM:
+
+```bash
+workshop run noble -- functional <package>       # Ubuntu 24.04
+workshop run jammy -- functional <package>       # Ubuntu 22.04
+workshop run resolute -- functional <package>    # Ubuntu 26.04
+```
+
+Workshop configs are defined in `.workshop/`. The `functional` action runs `sudo just functional "$@"` inside the VM. Extra pytest flags are passed through:
+
+```bash
+workshop run noble -- functional snap -x -k test_install
+```
 
 ## Commit and PR conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Read more: [types of tests in the charmlibs monorepo](https://documentation.ubun
 
 ### Running functional tests with Workshop
 
-Functional tests often require `sudo` and may be destructive to the local environment (e.g. installing or removing system packages). **Never run functional tests directly on the host machine.** Always use [Workshop](https://snapcraft.io/workshop) to run them in an isolated VM:
+Functional tests often require `sudo` and may be destructive to the local environment (e.g. installing or removing system packages). **Never run functional tests directly on the host machine.** Always use [Workshop](https://snapcraft.io/workshop) to run them in an isolated container:
 
 ```bash
 workshop run resolute -- functional <package>    # Ubuntu 26.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,9 @@ Read more: [types of tests in the charmlibs monorepo](https://documentation.ubun
 Functional tests often require `sudo` and may be destructive to the local environment (e.g. installing or removing system packages). **Never run functional tests directly on the host machine.** Always use [Workshop](https://snapcraft.io/workshop) to run them in an isolated VM:
 
 ```bash
+workshop run resolute -- functional <package>    # Ubuntu 26.04
 workshop run noble -- functional <package>       # Ubuntu 24.04
 workshop run jammy -- functional <package>       # Ubuntu 22.04
-workshop run resolute -- functional <package>    # Ubuntu 26.04
 ```
 
 Workshop configs are defined in `.workshop/`. The `functional` action runs `sudo just functional "$@"` inside the VM. Extra pytest flags are passed through:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ just add pathops 'pydantic>=2'
 
 `functional` and `integration` tests are also executed in CI, and can be run locally too. They're excluded from `just check` as they may require additional setup:
 
-- `just functional <package>` runs functional tests, which interact with real external processes (but not Juju itself). Some functional test suites may require `sudo` access and may be destructive to the local environment (e.g. installing or removing system packages). Use [Workshop](https://snapcraft.io/workshop) to run them in an isolated VM instead of running them directly on your host:
+- `just functional <package>` runs functional tests, which interact with real external processes (but not Juju itself). Some functional test suites may require `sudo` access and may be destructive to the local environment (e.g. installing or removing system packages). Use [Workshop](https://snapcraft.io/workshop) to run them in an isolated container instead of running them directly on your host:
 
   ```bash
   workshop run resolute -- functional <package>    # Ubuntu 26.04

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,9 @@ just add pathops 'pydantic>=2'
 - `just functional <package>` runs functional tests, which interact with real external processes (but not Juju itself). Some functional test suites may require `sudo` access and may be destructive to the local environment (e.g. installing or removing system packages). Use [Workshop](https://snapcraft.io/workshop) to run them in an isolated VM instead of running them directly on your host:
 
   ```bash
+  workshop run resolute -- functional <package>    # Ubuntu 26.04
   workshop run noble -- functional <package>       # Ubuntu 24.04
   workshop run jammy -- functional <package>       # Ubuntu 22.04
-  workshop run resolute -- functional <package>    # Ubuntu 26.04
   ```
 
   Extra pytest flags are passed through, e.g. `workshop run noble -- functional snap -x -k test_install`. Workshop configs are in `.workshop/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,16 @@ just add pathops 'pydantic>=2'
 
 `functional` and `integration` tests are also executed in CI, and can be run locally too. They're excluded from `just check` as they may require additional setup:
 
-- `just functional <package>` runs functional tests, which interact with real external processes (but not Juju itself). Some functional test suites may require additional software installed locally, like `pebble` or `sudo` access.
+- `just functional <package>` runs functional tests, which interact with real external processes (but not Juju itself). Some functional test suites may require `sudo` access and may be destructive to the local environment (e.g. installing or removing system packages). Use [Workshop](https://snapcraft.io/workshop) to run them in an isolated VM instead of running them directly on your host:
+
+  ```bash
+  workshop run noble -- functional <package>       # Ubuntu 24.04
+  workshop run jammy -- functional <package>       # Ubuntu 22.04
+  workshop run resolute -- functional <package>    # Ubuntu 26.04
+  ```
+
+  Extra pytest flags are passed through, e.g. `workshop run noble -- functional snap -x -k test_install`. Workshop configs are in `.workshop/`.
+
 - Integration tests involve packing real test charms and deploying them on a Juju cloud. Pack first with `just pack-k8s <package>` or `just pack-machine <package>`, then run `just integration-k8s <package>` or `just integration-machine <package>`.
 
 Read more: [the different types of tests](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs-tests/).


### PR DESCRIPTION
This PR adds workshop config (and instructions) to make it easier to run functional tests locally.

We don't exercise it in CI at all -- consider it experimental for now.