### PR TITLE
ci: exclude certain 'global' files from triggering all package tests

### DIFF
--- a/.github/get-changed.py
+++ b/.github/get-changed.py
@@ -37,6 +37,7 @@ _EXCLUSIONS = {
     '.github/PULL_REQUEST_TEMPLATE/adding-a-new-library.md',
     '.github/PULL_REQUEST_TEMPLATE/blank.md',
     '.github/PULL_REQUEST_TEMPLATE/migrating-a-library.md',
+    '.github/get-changed.py',
 }
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 

--- a/.github/get-changed.py
+++ b/.github/get-changed.py
@@ -37,6 +37,8 @@ _EXCLUSIONS = {
     '.github/PULL_REQUEST_TEMPLATE/adding-a-new-library.md',
     '.github/PULL_REQUEST_TEMPLATE/blank.md',
     '.github/PULL_REQUEST_TEMPLATE/migrating-a-library.md',
+    '.github/dependabot.yaml',
+    '.github/zizmor.yaml',
 }
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 

--- a/.github/get-changed.py
+++ b/.github/get-changed.py
@@ -37,7 +37,6 @@ _EXCLUSIONS = {
     '.github/PULL_REQUEST_TEMPLATE/adding-a-new-library.md',
     '.github/PULL_REQUEST_TEMPLATE/blank.md',
     '.github/PULL_REQUEST_TEMPLATE/migrating-a-library.md',
-    '.github/get-changed.py',
 }
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 

--- a/.github/get-changed.py
+++ b/.github/get-changed.py
@@ -32,6 +32,12 @@ _GLOBAL_FILES = {
     'uv.lock',
     'test-requirements.txt',
 }
+_EXCLUSIONS = {
+    '.github/PULL_REQUEST_TEMPLATE.md',
+    '.github/PULL_REQUEST_TEMPLATE/adding-a-new-library.md',
+    '.github/PULL_REQUEST_TEMPLATE/blank.md',
+    '.github/PULL_REQUEST_TEMPLATE/migrating-a-library.md',
+}
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 
 logging.basicConfig(level=logging.DEBUG)
@@ -63,7 +69,7 @@ def _main() -> None:
 def _get_global_changes(git_base_ref: str) -> list[str]:
     cmd = ['git', 'diff', '--name-only', git_base_ref]
     diff = subprocess.check_output(cmd, text=True).strip().splitlines()
-    changes = {c.split('/')[0] for c in diff}
+    changes = {c.split('/')[0] for c in diff if c not in _EXCLUSIONS}
     return sorted(_GLOBAL_FILES.intersection(changes))
 
 


### PR DESCRIPTION
This PR adds the ability to exclude certain files from triggering all package tests. For instance, currently anything changed under `.github/` triggers all tests to run. This makes perfect sense when workflows are changed, but doesn't really provide any value if PR templates are what's changing.

The exclusions are a static list of full file paths (from the repository root) to avoid unintended matches.

This doesn't change `CODEOWNERS`, so the maintainers are still requested for review as appropriate.

Currently, the PR adds the `PULL_REQUEST_TEMPLATE` files only. But maybe it should add some more, like `.github/dependabot.yaml`. I'm open to suggestions.

I verified that the feature works by temporarily excluding the `get-changed.py` script itself from triggering global changes.