### PR TITLE
fix: _tls_config CA cert path

### DIFF
--- a/nginx_k8s/CHANGELOG.md
+++ b/nginx_k8s/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.1 - 22 June 2026
+
+This change ensures that _tls_config checks the correct path for a CA cert. If the module checks the wrong path, it cannot correctly determine whether TLS is enabled or not.
+
 # 1.0.0 - 22 June 2026
 
 This change introduces necessary fixes to logic related to the Nginx Prometheus Exporter. As part of this fix, a breaking change is introduced, warranting a bump of the major version. The changes include:

--- a/nginx_k8s/src/charmlibs/nginx_k8s/__init__.py
+++ b/nginx_k8s/src/charmlibs/nginx_k8s/__init__.py
@@ -49,4 +49,4 @@ __all__ = (
     'TLSConfigManager',
 )
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/nginx_k8s/src/charmlibs/nginx_k8s/_tls_config.py
+++ b/nginx_k8s/src/charmlibs/nginx_k8s/_tls_config.py
@@ -31,7 +31,7 @@ class TLSConfigManager:
 
     KEY_PATH = '/etc/nginx/certs/server.key'
     CERT_PATH = '/etc/nginx/certs/server.cert'
-    CA_CERT_PATH = '/usr/local/share/ca-certificates/ca.cert'
+    CA_CERT_PATH = '/usr/local/share/ca-certificates/ca.crt'
 
     def __init__(
         self,


### PR DESCRIPTION
Fixes #544 by correcting the CA cert path that TLSConfig checks.

You can test this behaviour by first deploying the same bundle as you see in the issue. Then:
1. Shelling into Mimir's charm container: `juju ssh mimir/0 bash` 
2. Navigate to the corresponding code in `/var/lib/juju/agents/unit-mimir-0/charm/venv/lib/python3.14/site-packages/charmlibs/nginx_k8s/_tls_config.py`.
3. Make the change this PR makes on line 34 of the file.
4. Trigger the `nginx` config to be written again: `jhack fire mimir/0 update-status`
5. Now, the Pebble log error in Otelcol (see issue) should go away.
6. Manual testing from Otelcol's workload container should succeed in hitting Mimir's remote write endpoint: `curl https://mimir-0.mimir-endpoints.test.svc.cluster.local:443/api/v1/push`