### PR TITLE
ci: update workshop definitions

### DIFF
--- a/.workshop/jammy.yaml
+++ b/.workshop/jammy.yaml
@@ -2,7 +2,3 @@ name: jammy
 base: ubuntu@22.04
 sdks:
   - name: project-charmlibs
-actions:
-  functional: |
-    # Override Python with: workshop run --env PYTHON=python3.12 jammy -- functional ...
-    sudo just functional --python "${PYTHON:-python3}" "$@"

--- a/.workshop/noble.yaml
+++ b/.workshop/noble.yaml
@@ -2,7 +2,3 @@ name: noble
 base: ubuntu@24.04
 sdks:
   - name: project-charmlibs
-actions:
-  functional: |
-    # Override Python with: workshop run --env PYTHON=python3.12 noble -- functional ...
-    sudo just functional --python "${PYTHON:-python3}" "$@"

--- a/.workshop/resolute.yaml
+++ b/.workshop/resolute.yaml
@@ -2,7 +2,3 @@ name: resolute
 base: ubuntu@26.04
 sdks:
   - name: project-charmlibs
-actions:
-  functional: |
-    # Override Python with: workshop run --env PYTHON=python3.13 resolute -- functional ...
-    sudo just functional --python "${PYTHON:-python3}" "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,15 +134,15 @@ Read more: [types of tests in the charmlibs monorepo](https://documentation.ubun
 Functional tests often require `sudo` and may be destructive to the local environment (e.g. installing or removing system packages). **Never run functional tests directly on the host machine.** Always use [Workshop](https://snapcraft.io/workshop) to run them in an isolated container:
 
 ```bash
-workshop run resolute -- functional <package>    # Ubuntu 26.04
-workshop run noble -- functional <package>       # Ubuntu 24.04
-workshop run jammy -- functional <package>       # Ubuntu 22.04
+workshop exec resolute -- sudo just functional <package>    # Ubuntu 26.04
+workshop exec noble -- sudo just functional <package>       # Ubuntu 24.04
+workshop exec jammy -- sudo just functional <package>       # Ubuntu 22.04
 ```
 
-Workshop configs are defined in `.workshop/`. The `functional` action runs `sudo just functional "$@"` inside the VM. Extra pytest flags are passed through:
+Workshop configs are defined in `.workshop/`. Extra pytest flags are passed through to `just functional` (and on to pytest):
 
 ```bash
-workshop run noble -- functional snap -x -k test_install
+workshop exec noble -- sudo just functional snap -x -k test_install
 ```
 
 ## Commit and PR conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,12 +48,12 @@ just add pathops 'pydantic>=2'
 - `just functional <package>` runs functional tests, which interact with real external processes (but not Juju itself). Some functional test suites may require `sudo` access and may be destructive to the local environment (e.g. installing or removing system packages). Use [Workshop](https://snapcraft.io/workshop) to run them in an isolated container instead of running them directly on your host:
 
   ```bash
-  workshop run resolute -- functional <package>    # Ubuntu 26.04
-  workshop run noble -- functional <package>       # Ubuntu 24.04
-  workshop run jammy -- functional <package>       # Ubuntu 22.04
+  workshop exec resolute -- sudo just functional <package>    # Ubuntu 26.04
+  workshop exec noble -- sudo just functional <package>       # Ubuntu 24.04
+  workshop exec jammy -- sudo just functional <package>       # Ubuntu 22.04
   ```
 
-  Extra pytest flags are passed through, e.g. `workshop run noble -- functional snap -x -k test_install`. Workshop configs are in `.workshop/`.
+  Extra pytest flags are passed through, e.g. `workshop exec noble -- sudo just functional snap -x -k test_install`. Workshop configs are in `.workshop/`.
 
 - Integration tests involve packing real test charms and deploying them on a Juju cloud. Pack first with `just pack-k8s <package>` or `just pack-machine <package>`, then run `just integration-k8s <package>` or `just integration-machine <package>`.
 


### PR DESCRIPTION
I initially defined `functional` actions for all the workshops defined in this repository. This seemed like a convenient way to wrap up the need for `sudo` and also the `just python=... functional` justfile variable syntax for use. With the switch to using a regular option for the Python version, like `just functional --python=...` I'm not convinced that the actions provide value. This PR drops the action definitions and updates the docs accordingly.