### PR TITLE
ci: use charmcraft latest/stable (default) instead of 3.x/stable

### DIFF
--- a/.github/workflows/test-package.yaml
+++ b/.github/workflows/test-package.yaml
@@ -220,11 +220,11 @@ jobs:
 
       - name: Prepare Juju for microk8s
         if: ${{ matrix.substrate == 'k8s' }}
-        run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=3.x/stable -p microk8s
+        run: sudo concierge prepare --verbose --juju-channel=3/stable -p microk8s
 
       - name: Prepare Juju for machine
         if: ${{ matrix.substrate == 'machine' }}
-        run: sudo concierge prepare --verbose --juju-channel=3/stable --charmcraft-channel=3.x/stable -p machine
+        run: sudo concierge prepare --verbose --juju-channel=3/stable -p machine
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
This PR updates CI to stop specifying the Charmcraft channel `3.x/stable` for Concierge to install Charmcraft from. Charmcraft 4 was released some time ago, and has had stable releases, and we should use that instead.

This PR was prompted by a regular failure we saw in CI where `charmcraft pack` would sometimes fail with this output (as also reported in https://github.com/canonical/charmcraft/issues/2515):
```
Launching managed ubuntu 22.04 instance...
Creating new instance from remote
Creating new base instance from remote
Failed to wait for snap refreshes to complete.
* Command that failed: "lxc --project charmcraft exec local:base-instance-charmcraft-buildd-base-v7--910533fdd664bd2cdbe9 -- env CRAFT_MANAGED_MODE=1 CHARMCRAFT_MANAGED_MODE=1 DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true DEBIAN_PRIORITY=critical snap watch '--last=auto-refresh?'"
* Command exit code: 1
* Command standard error output: b'error: daemon is stopping to wait for socket activation\n'
```
This is should be fixed as of Charmcraft 4.2.0 (and `latest/stable` is currently 4.2.2).

Looking at this CI made me release that we should also be testing on Juju 4 (either instead of or as well as 3.6), and that we should switch from `microk8s` to Canonical K8s for our K8s substrate tests. I've created #576 and #577 for these.