### PR TITLE
ci: only print colours when appropriate

### DIFF
--- a/.scripts/just.py
+++ b/.scripts/just.py
@@ -50,32 +50,59 @@ TEST_REQUIREMENTS = REPO_ROOT / 'test-requirements.txt'
 
 DEFAULT_PYTHON = '3.10'
 
-# ANSI escape codes for formatting the messages.
-BOLD = '\033[1m'
-NORMAL = '\033[0m'
-CYAN = '\033[36m'
-# Quick start message printed when called with no arguments.
-QUICK_START = f"""
-{BOLD}Charmlibs is Canonical's charm library monorepo{NORMAL}
 
-{BOLD}List all commands with {CYAN}just help{NORMAL}{BOLD}, or:{NORMAL}
-- Create a new package: {CYAN}just init{NORMAL} or {CYAN}just init --interface{NORMAL}
-- Add a dependency to a package: {CYAN}just add <package> <dependency>{NORMAL}
-- Lint, unit test, and build docs for a package: {CYAN}just check <package>{NORMAL}
-- Run {CYAN}ruff{NORMAL} for all packages: {CYAN}just fast-lint{NORMAL}
+class Colors:
+    """ANSI escape codes for formatting messages, empty strings when color is disabled.
 
-{BOLD}Run individual checks for a package:{NORMAL}
-- {CYAN}just lint <package>{NORMAL} (fix errors with {CYAN}just format <package>{NORMAL})
-- {CYAN}just unit <package>{NORMAL}
-- {CYAN}just functional <package>{NORMAL} (may require extra software like {CYAN}pebble{NORMAL})
+    Whether color is enabled follows https://bixense.com/clicolors/: `NO_COLOR` disables color,
+    `CLICOLOR_FORCE` forces it on, otherwise color is only used when stdout is an interactive
+    terminal (so piped or redirected output stays plain text).
+    """
 
-{BOLD}Run integration tests{NORMAL} (requires a Juju controller and a cloud):
-- Pack: {CYAN}just pack-k8s <package>{NORMAL} or {CYAN}just pack-machine <package>{NORMAL}
-- Run: {CYAN}just integration-k8s <package>{NORMAL} or {CYAN}just integration-machine{NORMAL}
+    def __init__(self) -> None:
+        if self._enabled():
+            self.bold = '\033[1m'
+            self.normal = '\033[0m'
+            self.cyan = '\033[36m'
+        else:
+            self.bold = self.normal = self.cyan = ''
 
-{BOLD}Build the docs: {CYAN}just docs{NORMAL}
-- For specific packages only: {CYAN}just docs html <packages>{NORMAL}
+    @staticmethod
+    def _enabled() -> bool:
+        """Return whether to emit ANSI color codes."""
+        if os.environ.get('NO_COLOR'):
+            return False
+        if os.environ.get('CLICOLOR_FORCE'):
+            return True
+        return sys.stdout.isatty()
+
+
+def _quick_start() -> str:
+    """Return the quick start message printed when called with no arguments."""
+    c = Colors()
+    bold, normal, cyan = c.bold, c.normal, c.cyan
+    return f"""
+{bold}Charmlibs is Canonical's charm library monorepo{normal}
+
+{bold}List all commands with {cyan}just help{normal}{bold}, or:{normal}
+- Create a new package: {cyan}just init{normal} or {cyan}just init --interface{normal}
+- Add a dependency to a package: {cyan}just add <package> <dependency>{normal}
+- Lint, unit test, and build docs for a package: {cyan}just check <package>{normal}
+- Run {cyan}ruff{normal} for all packages: {cyan}just fast-lint{normal}
+
+{bold}Run individual checks for a package:{normal}
+- {cyan}just lint <package>{normal} (fix errors with {cyan}just format <package>{normal})
+- {cyan}just unit <package>{normal}
+- {cyan}just functional <package>{normal} (may require extra software like {cyan}pebble{normal})
+
+{bold}Run integration tests{normal} (requires a Juju controller and a cloud):
+- Pack: {cyan}just pack-k8s <package>{normal} or {cyan}just pack-machine <package>{normal}
+- Run: {cyan}just integration-k8s <package>{normal} or {cyan}just integration-machine{normal}
+
+{bold}Build the docs: {cyan}just docs{normal}
+- For specific packages only: {cyan}just docs html <packages>{normal}
 """.strip()
+
 
 # Mapping of recipe names to their functions, populated by the `_register` decorator.
 # `just help` prints the recipes in registration order.
@@ -90,13 +117,13 @@ def _register(fn: _F) -> _F:
 def main(argv: list[str]) -> int:
     """Dispatch `argv` to the named recipe, returning its exit code."""
     if not argv or argv[0] in ('-h', '--help'):
-        print(QUICK_START)
+        print(_quick_start())
         return 0
     name, *args = argv
     func = RECIPES.get(name)
     if func is None:
         print(f'Unknown recipe: {name!r}\n', file=sys.stderr)
-        print(QUICK_START)
+        print(_quick_start())
         return 2
     return func(args)
 
@@ -126,15 +153,16 @@ def init(argv: list[str]) -> int:
         help='Scaffold a charmlibs.interfaces package instead of a general charmlibs package.',
     )
     args, cookiecutter_args = parser.parse_known_args(argv)
+    c = Colors()
     if args.interface:
         print(
-            f'✨{BOLD}IMPORTANT{NORMAL}✨ The project name should be the canonical interface'
-            f' name, as used in {CYAN}charmcraft.yaml{NORMAL} files.'
+            f'✨{c.bold}IMPORTANT{c.normal}✨ The project name should be the canonical interface'
+            f' name, as used in {c.cyan}charmcraft.yaml{c.normal} files.'
         )
     else:
         print(
-            f'✨{BOLD}IMPORTANT{NORMAL}✨ The project name should be the import package name,'
-            f' without the {CYAN}charmlibs.{NORMAL} namespace.'
+            f'✨{c.bold}IMPORTANT{c.normal}✨ The project name should be the import package name,'
+            f' without the {c.cyan}charmlibs.{c.normal} namespace.'
         )
     print('You can press enter to accept the default, shown in brackets.')
     template = REPO_ROOT / '.template'

--- a/.scripts/just.py
+++ b/.scripts/just.py
@@ -77,8 +77,31 @@ class Colors:
         return sys.stdout.isatty()
 
 
+# Mapping of recipe names to their functions, populated by the `_register` decorator.
+# `just help` prints the recipes in registration order.
+RECIPES: dict[str, Callable[[list[str]], int]] = {}
+
+
+def _register(fn: _F) -> _F:
+    RECIPES[fn.__name__.removeprefix('_').replace('_', '-')] = fn
+    return fn
+
+
+def main(argv: list[str]) -> int:
+    """Dispatch `argv` to the named recipe, returning its exit code."""
+    if not argv or argv[0] in ('-h', '--help'):
+        print(_quick_start())
+        return 0
+    name, *args = argv
+    func = RECIPES.get(name)
+    if func is None:
+        print(f'Unknown recipe: {name!r}\n', file=sys.stderr)
+        print(_quick_start())
+        return 2
+    return func(args)
+
+
 def _quick_start() -> str:
-    """Return the quick start message printed when called with no arguments."""
     c = Colors()
     bold, normal, cyan = c.bold, c.normal, c.cyan
     return f"""
@@ -102,30 +125,6 @@ def _quick_start() -> str:
 {bold}Build the docs: {cyan}just docs{normal}
 - For specific packages only: {cyan}just docs html <packages>{normal}
 """.strip()
-
-
-# Mapping of recipe names to their functions, populated by the `_register` decorator.
-# `just help` prints the recipes in registration order.
-RECIPES: dict[str, Callable[[list[str]], int]] = {}
-
-
-def _register(fn: _F) -> _F:
-    RECIPES[fn.__name__.removeprefix('_').replace('_', '-')] = fn
-    return fn
-
-
-def main(argv: list[str]) -> int:
-    """Dispatch `argv` to the named recipe, returning its exit code."""
-    if not argv or argv[0] in ('-h', '--help'):
-        print(_quick_start())
-        return 0
-    name, *args = argv
-    func = RECIPES.get(name)
-    if func is None:
-        print(f'Unknown recipe: {name!r}\n', file=sys.stderr)
-        print(_quick_start())
-        return 2
-    return func(args)
 
 
 @_register

--- a/.scripts/just.py
+++ b/.scripts/just.py
@@ -103,27 +103,27 @@ def main(argv: list[str]) -> int:
 
 def _quick_start() -> str:
     c = Colors()
-    bold, normal, cyan = c.bold, c.normal, c.cyan
     return f"""
-{bold}Charmlibs is Canonical's charm library monorepo{normal}
+{c.bold}Charmlibs is Canonical's charm library monorepo{c.normal}
 
-{bold}List all commands with {cyan}just help{normal}{bold}, or:{normal}
-- Create a new package: {cyan}just init{normal} or {cyan}just init --interface{normal}
-- Add a dependency to a package: {cyan}just add <package> <dependency>{normal}
-- Lint, unit test, and build docs for a package: {cyan}just check <package>{normal}
-- Run {cyan}ruff{normal} for all packages: {cyan}just fast-lint{normal}
+{c.bold}List all commands with {c.cyan}just help{c.normal}{c.bold}, or:{c.normal}
+- Create a new package: {c.cyan}just init{c.normal} or {c.cyan}just init --interface{c.normal}
+- Add a dependency to a package: {c.cyan}just add <package> <dependency>{c.normal}
+- Lint, unit test, and build docs for a package: {c.cyan}just check <package>{c.normal}
+- Run {c.cyan}ruff{c.normal} for all packages: {c.cyan}just fast-lint{c.normal}
 
-{bold}Run individual checks for a package:{normal}
-- {cyan}just lint <package>{normal} (fix errors with {cyan}just format <package>{normal})
-- {cyan}just unit <package>{normal}
-- {cyan}just functional <package>{normal} (may require extra software like {cyan}pebble{normal})
+{c.bold}Run individual checks for a package:{c.normal}
+- {c.cyan}just lint <package>{c.normal} (fix errors with {c.cyan}just format <package>{c.normal})
+- {c.cyan}just unit <package>{c.normal}
+- {c.cyan}just functional <package>{c.normal} (may need sudo and additional software installed)
 
-{bold}Run integration tests{normal} (requires a Juju controller and a cloud):
-- Pack: {cyan}just pack-k8s <package>{normal} or {cyan}just pack-machine <package>{normal}
-- Run: {cyan}just integration-k8s <package>{normal} or {cyan}just integration-machine{normal}
+{c.bold}Run integration tests{c.normal} (requires a Juju controller and a cloud):
+- Pack: {c.cyan}just pack-k8s <package>{c.normal} or {c.cyan}just pack-machine <package>{c.normal}
+- Run (excluding machine_only tests): {c.cyan}just integration-k8s <package>{c.normal}
+- Run (excluding k8s_only tests): {c.cyan}just integration-machine <package>{c.normal}
 
-{bold}Build the docs: {cyan}just docs{normal}
-- For specific packages only: {cyan}just docs html <packages>{normal}
+{c.bold}Build the docs: {c.cyan}just docs{c.normal}
+- For specific packages only: {c.cyan}just docs html <packages>{c.normal}
 """.strip()
 
 

--- a/.scripts/just.py
+++ b/.scripts/just.py
@@ -65,9 +65,9 @@ class Colors:
     @staticmethod
     def _enabled() -> bool:
         """Return whether to emit ANSI color codes."""
-        if os.environ.get('NO_COLOR'):  # https://bixense.com/clicolors/
+        if os.environ.get('NO_COLOR'):  # https://no-color.org/ (present and non-empty)
             return False
-        if os.environ.get('FORCE_COLOR'):  # https://force-color.org/
+        if 'FORCE_COLOR' in os.environ:  # https://force-color.org/ (present, empty string ok)
             return True
         return sys.stdout.isatty()
 

--- a/.scripts/just.py
+++ b/.scripts/just.py
@@ -47,17 +47,12 @@ if typing.TYPE_CHECKING:
 # `.scripts/just.py` -> repo root is two parents up.
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 TEST_REQUIREMENTS = REPO_ROOT / 'test-requirements.txt'
-
+# The default Python version to use, and the minimum we'll run with.
 DEFAULT_PYTHON = '3.10'
 
 
 class Colors:
-    """ANSI escape codes for formatting messages, empty strings when color is disabled.
-
-    Whether color is enabled follows https://bixense.com/clicolors/: `NO_COLOR` disables color,
-    `CLICOLOR_FORCE` forces it on, otherwise color is only used when stdout is an interactive
-    terminal (so piped or redirected output stays plain text).
-    """
+    """ANSI escape codes for formatting messages, empty strings when color is disabled."""
 
     def __init__(self) -> None:
         if self._enabled():
@@ -70,21 +65,11 @@ class Colors:
     @staticmethod
     def _enabled() -> bool:
         """Return whether to emit ANSI color codes."""
-        if os.environ.get('NO_COLOR'):
+        if os.environ.get('NO_COLOR'):  # https://bixense.com/clicolors/
             return False
-        if os.environ.get('CLICOLOR_FORCE'):
+        if os.environ.get('FORCE_COLOR'):  # https://force-color.org/
             return True
         return sys.stdout.isatty()
-
-
-# Mapping of recipe names to their functions, populated by the `_register` decorator.
-# `just help` prints the recipes in registration order.
-RECIPES: dict[str, Callable[[list[str]], int]] = {}
-
-
-def _register(fn: _F) -> _F:
-    RECIPES[fn.__name__.removeprefix('_').replace('_', '-')] = fn
-    return fn
 
 
 def main(argv: list[str]) -> int:
@@ -99,6 +84,9 @@ def main(argv: list[str]) -> int:
         print(_quick_start())
         return 2
     return func(args)
+
+
+# --- Main --------------------------------------------------------------------------------------
 
 
 def _quick_start() -> str:
@@ -125,6 +113,18 @@ def _quick_start() -> str:
 {c.bold}Build the docs: {c.cyan}just docs{c.normal}
 - For specific packages only: {c.cyan}just docs html <packages>{c.normal}
 """.strip()
+
+
+# --- Recipes -----------------------------------------------------------------------------------
+
+# Mapping of recipe names to their functions, populated by the `_register` decorator.
+# `just help` prints the recipes in registration order.
+RECIPES: dict[str, Callable[[list[str]], int]] = {}
+
+
+def _register(fn: _F) -> _F:
+    RECIPES[fn.__name__.removeprefix('_').replace('_', '-')] = fn
+    return fn
 
 
 @_register

--- a/.scripts/just.py
+++ b/.scripts/just.py
@@ -72,6 +72,9 @@ class Colors:
         return sys.stdout.isatty()
 
 
+# --- Main --------------------------------------------------------------------------------------
+
+
 def main(argv: list[str]) -> int:
     """Dispatch `argv` to the named recipe, returning its exit code."""
     if not argv or argv[0] in ('-h', '--help'):
@@ -84,9 +87,6 @@ def main(argv: list[str]) -> int:
         print(_quick_start())
         return 2
     return func(args)
-
-
-# --- Main --------------------------------------------------------------------------------------
 
 
 def _quick_start() -> str:

--- a/.scripts/just.py
+++ b/.scripts/just.py
@@ -65,10 +65,10 @@ class Colors:
     @staticmethod
     def _enabled() -> bool:
         """Return whether to emit ANSI color codes."""
-        if os.environ.get('NO_COLOR'):  # https://no-color.org/ (present and non-empty)
-            return False
-        if 'FORCE_COLOR' in os.environ:  # https://force-color.org/ (present, empty string ok)
+        if (force := os.environ.get('FORCE_COLOR')) and force != '0':
             return True
+        if (no := os.environ.get('NO_COLOR')) and no != '0':
+            return False
         return sys.stdout.isatty()
 
 

--- a/.scripts/tests/test_just.py
+++ b/.scripts/tests/test_just.py
@@ -157,24 +157,37 @@ class TestCoverageCmds:
 class TestColorsEnabled:
     def test_no_color_disables(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setenv('NO_COLOR', '1')
-        monkeypatch.setenv('CLICOLOR_FORCE', '1')  # NO_COLOR takes precedence.
+        monkeypatch.setenv('FORCE_COLOR', '1')  # NO_COLOR takes precedence.
         assert just.Colors._enabled() is False
 
-    def test_clicolor_force_enables(self, monkeypatch: pytest.MonkeyPatch):
+    def test_empty_no_color_does_not_disable(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv('NO_COLOR', '')  # Empty NO_COLOR is ignored per no-color.org.
+        monkeypatch.delenv('FORCE_COLOR', raising=False)
+        with patch('sys.stdout.isatty', return_value=True):
+            assert just.Colors._enabled() is True
+
+    def test_force_color_enables(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv('NO_COLOR', raising=False)
-        monkeypatch.setenv('CLICOLOR_FORCE', '1')
+        monkeypatch.setenv('FORCE_COLOR', '1')
+        with patch('sys.stdout.isatty', return_value=False):
+            assert just.Colors._enabled() is True
+
+    def test_empty_force_color_enables(self, monkeypatch: pytest.MonkeyPatch):
+        # Empty FORCE_COLOR still forces color on, per force-color.org.
+        monkeypatch.delenv('NO_COLOR', raising=False)
+        monkeypatch.setenv('FORCE_COLOR', '')
         with patch('sys.stdout.isatty', return_value=False):
             assert just.Colors._enabled() is True
 
     def test_tty_enables(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv('NO_COLOR', raising=False)
-        monkeypatch.delenv('CLICOLOR_FORCE', raising=False)
+        monkeypatch.delenv('FORCE_COLOR', raising=False)
         with patch('sys.stdout.isatty', return_value=True):
             assert just.Colors._enabled() is True
 
     def test_non_tty_disables(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.delenv('NO_COLOR', raising=False)
-        monkeypatch.delenv('CLICOLOR_FORCE', raising=False)
+        monkeypatch.delenv('FORCE_COLOR', raising=False)
         with patch('sys.stdout.isatty', return_value=False):
             assert just.Colors._enabled() is False
 

--- a/.scripts/tests/test_just.py
+++ b/.scripts/tests/test_just.py
@@ -154,6 +154,57 @@ class TestCoverageCmds:
         assert '--data-file=.report/coverage-fakesuite-fakepy.db' in report_cmd
 
 
+class TestColorsEnabled:
+    def test_no_color_disables(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv('NO_COLOR', '1')
+        monkeypatch.setenv('CLICOLOR_FORCE', '1')  # NO_COLOR takes precedence.
+        assert just.Colors._enabled() is False
+
+    def test_clicolor_force_enables(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv('NO_COLOR', raising=False)
+        monkeypatch.setenv('CLICOLOR_FORCE', '1')
+        with patch('sys.stdout.isatty', return_value=False):
+            assert just.Colors._enabled() is True
+
+    def test_tty_enables(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv('NO_COLOR', raising=False)
+        monkeypatch.delenv('CLICOLOR_FORCE', raising=False)
+        with patch('sys.stdout.isatty', return_value=True):
+            assert just.Colors._enabled() is True
+
+    def test_non_tty_disables(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.delenv('NO_COLOR', raising=False)
+        monkeypatch.delenv('CLICOLOR_FORCE', raising=False)
+        with patch('sys.stdout.isatty', return_value=False):
+            assert just.Colors._enabled() is False
+
+
+class TestColors:
+    def test_enabled(self):
+        with patch('just.Colors._enabled', return_value=True):
+            colors = just.Colors()
+        assert (colors.bold, colors.normal, colors.cyan) == ('\033[1m', '\033[0m', '\033[36m')
+
+    def test_disabled(self):
+        with patch('just.Colors._enabled', return_value=False):
+            colors = just.Colors()
+        assert (colors.bold, colors.normal, colors.cyan) == ('', '', '')
+
+
+class TestQuickStart:
+    def test_with_colors(self):
+        with patch('just.Colors._enabled', return_value=True):
+            message = just._quick_start()
+        assert '\033[' in message
+        assert 'just help' in message
+
+    def test_without_colors(self):
+        with patch('just.Colors._enabled', return_value=False):
+            message = just._quick_start()
+        assert '\033[' not in message
+        assert 'just help' in message
+
+
 class TestMain:
     def test_ok(self):
         result = just.main(['help'])

--- a/.scripts/tests/test_just.py
+++ b/.scripts/tests/test_just.py
@@ -154,68 +154,64 @@ class TestCoverageCmds:
         assert '--data-file=.report/coverage-fakesuite-fakepy.db' in report_cmd
 
 
-class TestColorsEnabled:
-    def test_no_color_disables(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv('NO_COLOR', '1')
-        monkeypatch.setenv('FORCE_COLOR', '1')  # NO_COLOR takes precedence.
+class TestColors:
+    @pytest.mark.parametrize('no_color', ['1', 'anything'])
+    def test_no_color_alone_disables(self, monkeypatch: pytest.MonkeyPatch, no_color: str):
+        monkeypatch.delenv('FORCE_COLOR', raising=False)
+        monkeypatch.setenv('NO_COLOR', no_color)
         assert just.Colors._enabled() is False
 
-    def test_empty_no_color_does_not_disable(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv('NO_COLOR', '')  # Empty NO_COLOR is ignored per no-color.org.
+    @pytest.mark.parametrize('no_color', ['', '0'])
+    def test_falsy_no_color_does_not_disable(self, monkeypatch: pytest.MonkeyPatch, no_color: str):
         monkeypatch.delenv('FORCE_COLOR', raising=False)
+        monkeypatch.setenv('NO_COLOR', no_color)
         with patch('sys.stdout.isatty', return_value=True):
             assert just.Colors._enabled() is True
 
-    def test_force_color_enables(self, monkeypatch: pytest.MonkeyPatch):
+    @pytest.mark.parametrize('force_color', ['1', 'anything'])
+    def test_force_color_alone_enables(self, monkeypatch: pytest.MonkeyPatch, force_color: str):
         monkeypatch.delenv('NO_COLOR', raising=False)
-        monkeypatch.setenv('FORCE_COLOR', '1')
+        monkeypatch.setenv('FORCE_COLOR', force_color)
         with patch('sys.stdout.isatty', return_value=False):
             assert just.Colors._enabled() is True
 
-    def test_empty_force_color_enables(self, monkeypatch: pytest.MonkeyPatch):
-        # Empty FORCE_COLOR still forces color on, per force-color.org.
+    @pytest.mark.parametrize('force_color', ['', '0'])
+    def test_falsy_force_color_does_not_enable(self, monkeypatch: pytest.MonkeyPatch, force_color: str):
         monkeypatch.delenv('NO_COLOR', raising=False)
-        monkeypatch.setenv('FORCE_COLOR', '')
-        with patch('sys.stdout.isatty', return_value=False):
-            assert just.Colors._enabled() is True
-
-    def test_tty_enables(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.delenv('NO_COLOR', raising=False)
-        monkeypatch.delenv('FORCE_COLOR', raising=False)
-        with patch('sys.stdout.isatty', return_value=True):
-            assert just.Colors._enabled() is True
-
-    def test_non_tty_disables(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.delenv('NO_COLOR', raising=False)
-        monkeypatch.delenv('FORCE_COLOR', raising=False)
+        monkeypatch.setenv('FORCE_COLOR', force_color)
         with patch('sys.stdout.isatty', return_value=False):
             assert just.Colors._enabled() is False
 
+    @pytest.mark.parametrize('force_color', ['1', ''])
+    @pytest.mark.parametrize('no_color', ['1', ''])
+    def test_force_color_overrides_no_color(self, monkeypatch: pytest.MonkeyPatch, force_color: str, no_color: str):
+        monkeypatch.setenv('NO_COLOR', no_color)
+        monkeypatch.setenv('FORCE_COLOR', force_color)
+        with patch('sys.stdout.isatty', return_value=False):
+            assert just.Colors._enabled() is bool(force_color)
 
-class TestColors:
+    @pytest.mark.parametrize('isatty', [True, False])
+    def test_isatty(self, monkeypatch: pytest.MonkeyPatch, isatty: bool):
+        monkeypatch.delenv('NO_COLOR', raising=False)
+        monkeypatch.delenv('FORCE_COLOR', raising=False)
+        with patch('sys.stdout.isatty', return_value=isatty):
+            assert just.Colors._enabled() is isatty
+
     def test_enabled(self):
         with patch('just.Colors._enabled', return_value=True):
             colors = just.Colors()
-        assert (colors.bold, colors.normal, colors.cyan) == ('\033[1m', '\033[0m', '\033[36m')
+            message = just._quick_start()
+        assert all((colors.bold, colors.normal, colors.cyan))
+        assert 'just help' in message  # Correct message.
+        assert '\033[' in message  # With colors.
 
     def test_disabled(self):
         with patch('just.Colors._enabled', return_value=False):
             colors = just.Colors()
-        assert (colors.bold, colors.normal, colors.cyan) == ('', '', '')
-
-
-class TestQuickStart:
-    def test_with_colors(self):
-        with patch('just.Colors._enabled', return_value=True):
             message = just._quick_start()
-        assert '\033[' in message
-        assert 'just help' in message
-
-    def test_without_colors(self):
-        with patch('just.Colors._enabled', return_value=False):
-            message = just._quick_start()
-        assert '\033[' not in message
-        assert 'just help' in message
+        assert not any((colors.bold, colors.normal, colors.cyan))
+        assert 'just help' in message  # Correct message.
+        assert '\033[' not in message  # No colors.
 
 
 class TestMain:

--- a/.scripts/tests/test_just.py
+++ b/.scripts/tests/test_just.py
@@ -176,7 +176,9 @@ class TestColors:
             assert just.Colors._enabled() is True
 
     @pytest.mark.parametrize('force_color', ['', '0'])
-    def test_falsy_force_color_does_not_enable(self, monkeypatch: pytest.MonkeyPatch, force_color: str):
+    def test_falsy_force_color_does_not_enable(
+        self, monkeypatch: pytest.MonkeyPatch, force_color: str
+    ):
         monkeypatch.delenv('NO_COLOR', raising=False)
         monkeypatch.setenv('FORCE_COLOR', force_color)
         with patch('sys.stdout.isatty', return_value=False):
@@ -184,7 +186,9 @@ class TestColors:
 
     @pytest.mark.parametrize('force_color', ['1', ''])
     @pytest.mark.parametrize('no_color', ['1', ''])
-    def test_force_color_overrides_no_color(self, monkeypatch: pytest.MonkeyPatch, force_color: str, no_color: str):
+    def test_force_color_overrides_no_color(
+        self, monkeypatch: pytest.MonkeyPatch, force_color: str, no_color: str
+    ):
         monkeypatch.setenv('NO_COLOR', no_color)
         monkeypatch.setenv('FORCE_COLOR', force_color)
         with patch('sys.stdout.isatty', return_value=False):


### PR DESCRIPTION
This PR updates `just.py` to emit ANSI colour codes only when `FORCE_COLOR` is set or the output is a TTY.

Resolves #523.