### PR TITLE
docs: update Charmlibs URL for otlp, nginx_k8s

### DIFF
--- a/interfaces/otlp/README.md
+++ b/interfaces/otlp/README.md
@@ -76,7 +76,7 @@ class MyOtlpSender(CharmBase):
 
 ## Documentation
 
-For complete documentation, see the [charmlibs documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/otlp).
+For complete documentation, see the [charmlibs documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/otlp).
 
 ## Contributing
 

--- a/nginx_k8s/README.md
+++ b/nginx_k8s/README.md
@@ -9,7 +9,7 @@ To install, add `charmlibs-nginx-k8s` to your requirements. Then in your Python 
 from charmlibs import nginx_k8s
 ```
 
-Check out the reference docs on the [charmlibs docsite](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/nginx-k8s/).
+Check out the reference docs on the [charmlibs docsite](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/nginx-k8s/).
 
 # Getting started
 

--- a/nginx_k8s/pyproject.toml
+++ b/nginx_k8s/pyproject.toml
@@ -33,7 +33,7 @@ integration = [
 ]
 
 [project.urls]
-"Documentation" = "https://canonical.com/juju/docs/charmlibsreference/charmlibs/nginx_k8s/"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/nginx_k8s/"
 "Repository" = "https://github.com/canonical/charmlibs"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/nginx_k8s/CHANGELOG.md"

--- a/nginx_k8s/pyproject.toml
+++ b/nginx_k8s/pyproject.toml
@@ -33,7 +33,7 @@ integration = [
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/nginx_k8s/"
+"Documentation" = "https://canonical.com/juju/docs/charmlibsreference/charmlibs/nginx_k8s/"
 "Repository" = "https://github.com/canonical/charmlibs"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/nginx_k8s/CHANGELOG.md"


### PR DESCRIPTION
We recently moved Charmlibs docs to https://canonical.com/juju/docs/charmlibs/. The previous URLs redirect through, but it's best if we use the new destination URLs.

I haven't bumped the package versions - I'll leave that up to the Observability team.