### PR TITLE
docs: update Charmlibs URLs for Service Mesh team packages

### DIFF
--- a/interfaces/gateway_metadata/README.md
+++ b/interfaces/gateway_metadata/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-gateway-metadata` to your Python dependenc
 from charmlibs.interfaces import gateway_metadata
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/gateway-metadata) for more.
+See the [reference documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/gateway-metadata) for more.

--- a/interfaces/gateway_metadata/pyproject.toml
+++ b/interfaces/gateway_metadata/pyproject.toml
@@ -33,7 +33,7 @@ integration = [  # installed for `just integration interfaces/gateway_metadata`
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/gateway-metadata"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/gateway-metadata"
 "Repository" = "https://github.com/canonical/charmlibs/tree/main/interfaces/gateway_metadata"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/interfaces/gateway_metadata/CHANGELOG.md"

--- a/interfaces/index.json
+++ b/interfaces/index.json
@@ -374,7 +374,7 @@
     "version": "0",
     "lib": "charmlibs.interfaces.istio_metadata",
     "lib_url": "https://pypi.org/project/charmlibs-interfaces-istio-metadata",
-    "lib_docs_url": "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/istio-metadata",
+    "lib_docs_url": "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/istio-metadata",
     "docs_url": "https://canonical.com/juju/docs/charmlibs/reference/interfaces/istio_metadata/",
     "summary": "Share Istio installation metadata between charms.",
     "description": "The `istio_metadata` interface allows an Istio control plane charm to share information about its installation (such as the root namespace) with other charms that need to interoperate with Istio.\nThe provider charm (the Istio control plane) publishes the metadata, and requirer charms read it to configure their own integration with Istio.",

--- a/interfaces/istio_ingress_route/README.md
+++ b/interfaces/istio_ingress_route/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-istio-ingress-route` to your Python depend
 from charmlibs.interfaces import istio_ingress_route
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/istio-ingress-route) for more.
+See the [reference documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/istio-ingress-route) for more.

--- a/interfaces/istio_ingress_route/pyproject.toml
+++ b/interfaces/istio_ingress_route/pyproject.toml
@@ -33,7 +33,7 @@ integration = [  # installed for `just integration interfaces/istio_ingress_rout
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/istio-ingress-route"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/istio-ingress-route"
 "Repository" = "https://github.com/canonical/charmlibs/tree/main/interfaces/istio_ingress_route"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/interfaces/istio_ingress_route/CHANGELOG.md"

--- a/interfaces/istio_metadata/README.md
+++ b/interfaces/istio_metadata/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-istio-metadata` to your Python dependencie
 from charmlibs.interfaces import istio_metadata
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/istio_metadata) for more.
+See the [reference documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/istio_metadata) for more.

--- a/interfaces/istio_metadata/pyproject.toml
+++ b/interfaces/istio_metadata/pyproject.toml
@@ -33,7 +33,7 @@ integration = [  # installed for `just integration interfaces/istio_metadata`
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/istio-metadata"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/istio-metadata"
 "Repository" = "https://github.com/canonical/charmlibs/tree/main/interfaces/istio_metadata"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/interfaces/istio_metadata/CHANGELOG.md"

--- a/interfaces/istio_request_auth/README.md
+++ b/interfaces/istio_request_auth/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-istio-request-auth` to your Python depende
 from charmlibs.interfaces import istio_request_auth
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/istio-request-auth) for more.
+See the [reference documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/istio-request-auth) for more.

--- a/interfaces/istio_request_auth/pyproject.toml
+++ b/interfaces/istio_request_auth/pyproject.toml
@@ -33,7 +33,7 @@ integration = [  # installed for `just integration interfaces/istio_request_auth
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/istio-request-auth"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/istio-request-auth"
 "Repository" = "https://github.com/canonical/charmlibs/tree/main/interfaces/istio_request_auth"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/interfaces/istio_request_auth/CHANGELOG.md"

--- a/interfaces/service_mesh/README.md
+++ b/interfaces/service_mesh/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-service-mesh` to your Python dependencies.
 from charmlibs.interfaces import service_mesh
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/service-mesh) for more.
+See the [reference documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/service-mesh) for more.

--- a/interfaces/service_mesh/pyproject.toml
+++ b/interfaces/service_mesh/pyproject.toml
@@ -34,7 +34,7 @@ integration = [  # installed for `just integration interfaces/service_mesh`
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/service-mesh"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/service-mesh"
 "Repository" = "https://github.com/canonical/charmlibs/tree/main/interfaces/service_mesh"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/interfaces/service_mesh/CHANGELOG.md"


### PR DESCRIPTION
We recently moved Charmlibs docs to https://canonical.com/juju/docs/charmlibs/. The previous URLs redirect through, but it's best if we use the new destination URLs.

I haven't bumped the package versions - I'll leave that up to the Service Mesh team.