### PR TITLE
docs: update Charmlibs URLs for rollingops

### DIFF
--- a/rollingops/README.md
+++ b/rollingops/README.md
@@ -22,7 +22,7 @@ To install, add `charmlibs-rollingops` to your Python dependencies. Then in your
 from charmlibs import rollingops
 ```
 
-See the [reference documentation](https://documentation.ubuntu.com/charmlibs/reference/charmlibs/rollingops) for more.
+See the [reference documentation](https://canonical.com/juju/docs/charmlibs/reference/charmlibs/rollingops) for more.
 
 # Developing
 

--- a/rollingops/pyproject.toml
+++ b/rollingops/pyproject.toml
@@ -40,7 +40,7 @@ integration = [  # installed for `just integration rollingops`
 ]
 
 [project.urls]
-"Documentation" = "https://documentation.ubuntu.com/charmlibs/reference/charmlibs/rollingops"
+"Documentation" = "https://canonical.com/juju/docs/charmlibs/reference/charmlibs/rollingops"
 "Repository" = "https://github.com/canonical/charmlibs/tree/main/rollingops"
 "Issues" = "https://github.com/canonical/charmlibs/issues"
 "Changelog" = "https://github.com/canonical/charmlibs/blob/main/rollingops/CHANGELOG.md"


### PR DESCRIPTION
We recently moved Charmlibs docs to https://canonical.com/juju/docs/charmlibs/. The previous URLs redirect through, but it's best if we use the new destination URLs.

I haven't bumped the package version - I'll leave that up to the Data team.