### PR TITLE
docs: populate lib fields for identity interfaces

### DIFF
--- a/interfaces/forward_auth/interface/v0/interface.yaml
+++ b/interfaces/forward_auth/interface/v0/interface.yaml
@@ -3,6 +3,7 @@ internal: true
 
 version: 0
 status: draft
+lib: charms.oathkeeper.forward_auth
 
 providers:
   - name: oathkeeper-operator

--- a/interfaces/hydra_endpoints/interface/v0/interface.yaml
+++ b/interfaces/hydra_endpoints/interface/v0/interface.yaml
@@ -3,6 +3,7 @@ internal: true
 
 version: 0
 status: draft
+lib: charms.hydra.hydra_endpoints
 
 providers:
   - name: hydra-operator

--- a/interfaces/index.json
+++ b/interfaces/index.json
@@ -192,8 +192,8 @@
   {
     "name": "forward_auth",
     "version": "0",
-    "lib": "",
-    "lib_url": "",
+    "lib": "charms.oathkeeper.forward_auth",
+    "lib_url": "https://charmhub.io/oathkeeper/libraries/forward_auth",
     "docs_url": "https://documentation.ubuntu.com/charmlibs/reference/interfaces/forward_auth/",
     "summary": "",
     "description": "",
@@ -232,8 +232,8 @@
   {
     "name": "hydra_endpoints",
     "version": "0",
-    "lib": "",
-    "lib_url": "",
+    "lib": "charms.hydra.hydra_endpoints",
+    "lib_url": "https://charmhub.io/hydra/libraries/hydra_endpoints",
     "docs_url": "https://documentation.ubuntu.com/charmlibs/reference/interfaces/hydra_endpoints/",
     "summary": "",
     "description": "",
@@ -332,8 +332,8 @@
   {
     "name": "kratos_info",
     "version": "0",
-    "lib": "",
-    "lib_url": "",
+    "lib": "charms.kratos.kratos_info",
+    "lib_url": "https://charmhub.io/kratos/libraries/kratos_info",
     "docs_url": "https://documentation.ubuntu.com/charmlibs/reference/interfaces/kratos_info/",
     "summary": "",
     "description": "",
@@ -372,8 +372,8 @@
   {
     "name": "login_ui_endpoints",
     "version": "0",
-    "lib": "",
-    "lib_url": "",
+    "lib": "charms.identity_platform_login_ui_operator.login_ui_endpoints",
+    "lib_url": "https://charmhub.io/identity-platform-login-ui-operator/libraries/login_ui_endpoints",
     "docs_url": "https://documentation.ubuntu.com/charmlibs/reference/interfaces/login_ui_endpoints/",
     "summary": "",
     "description": "",

--- a/interfaces/kratos_info/interface/v0/interface.yaml
+++ b/interfaces/kratos_info/interface/v0/interface.yaml
@@ -3,6 +3,7 @@ internal: true
 
 version: 0
 status: published
+lib: charms.kratos.kratos_info
 
 providers:
   - name: kratos-operator

--- a/interfaces/login_ui_endpoints/interface/v0/interface.yaml
+++ b/interfaces/login_ui_endpoints/interface/v0/interface.yaml
@@ -3,6 +3,7 @@ internal: true
 
 version: 0
 status: draft
+lib: charms.identity_platform_login_ui_operator.login_ui_endpoints
 
 providers:
   - name: identity-platform-login-ui-operator


### PR DESCRIPTION
This PR adds `lib` entries to the interface metadata for some `identity` owned interfaces that were missing them.