### PR TITLE
chore: add Code of Conduct linking to Ubuntu CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This project follows the [Ubuntu Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct).


### PR DESCRIPTION
Adds a short CoC in the style we're using across Charm Tech repos. I figure this applies to anyone who hosts a library in the monorepo.