### PR TITLE
docs: update Charmlibs URLs for sloth

### DIFF
--- a/interfaces/sloth/README.md
+++ b/interfaces/sloth/README.md
@@ -60,7 +60,7 @@ class SlothCharm(ops.CharmBase):
 
 ## Documentation
 
-For complete documentation, see the [charmlibs documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/interfaces/sloth).
+For complete documentation, see the [charmlibs documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/interfaces/sloth).
 
 ## Contributing
 


### PR DESCRIPTION
We recently moved Charmlibs docs to https://canonical.com/juju/docs/charmlibs/. The previous URLs redirect through, but it's best if we use the new destination URLs.

I haven't bumped the package version - I'll leave that up to the Tracing and Profiling team.