### PR TITLE
chore: use SPDX license expression in maintainer-owned pyproject.toml

### DIFF
--- a/.example/pyproject.toml
+++ b/.example/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.10"
 authors = [
     {name="The Charm Tech team at Canonical"},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",

--- a/.template/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/.template/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">={{ cookiecutter.min_python_version }}"
 authors = [
     {name="{{ cookiecutter.author }}"},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",

--- a/apt/pyproject.toml
+++ b/apt/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.10"
 authors = [
     {name="The Charm Tech team at Canonical Ltd."},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",

--- a/interfaces/.example/pyproject.toml
+++ b/interfaces/.example/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.10"
 authors = [
     {name="The Charm Tech team at Canonical"},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",

--- a/passwd/pyproject.toml
+++ b/passwd/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.10"
 authors = [
     {name="charmlibs-maintainers"},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",

--- a/pathops/pyproject.toml
+++ b/pathops/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.10"
 authors = [
     {name="The Charm Tech team at Canonical Ltd."},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",

--- a/snap/pyproject.toml
+++ b/snap/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.10"
 authors = [
     {name="The Charm Tech team at Canonical"},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",

--- a/sysctl/pyproject.toml
+++ b/sysctl/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.10"
 authors = [
     {name="The Charm Tech team at Canonical"},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",

--- a/systemd/pyproject.toml
+++ b/systemd/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.10"
 authors = [
     {name="The Charm Tech team at Canonical"},
 ]
+license = "Apache-2.0"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Developers",
     "Operating System :: POSIX :: Linux",
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Migrate the Apache-2.0 license from the deprecated trove classifier ('License :: OSI Approved :: Apache Software License') to a PEP 639 license expression ('license = "Apache-2.0"').

Scope: maintainer-owned packages (apt, passwd, pathops, snap, sysctl, systemd) and the .example / interfaces/.example templates. Other libraries are owned by separate teams (see CODEOWNERS) and can follow in per-team PRs as the issue suggests.

The four tests/integration/charms/*/library/pyproject.toml files under .example are symlinks to the parent template, so they pick up the change transparently.

Fixes #293