### PR TITLE
docs: document the docs build process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,69 @@ just add pathops 'pydantic>=2'
 
 Read more: [the different types of tests](https://canonical.com/juju/docs/charmlibs/explanation/charmlibs-tests/).
 
+# Documentation
+
+The documentation site published at [canonical.com/juju/docs/charmlibs](https://canonical.com/juju/docs/charmlibs) is built with [Sphinx](https://www.sphinx-doc.org/) from the source in the `.docs/` directory. It combines two kinds of content:
+
+- **Hand-written diataxis pages** (tutorials, how-to guides, and explanations) authored in `.docs/`, plus per-library pages that live in each library's own `docs/` directory.
+- **Reference docs** generated automatically from your library's docstrings via Sphinx [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html). The module docstring in your package's `__init__.py` becomes the top-level description for that library's reference page.
+
+## Building the docs
+
+All docs commands are exposed under the `docs` module of `just`. Run `just docs help` to list them.
+
+```bash
+just docs html <package>   # build docs, generating reference docs for <package> only (fast)
+just docs html             # build everything, including reference docs for all packages
+just docs                  # alias for `just docs html`
+just docs html -           # build the site with no package reference docs (fastest; for editing prose only)
+```
+
+`just docs html <package>` is also run as part of `just check <package>`, so building the reference docs for your library happens automatically when you run the standard pre-commit check.
+
+The built site is written to `.docs/_build/html` by default (or to `$READTHEDOCS_OUTPUT` in CI).
+
+## How the build works
+
+The build is intentionally multi-pass, because different libraries can have conflicting dependencies and we can't install them all into a single Sphinx environment:
+
+1. **Diataxis preprocessing.** The `.docs/scripts/diataxis_preprocessor.py` script runs first. It walks every library, copies any `docs/` pages into the Sphinx source tree, and generates the `_lib-*.md` toctree include files that the category index pages pull in.
+2. **Per-package reference passes.** `sphinx-build` is invoked once per package, each time with that package installed into an isolated `uvx` environment and the `package=<name>` config option set. Each pass runs autodoc against a single library and saves its resolved doctree and index information to disk. Reference warnings are suppressed during these passes because cross-references to other libraries aren't available yet.
+3. **Final combined pass.** A final `sphinx-build` runs with no `package` set. It restores the per-package reference docs saved in step 2, combines them with the hand-written pages, and produces the complete HTML site (and `llms.txt`).
+
+The logic for steps 2 and 3 lives in the local Sphinx extensions under `.docs/extensions/` (notably `package_docs.py` and `interface_docs.py`), which are registered in `.docs/conf.py`. Docs dependencies are pinned in `.docs/_dev/requirements.txt`.
+
+## Working on the docs
+
+To preview prose changes with live reload, use:
+
+```bash
+just docs run    # watch, build, and serve; does not rebuild package reference docs automatically
+```
+
+Other useful checks:
+
+```bash
+just docs linkcheck   # check for broken links
+just docs spelling    # flag US-English misspellings not in the custom wordlist
+just docs vale        # check Canonical style guide compliance (errors only)
+just docs woke        # check for non-inclusive language
+just docs clean       # remove files created by building the docs
+```
+
+The local Sphinx extensions have their own tests and type checks:
+
+```bash
+just docs ext-unit     # run unit tests for the local extensions
+just docs ext-static   # run pyright over the local extensions
+```
+
+## Writing reference docstrings
+
+Reference docs are generated from docstrings, so anything you write in your public API's docstrings appears verbatim in the published reference. Keep them informative for library users rather than implementation notes. When adding cross-reference sections like "Read more", use bare text (for example, ``Read more: {ref}`how-to-customize-integration-tests` ``) rather than block quotes.
+
+For adding tutorials, how-to guides, and explanations specific to your library, see the [how-to guide for adding docs to a library](https://canonical.com/juju/docs/charmlibs/how-to/add-library-docs/).
+
 # Pull requests
 
 PRs are squash-merged, so your PR title becomes the single commit message that lands on `main`. Commit messages on your branch don't need to follow any particular format.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ The documentation site published at [canonical.com/juju/docs/charmlibs](https://
 
 - **Hand-written diataxis pages** (tutorials, how-to guides, and explanations) authored in `.docs/`, plus per-library pages that live in each library's own `docs/` directory.
 - **Reference docs** generated automatically from your library's docstrings via Sphinx [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html). The module docstring in your package's `__init__.py` becomes the top-level description for that library's reference page.
-- **Interface specification docs** generated from the versioned `README.md` files in each interface's `interface/vN/` directory. These describe the relation interface contract itself (separately from the `charmlibs.interfaces` Python package reference, which is generated from docstrings like any other library).
+- **Interface specification docs** generated from the versioned `README.md` files in each interface's `interface/` directory. These describe the relation interface contract itself (separately from the `charmlibs.interfaces` Python package reference, which is generated from docstrings like any other library).
 
 ## Building the docs
 
@@ -99,8 +99,6 @@ just docs html -           # build the site with no package reference docs (fast
 
 `just docs html <package>` is also run as part of `just check <package>`, so building the reference docs for your library happens automatically when you run the standard pre-commit check.
 
-The built site is written to `.docs/_build/html` by default (or to `$READTHEDOCS_OUTPUT` in CI).
-
 ## How the build works
 
 The build is intentionally multi-pass, because different libraries can have conflicting dependencies and we can't install them all into a single Sphinx environment:
@@ -112,37 +110,20 @@ The build is intentionally multi-pass, because different libraries can have conf
 The logic for steps 2 and 3 lives in the local Sphinx extensions under `.docs/extensions/`, which are registered in `.docs/conf.py`. In particular:
 
 - `package_docs.py` drives the per-package autodoc passes and saves/restores each library's reference doctree.
-- `interface_docs.py` generates the interface specification pages. During the final pass it reads each interface's `interface/vN/README.md`, rewrites relative links to point at the repo on GitHub, and writes one page per interface version under `reference/interfaces/`. During the per-package passes it only writes a placeholder so the toctree glob doesn't fail.
+- `interface_docs.py` generates the interface specification pages. During the final pass it reads the interface `README.md` files, rewrites relative links to point at the repo on GitHub, and writes the pages under `reference/interfaces/`. (During the per-package passes it only writes a placeholder so the toctree glob doesn't fail.)
 
-Docs dependencies are pinned in `.docs/_dev/requirements.txt`.
+## Writing library docs
 
-## Working on the docs
-
-To preview prose changes with live reload, use:
-
-```bash
-just docs run    # watch, build, and serve; does not rebuild package reference docs automatically
-```
-
-Other useful checks:
-
-```bash
-just docs linkcheck   # check for broken links
-just docs spelling    # flag US-English misspellings not in the custom wordlist
-just docs vale        # check Canonical style guide compliance (errors only)
-just docs woke        # check for non-inclusive language
-just docs clean       # remove files created by building the docs
-```
-
-The local Sphinx extensions have their own tests and type checks:
-
-```bash
-just docs ext-unit     # run unit tests for the local extensions
-just docs ext-static   # run pyright over the local extensions
-```
-
-## Writing reference docstrings
-
-Reference docs are generated from docstrings, so anything you write in your public API's docstrings appears verbatim in the published reference. Keep them informative for library users rather than implementation notes. When adding cross-reference sections like "Read more", use bare text (for example, ``Read more: {ref}`how-to-customize-integration-tests` ``) rather than block quotes.
+Reference docs are generated from docstrings, so anything you write in your public API's docstrings appears verbatim in the published reference. Keep them informative for library users rather than implementation notes.
 
 For adding tutorials, how-to guides, and explanations specific to your library, see the [how-to guide for adding docs to a library](https://canonical.com/juju/docs/charmlibs/how-to/add-library-docs/).
+
+## Working on the docs extensions
+
+The local Sphinx extensions are covered by linting, and have their own tests and static analysis:
+
+```bash
+just fast-lint .docs   # run ruff for content under .docs/
+just docs ext-unit     # run unit tests under .docs/tests
+just docs ext-static   # run pyright over the local Sphinx extensions and tests
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,25 @@ just add pathops 'pydantic>=2'
 
 Read more: [the different types of tests](https://canonical.com/juju/docs/charmlibs/explanation/charmlibs-tests/).
 
+# Pull requests
+
+PRs are squash-merged, so your PR title becomes the single commit message that lands on `main`. Commit messages on your branch don't need to follow any particular format.
+
+PR titles must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). When a PR affects a single library, use the distribution package name without the leading `charmlibs-` or `charmlibs-interfaces` as the scope:
+
+```
+feat(pathops): add copytree and rmtree
+chore(tls-certificates): update to Pydantic v2
+```
+
+## Versioning and releases
+
+Libraries are automatically published to PyPI when a merged PR bumps the version to a non-dev version. Dev versions (like `1.0.0.dev0`) are excluded from the release CI, so you can safely merge in-progress work with a dev version.
+
+Any PR that would trigger a release must also update the library's `CHANGELOG.md` — CI will block the merge otherwise.
+
+Read more: [publishing packages from the monorepo](https://canonical.com/juju/docs/charmlibs/explanation/charmlibs-publishing/).
+
 # Documentation
 
 The documentation site published at [canonical.com/juju/docs/charmlibs](https://canonical.com/juju/docs/charmlibs) is built with [Sphinx](https://www.sphinx-doc.org/) from the source in the `.docs/` directory. It combines three kinds of content:
@@ -127,22 +146,3 @@ just docs ext-static   # run pyright over the local extensions
 Reference docs are generated from docstrings, so anything you write in your public API's docstrings appears verbatim in the published reference. Keep them informative for library users rather than implementation notes. When adding cross-reference sections like "Read more", use bare text (for example, ``Read more: {ref}`how-to-customize-integration-tests` ``) rather than block quotes.
 
 For adding tutorials, how-to guides, and explanations specific to your library, see the [how-to guide for adding docs to a library](https://canonical.com/juju/docs/charmlibs/how-to/add-library-docs/).
-
-# Pull requests
-
-PRs are squash-merged, so your PR title becomes the single commit message that lands on `main`. Commit messages on your branch don't need to follow any particular format.
-
-PR titles must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). When a PR affects a single library, use the distribution package name without the leading `charmlibs-` or `charmlibs-interfaces` as the scope:
-
-```
-feat(pathops): add copytree and rmtree
-chore(tls-certificates): update to Pydantic v2
-```
-
-## Versioning and releases
-
-Libraries are automatically published to PyPI when a merged PR bumps the version to a non-dev version. Dev versions (like `1.0.0.dev0`) are excluded from the release CI, so you can safely merge in-progress work with a dev version.
-
-Any PR that would trigger a release must also update the library's `CHANGELOG.md` — CI will block the merge otherwise.
-
-Read more: [publishing packages from the monorepo](https://canonical.com/juju/docs/charmlibs/explanation/charmlibs-publishing/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,11 @@ Read more: [the different types of tests](https://canonical.com/juju/docs/charml
 
 # Documentation
 
-The documentation site published at [canonical.com/juju/docs/charmlibs](https://canonical.com/juju/docs/charmlibs) is built with [Sphinx](https://www.sphinx-doc.org/) from the source in the `.docs/` directory. It combines two kinds of content:
+The documentation site published at [canonical.com/juju/docs/charmlibs](https://canonical.com/juju/docs/charmlibs) is built with [Sphinx](https://www.sphinx-doc.org/) from the source in the `.docs/` directory. It combines three kinds of content:
 
 - **Hand-written diataxis pages** (tutorials, how-to guides, and explanations) authored in `.docs/`, plus per-library pages that live in each library's own `docs/` directory.
 - **Reference docs** generated automatically from your library's docstrings via Sphinx [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html). The module docstring in your package's `__init__.py` becomes the top-level description for that library's reference page.
+- **Interface specification docs** generated from the versioned `README.md` files in each interface's `interface/vN/` directory. These describe the relation interface contract itself (separately from the `charmlibs.interfaces` Python package reference, which is generated from docstrings like any other library).
 
 ## Building the docs
 
@@ -87,9 +88,14 @@ The build is intentionally multi-pass, because different libraries can have conf
 
 1. **Diataxis preprocessing.** The `.docs/scripts/diataxis_preprocessor.py` script runs first. It walks every library, copies any `docs/` pages into the Sphinx source tree, and generates the `_lib-*.md` toctree include files that the category index pages pull in.
 2. **Per-package reference passes.** `sphinx-build` is invoked once per package, each time with that package installed into an isolated `uvx` environment and the `package=<name>` config option set. Each pass runs autodoc against a single library and saves its resolved doctree and index information to disk. Reference warnings are suppressed during these passes because cross-references to other libraries aren't available yet.
-3. **Final combined pass.** A final `sphinx-build` runs with no `package` set. It restores the per-package reference docs saved in step 2, combines them with the hand-written pages, and produces the complete HTML site (and `llms.txt`).
+3. **Final combined pass.** A final `sphinx-build` runs with no `package` set. It restores the per-package reference docs saved in step 2, generates the interface specification pages, combines everything with the hand-written pages, and produces the complete HTML site (and `llms.txt`).
 
-The logic for steps 2 and 3 lives in the local Sphinx extensions under `.docs/extensions/` (notably `package_docs.py` and `interface_docs.py`), which are registered in `.docs/conf.py`. Docs dependencies are pinned in `.docs/_dev/requirements.txt`.
+The logic for steps 2 and 3 lives in the local Sphinx extensions under `.docs/extensions/`, which are registered in `.docs/conf.py`. In particular:
+
+- `package_docs.py` drives the per-package autodoc passes and saves/restores each library's reference doctree.
+- `interface_docs.py` generates the interface specification pages. During the final pass it reads each interface's `interface/vN/README.md`, rewrites relative links to point at the repo on GitHub, and writes one page per interface version under `reference/interfaces/`. During the per-package passes it only writes a placeholder so the toctree glob doesn't fail.
+
+Docs dependencies are pinned in `.docs/_dev/requirements.txt`.
 
 ## Working on the docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,11 +80,11 @@ Read more: [publishing packages from the monorepo](https://canonical.com/juju/do
 
 # Documentation
 
-The documentation site published at [canonical.com/juju/docs/charmlibs](https://canonical.com/juju/docs/charmlibs) is built with [Sphinx](https://www.sphinx-doc.org/) from the source in the `.docs/` directory. It combines three kinds of content:
+The documentation site published at [canonical.com/juju/docs/charmlibs](https://canonical.com/juju/docs/charmlibs) uses a custom build process on top of [canonical/sphinx-stack]( https://github.com/canonical/sphinx-stack). It combines three kinds of content:
 
-- **Hand-written diataxis pages** (tutorials, how-to guides, and explanations) authored in `.docs/`, plus per-library pages that live in each library's own `docs/` directory.
+- **Hand-written Diataxis pages** (tutorials, how-to guides, and explanations) authored in `.docs/`, plus per-library pages that live in each library's own `docs/` directory.
 - **Reference docs** generated automatically from your library's docstrings via Sphinx [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html). The module docstring in your package's `__init__.py` becomes the top-level description for that library's reference page.
-- **Interface specification docs** generated from the versioned `README.md` files in each interface's `interface/` directory. These describe the relation interface contract itself (separately from the `charmlibs.interfaces` Python package reference, which is generated from docstrings like any other library).
+- **Interface specification docs** generated from the `README.md` files in each interface's `interface/` directory. These describe the relation interface contract itself (separately from the `charmlibs.interfaces` Python package reference, which is generated from docstrings like any other library).
 
 ## Building the docs
 
@@ -94,7 +94,7 @@ All docs commands are exposed under the `docs` module of `just`. Run `just docs 
 just docs html <package>   # build docs, generating reference docs for <package> only (fast)
 just docs html             # build everything, including reference docs for all packages
 just docs                  # alias for `just docs html`
-just docs html -           # build the site with no package reference docs (fastest; for editing prose only)
+just docs html -           # build the site with no package reference docs (fastest; for Diataxis docs only)
 ```
 
 `just docs html <package>` is also run as part of `just check <package>`, so building the reference docs for your library happens automatically when you run the standard pre-commit check.
@@ -124,6 +124,6 @@ The local Sphinx extensions are covered by linting, and have their own tests and
 
 ```bash
 just fast-lint .docs   # run ruff for content under .docs/
-just docs ext-unit     # run unit tests under .docs/tests
+just docs ext-unit     # run unit tests under .docs/tests/
 just docs ext-static   # run pyright over the local Sphinx extensions and tests
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,12 @@ The documentation site published at [canonical.com/juju/docs/charmlibs](https://
 - **Reference docs** generated automatically from your library's docstrings via Sphinx [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html). The module docstring in your package's `__init__.py` becomes the top-level description for that library's reference page.
 - **Interface specification docs** generated from the `README.md` files in each interface's `interface/` directory. These describe the relation interface contract itself (separately from the `charmlibs.interfaces` Python package reference, which is generated from docstrings like any other library).
 
+## Writing library docs
+
+Reference docs are generated from docstrings, so anything you write in your public API's docstrings appears verbatim in the published reference. Keep them informative for library users rather than implementation notes.
+
+For adding tutorials, how-to guides, and explanations specific to your library, see the [how-to guide for adding docs to a library](https://canonical.com/juju/docs/charmlibs/how-to/add-library-docs/).
+
 ## Building the docs
 
 All docs commands are exposed under the `docs` module of `just`. Run `just docs help` to list them.
@@ -111,12 +117,6 @@ The logic for steps 2 and 3 lives in the local Sphinx extensions under `.docs/ex
 
 - `package_docs.py` drives the per-package autodoc passes and saves/restores each library's reference doctree.
 - `interface_docs.py` generates the interface specification pages. During the final pass it reads the interface `README.md` files, rewrites relative links to point at the repo on GitHub, and writes the pages under `reference/interfaces/`. (During the per-package passes it only writes a placeholder so the toctree glob doesn't fail.)
-
-## Writing library docs
-
-Reference docs are generated from docstrings, so anything you write in your public API's docstrings appears verbatim in the published reference. Keep them informative for library users rather than implementation notes.
-
-For adding tutorials, how-to guides, and explanations specific to your library, see the [how-to guide for adding docs to a library](https://canonical.com/juju/docs/charmlibs/how-to/add-library-docs/).
 
 ## Working on the docs extensions
 


### PR DESCRIPTION
This PR documents the documentation build process, in `CONTRIBUTING.md`.

Resolves #237.