### PR TITLE
ci: exclude zizmor.yml from global change detection

### DIFF
--- a/.github/get-changed.py
+++ b/.github/get-changed.py
@@ -38,7 +38,7 @@ _EXCLUSIONS = {
     '.github/PULL_REQUEST_TEMPLATE/blank.md',
     '.github/PULL_REQUEST_TEMPLATE/migrating-a-library.md',
     '.github/dependabot.yaml',
-    '.github/zizmor.yaml',
+    '.github/zizmor.yml',
 }
 _REPO_ROOT = pathlib.Path(__file__).parent.parent
 


### PR DESCRIPTION
This PR excludes `zizmor.yml` rather than `zizmor.yaml` from global change detection -- both extensions are supported (per https://docs.zizmor.sh/configuration/), but we'll stick with `zizmor.yml` in this repository until (if) all [charm tech repos](https://github.com/orgs/canonical/teams/charm-tech/repositories) migrate at the same time (per #550).