### PR TITLE
docs: update Charmlibs URL for k8s_backup_target

### DIFF
--- a/interfaces/k8s_backup_target/README.md
+++ b/interfaces/k8s_backup_target/README.md
@@ -8,4 +8,4 @@ To install, add `charmlibs-interfaces-k8s-backup-target` to your Python dependen
 from charmlibs.interfaces import k8s_backup_target
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/k8s-backup-target).
+See the [reference documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/k8s-backup-target).


### PR DESCRIPTION
We recently moved Charmlibs docs to https://canonical.com/juju/docs/charmlibs/. The previous URLs redirect through, but it's best if we use the new destination URLs.

I haven't bumped the package version - I'll leave that up to the Analytics team.