### PR TITLE
docs: update Charmlibs URLs for certificate_transfer, tls-certificates

### DIFF
--- a/interfaces/certificate_transfer/README.md
+++ b/interfaces/certificate_transfer/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-certificate_transfer` to your Python depen
 from charmlibs.interfaces import certificate_transfer
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/certificate_transfer).
+See the [reference documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/certificate_transfer).

--- a/interfaces/certificate_transfer/pyproject.toml
+++ b/interfaces/certificate_transfer/pyproject.toml
@@ -32,7 +32,7 @@ integration = [  # installed for `just integration interfaces/certificate_transf
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/certificate-transfer"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/certificate-transfer"
 "Repository" = "https://github.com/canonical/charmlibs/tree/main/interfaces/certificate_transfer"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/interfaces/certificate_transfer/CHANGELOG.md"

--- a/interfaces/index.json
+++ b/interfaces/index.json
@@ -817,7 +817,7 @@
     "version": "1",
     "lib": "charmlibs.interfaces.tls_certificates",
     "lib_url": "https://pypi.org/project/charmlibs-interfaces-tls-certificates",
-    "lib_docs_url": "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/tls-certificates",
+    "lib_docs_url": "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/tls-certificates",
     "docs_url": "https://canonical.com/juju/docs/charmlibs/reference/interfaces/tls-certificates/",
     "summary": "Securely request TLS certificates.",
     "description": "The `tls-certificates` interface allows charms to securely request and receive TLS certificates. The requirer charm is responsible for its private key and defining its certificate signing requests (CSRs). The provider charm delivers the certificate for each request, including the CA chain and CA certificate.",

--- a/interfaces/tls-certificates/README.md
+++ b/interfaces/tls-certificates/README.md
@@ -9,7 +9,7 @@ from charmlibs.interfaces import tls_certificates
 ```
 
 Read more:
-- [Tutorial](https://documentation.ubuntu.com/charmlibs/tutorials/charmlibs/interfaces/tls-certificates/tutorial/)
-- [Library reference](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/tls-certificates/)
-- [How to configure certificate requests](https://documentation.ubuntu.com/charmlibs/how-to/charmlibs/interfaces/tls-certificates/configure-certificate-requests/)
-- [Explanation of the library design](https://documentation.ubuntu.com/charmlibs/explanation/charmlibs/interfaces/tls-certificates/design/)
+- [Tutorial](https://canonical.com/juju/docs/charmlibs/tutorials/charmlibs/interfaces/tls-certificates/tutorial/)
+- [Library reference](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/tls-certificates/)
+- [How to configure certificate requests](https://canonical.com/juju/docs/charmlibs/how-to/charmlibs/interfaces/tls-certificates/configure-certificate-requests/)
+- [Explanation of the library design](https://canonical.com/juju/docs/charmlibs/explanation/charmlibs/interfaces/tls-certificates/design/)

--- a/interfaces/tls-certificates/pyproject.toml
+++ b/interfaces/tls-certificates/pyproject.toml
@@ -36,7 +36,7 @@ integration = [  # installed for `just integration interfaces/tls_certificates`
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/tls-certificates"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/tls-certificates"
 "Repository" = "https://github.com/canonical/charmlibs/tree/main/interfaces/tls-certificates"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/interfaces/tls-certificates/CHANGELOG.md"

--- a/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/__init__.py
+++ b/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/__init__.py
@@ -19,10 +19,10 @@ in the :class:`TLSCertificatesRequiresV4` and :class:`TLSCertificatesProvidesV4`
 
 Read more:
 
-- `Tutorial <https://documentation.ubuntu.com/charmlibs/tutorials/charmlibs/interfaces/tls-certificates/tutorial/>`_
-- `Library reference <https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/tls-certificates/>`_
-- `How to configure certificate requests <https://documentation.ubuntu.com/charmlibs/how-to/charmlibs/interfaces/tls-certificates/configure-certificate-requests/>`_
-- `Explanation of the library design <https://documentation.ubuntu.com/charmlibs/explanation/charmlibs/interfaces/tls-certificates/design/>`_
+- `Tutorial <https://canonical.com/juju/docs/charmlibs/tutorials/charmlibs/interfaces/tls-certificates/tutorial/>`_
+- `Library reference <https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/tls-certificates/>`_
+- `How to configure certificate requests <https://canonical.com/juju/docs/charmlibs/how-to/charmlibs/interfaces/tls-certificates/configure-certificate-requests/>`_
+- `Explanation of the library design <https://canonical.com/juju/docs/charmlibs/explanation/charmlibs/interfaces/tls-certificates/design/>`_
 """
 
 from ._tls_certificates import (


### PR DESCRIPTION
We recently moved Charmlibs docs to https://canonical.com/juju/docs/charmlibs/. The previous URLs redirect through, but it's best if we use the new destination URLs.

I haven't bumped the package versions - I'll leave that up to the TLS team.