### PR TITLE
chore(rollingops): update README

### DIFF
--- a/rollingops/README.md
+++ b/rollingops/README.md
@@ -27,10 +27,3 @@ See the [reference documentation](https://documentation.ubuntu.com/charmlibs/ref
 # Developing
 
 Refer to [CONTRIBUTING.md](https://github.com/canonical/charmlibs/blob/main/CONTRIBUTING.md) for development instructions.
-
-**Note:** Until this [issue](https://github.com/canonical/charmlibs/issues/449) is resolved,
-you must explicitly set the Python version when running `just` commands:
-
-```bash
-just python=3.12 <recipe> rollingops
-```


### PR DESCRIPTION
## Description

This PR updates the README.md

We no longer need to specify the python version when using just.