### PR TITLE
fix(tls): migrate secrets to new label

### DIFF
--- a/interfaces/tls-certificates/CHANGELOG.md
+++ b/interfaces/tls-certificates/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.9.0 - 6 July 2026
+
+Store the `Mode.APP` private key under a new secret label and automatically migrate keys created by older versions (including pre-existing unit-owned keys) to an app-owned secret. The key material is preserved, so certificates are not regenerated on upgrade.
+
 # 1.8.3 - 5 June 2026
 
 Add a safety net to ensure expiring certificates are renewed even if the charm fails to trigger the renewal process.

--- a/interfaces/tls-certificates/pyproject.toml
+++ b/interfaces/tls-certificates/pyproject.toml
@@ -81,6 +81,9 @@ include = ["src", "tests", "interface"]
 pythonVersion = "3.10"  # check no python > 3.10 features are used
 ignore = [
     "tests/integration/charms/*/published/src/charmlibs",
+    # imports the Charmhub-hosted lib, which is only present in the packed charm
+    "tests/integration/charms/requirer/fetch_lib_charm.py",
+    "tests/integration/charms/requirer/fetch-lib-*",
 ]
 
 [tool.pytest.ini_options]

--- a/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_backwards_compatibility.py
+++ b/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_backwards_compatibility.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Canonical Ltd.
+
+"""Backwards-compatibility shims for deployments created by older library versions.
+
+This module is the single home for the upgrade-path hacks in this library. Each
+shim papers over data (secret labels, secret ownership, ...) written by an older
+version of this library or its Charmhub predecessor
+(``charms.tls_certificates_interface.v4``), so that existing deployments keep
+working after a charm upgrade.
+
+Keep each shim self-contained and document:
+
+- what the old versions wrote,
+- what the current code expects instead, and
+- when the shim can be removed.
+
+To avoid circular imports, this module must not import from
+``._tls_certificates``; callers pass in whatever they need (e.g. ``LIBID``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ops.model import SecretNotFoundError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    import ops
+
+logger = logging.getLogger(__name__)
+
+
+def legacy_app_private_key_secret_label(libid: str, relationship_name: str) -> str:
+    """Label under which ``Mode.APP`` private keys were stored by older versions.
+
+    Depending on the version that created the secret, it refers to:
+
+    - a unit-owned secret, created by every unit (before the fix in
+      https://github.com/canonical/charmlibs/pull/267, i.e. Charmhub v4
+      libpatch < 30), or
+    - an app-owned secret (versions with that fix that still used this label).
+
+    ops cannot report who owns a secret, and Juju's label lookup is ambiguous
+    when a unit-owned and an app-owned secret share a label. Current versions
+    therefore store the APP key under a distinct label (with an ``-app-``
+    infix), and the shims below migrate away from this legacy label.
+    """
+    return f"{libid}-private-key-{relationship_name}"
+
+
+def migrate_legacy_app_private_key(
+    model: ops.Model,
+    libid: str,
+    relationship_name: str,
+    store_app_private_key: Callable[[str], None],
+) -> bool:
+    """Adopt the ``Mode.APP`` private key stored under the legacy label, if any.
+
+    Re-stores the legacy key via ``store_app_private_key`` (which must write an
+    app-owned secret under the current label) and removes the legacy secret.
+    Reusing the key material keeps the outstanding CSRs and issued certificates
+    valid, so upgrading does not regenerate certificates
+    (https://github.com/canonical/charmlibs/issues/565).
+
+    Must only be called on the leader unit, and only when no secret exists
+    under the current APP label yet.
+
+    Returns:
+        True if a legacy key was migrated, False if there was nothing to migrate.
+
+    Removal: once upgrades from charmlibs < 1.9.0 and from the Charmhub v4
+    library no longer need to be supported.
+    """
+    label = legacy_app_private_key_secret_label(libid, relationship_name)
+    try:
+        secret = model.get_secret(label=label)
+        private_key = secret.get_content(refresh=True)["private-key"]
+    except (SecretNotFoundError, KeyError):
+        return False
+    try:
+        store_app_private_key(private_key)
+    except ValueError:
+        logger.warning(
+            "Legacy private key secret with label %s does not contain a valid key, ignoring it",
+            label,
+        )
+        return False
+    secret.remove_all_revisions()
+    logger.info("Migrated private key from legacy secret with label %s", label)
+    return True
+
+
+def remove_legacy_app_private_key(model: ops.Model, libid: str, relationship_name: str) -> None:
+    """Remove the ``Mode.APP`` private key secret stored under the legacy label, if any.
+
+    Complements :func:`migrate_legacy_app_private_key` in the code paths that
+    remove the library-generated private key (relation broken, charm-provided
+    key), so a not-yet-migrated legacy secret is cleaned up as well.
+
+    Removal: together with :func:`migrate_legacy_app_private_key`.
+    """
+    try:
+        secret = model.get_secret(
+            label=legacy_app_private_key_secret_label(libid, relationship_name)
+        )
+        secret.remove_all_revisions()
+        logger.debug("Removed legacy private key secret")
+    except SecretNotFoundError:
+        pass
+
+
+def certificate_secret_label_without_relation_name(
+    libid: str, csr_sha256_hex: str, unit_number: str | None
+) -> str:
+    """Certificate secret label format used before the relation name was added.
+
+    Old versions labelled certificate secrets without the relation name, so
+    certificate lookups fall back to this label for secrets created before the
+    change. ``unit_number`` is None in ``Mode.APP``.
+
+    Removal: once certificates issued by those versions have all been renewed
+    under the current label format (a certificate lifetime after all supported
+    deployments upgraded).
+    """
+    if unit_number is not None:
+        return f"{libid}-certificate-{unit_number}-{csr_sha256_hex}"
+    return f"{libid}-certificate-{csr_sha256_hex}"

--- a/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_tls_certificates.py
+++ b/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_tls_certificates.py
@@ -46,6 +46,8 @@ from ops.model import (
     Unit,
 )
 
+from . import _backwards_compatibility
+
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping, MutableMapping
 
@@ -2034,7 +2036,22 @@ class TLSCertificatesRequiresV4(Object):
         if mode == Mode.APP and not self.model.unit.is_leader():
             logger.debug("Not leader, skipping private key generation in APP mode")
             return
+        if mode == Mode.APP and self._migrate_legacy_app_private_key():
+            return
         self._generate_private_key(mode)
+
+    def _migrate_legacy_app_private_key(self) -> bool:
+        """Adopt an APP private key stored under the legacy label by an older version."""
+
+        def store(private_key: str) -> None:
+            self._store_private_key_in_secret(PrivateKey.from_string(private_key), Mode.APP)
+
+        return _backwards_compatibility.migrate_legacy_app_private_key(
+            model=self.model,
+            libid=LIBID,
+            relationship_name=self.relationship_name,
+            store_app_private_key=store,
+        )
 
     def _validate_secret_exists(self, secret: Secret) -> None:
         secret.get_info()  # Will raise `SecretNotFoundError` if the secret does not exist
@@ -2426,6 +2443,10 @@ class TLSCertificatesRequiresV4(Object):
             secret.remove_all_revisions()
         except SecretNotFoundError:
             logger.warning("Private key secret not found, nothing to remove")
+        if mode == Mode.APP:
+            _backwards_compatibility.remove_legacy_app_private_key(
+                self.model, LIBID, self.relationship_name
+            )
 
     def _csr_matches_certificate_request(
         self, certificate_signing_request: CertificateSigningRequest, is_ca: bool
@@ -2921,7 +2942,10 @@ class TLSCertificatesRequiresV4(Object):
         if mode == Mode.UNIT:
             return f"{LIBID}-private-key-{self._get_unit_number()}-{self.relationship_name}"
         elif mode == Mode.APP:
-            return f"{LIBID}-private-key-{self.relationship_name}"
+            # the "-app-" infix distinguishes this label from the one used by older
+            # versions, which may refer to a unit-owned secret
+            # (see _backwards_compatibility.legacy_app_private_key_secret_label)
+            return f"{LIBID}-private-key-app-{self.relationship_name}"
 
     def _get_csr_secret_label(
         self, csr: CertificateSigningRequest, mode: Literal[Mode.UNIT, Mode.APP]
@@ -2932,20 +2956,6 @@ class TLSCertificatesRequiresV4(Object):
             return f"{LIBID}-certificate-{unit_num}-{self.relationship_name}-{csr_in_sha256_hex}"
         elif mode == Mode.APP:
             return f"{LIBID}-certificate-{self.relationship_name}-{csr_in_sha256_hex}"
-
-    def _get_csr_secret_label_without_relation_name(
-        self, csr: CertificateSigningRequest, mode: Literal[Mode.UNIT, Mode.APP]
-    ) -> str:
-        """Get the old certificate secret label format (without relation name).
-
-        This method provides backward compatibility for secrets created
-        before the relation name was added to the label.
-        """
-        csr_in_sha256_hex = csr.get_sha256_hex()
-        if mode == Mode.UNIT:
-            return f"{LIBID}-certificate-{self._get_unit_number()}-{csr_in_sha256_hex}"
-        elif mode == Mode.APP:
-            return f"{LIBID}-certificate-{csr_in_sha256_hex}"
 
     def _get_certificate_secret(
         self, csr: CertificateSigningRequest, mode: Literal[Mode.UNIT, Mode.APP]
@@ -2968,7 +2978,11 @@ class TLSCertificatesRequiresV4(Object):
         except SecretNotFoundError:
             pass
 
-        old_secret_label = self._get_csr_secret_label_without_relation_name(csr, mode)
+        old_secret_label = _backwards_compatibility.certificate_secret_label_without_relation_name(
+            libid=LIBID,
+            csr_sha256_hex=csr.get_sha256_hex(),
+            unit_number=self._get_unit_number() if mode == Mode.UNIT else None,
+        )
         try:
             return self.model.get_secret(label=old_secret_label)
         except SecretNotFoundError:

--- a/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_version.py
+++ b/interfaces/tls-certificates/src/charmlibs/interfaces/tls_certificates/_version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.8.3"
+__version__ = "1.9.0"

--- a/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-latest/charmcraft.yaml
+++ b/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-latest/charmcraft.yaml
@@ -1,0 +1,1 @@
+../charmcraft.yaml

--- a/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-latest/pyproject.toml
+++ b/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-latest/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "requirer-charm"
+version = "0.0.0"
+description = "Test requirer charm using the newest Charmhub v4 lib, for upgrade integration tests"
+requires-python = ">=3.10"
+dependencies = [
+    "ops",
+    # PYDEPS of charms.tls_certificates_interface.v4.tls_certificates
+    "cryptography",
+    "pydantic",
+]

--- a/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-latest/src/charm.py
+++ b/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-latest/src/charm.py
@@ -1,0 +1,1 @@
+../../fetch_lib_charm.py

--- a/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-pre-fix/charmcraft.yaml
+++ b/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-pre-fix/charmcraft.yaml
@@ -1,0 +1,1 @@
+../charmcraft.yaml

--- a/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-pre-fix/pyproject.toml
+++ b/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-pre-fix/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "requirer-charm"
+version = "0.0.0"
+description = "Test requirer charm using the Charmhub v4 lib from before the app-owned private key fix, for upgrade integration tests"
+requires-python = ">=3.10"
+dependencies = [
+    "ops",
+    # PYDEPS of charms.tls_certificates_interface.v4.tls_certificates
+    "cryptography",
+    "pydantic",
+]

--- a/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-pre-fix/src/charm.py
+++ b/interfaces/tls-certificates/tests/integration/charms/requirer/fetch-lib-pre-fix/src/charm.py
@@ -1,0 +1,1 @@
+../../fetch_lib_charm.py

--- a/interfaces/tls-certificates/tests/integration/charms/requirer/fetch_lib_charm.py
+++ b/interfaces/tls-certificates/tests/integration/charms/requirer/fetch_lib_charm.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Requirer charm built on the Charmhub-hosted v4 lib, for upgrade integration tests.
+
+This charm is packed with ``charms.tls_certificates_interface.v4.tls_certificates``
+fetched from Charmhub (see pack.sh), at two pinned versions:
+
+- fetch-lib-pre-fix: libpatch 26, from before APP mode private keys were stored
+  as app-owned secrets (https://github.com/canonical/charmlibs/pull/267).
+- fetch-lib-latest: the newest libpatch, which stores APP mode private keys
+  app-owned but under the label this library now treats as legacy.
+
+Upgrade tests deploy this charm, then refresh to the local charm built on the
+current library, to validate that existing deployments keep their private key
+and certificate (https://github.com/canonical/charmlibs/issues/565).
+
+The certificate request construction must stay identical to charm.py so that
+the CSR created by this charm still matches the request the local charm makes
+after the refresh.
+"""
+
+from typing import Any, cast
+
+from ops import main
+from ops.charm import ActionEvent, CharmBase, CollectStatusEvent
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+
+from charms.tls_certificates_interface.v4.tls_certificates import (
+    CertificateRequestAttributes,
+    Mode,
+    TLSCertificatesRequiresV4,
+)
+
+
+class FetchLibTLSCertificatesRequirerCharm(CharmBase):
+    def __init__(self, *args: Any):
+        super().__init__(*args)
+        self._certificate_request = self._get_certificate_request()
+        self.certificates = TLSCertificatesRequiresV4(
+            charm=self,
+            relationship_name="certificates",
+            certificate_requests=[self._certificate_request],
+            mode=self._get_mode(),
+            refresh_events=[self.on.config_changed],
+        )
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
+        self.framework.observe(self.on.get_certificate_action, self._on_get_certificate_action)
+
+    def _on_collect_unit_status(self, event: CollectStatusEvent):
+        if not self._relation_created("certificates"):
+            event.add_status(BlockedStatus("Missing relation to certificates provider"))
+            return
+        cert, _ = self.certificates.get_assigned_certificate(
+            certificate_request=self._certificate_request
+        )
+        if not cert:
+            event.add_status(WaitingStatus("Waiting for certificate"))
+            return
+        event.add_status(ActiveStatus())
+
+    def _on_get_certificate_action(self, event: ActionEvent) -> None:
+        certificate, _ = self.certificates.get_assigned_certificate(
+            certificate_request=self._certificate_request
+        )
+        if not certificate:
+            event.fail("Certificate not available")
+            return
+        event.set_results({
+            "certificate": str(certificate.certificate),
+            "ca": str(certificate.ca),
+            "chain": str(certificate.chain),
+        })
+
+    def _relation_created(self, relation_name: str) -> bool:
+        try:
+            if self.model.get_relation(relation_name):
+                return True
+            return False
+        except KeyError:
+            return False
+
+    def _get_mode(self) -> Mode:
+        mode_config = cast("str", self.model.config.get("mode", "unit"))
+        if mode_config == "app":
+            return Mode.APP
+        return Mode.UNIT
+
+    def _get_certificate_request(self) -> CertificateRequestAttributes:
+        return CertificateRequestAttributes(
+            common_name=self._get_config_common_name(),
+            sans_dns=self._get_config_sans_dns(),
+            organization=self._get_config_organization_name(),
+            organizational_unit=self._get_config_organization_unit_name(),
+            email_address=self._get_config_email_address(),
+            country_name=self._get_config_country_name(),
+            state_or_province_name=self._get_config_state_or_province_name(),
+            locality_name=self._get_config_locality_name(),
+        )
+
+    def _get_config_common_name(self) -> str:
+        common_name = self.model.config.get("common_name")
+        return str(common_name) if common_name is not None else "default"
+
+    def _get_config_sans_dns(self) -> frozenset[str]:
+        config_sans_dns = cast("str", self.model.config.get("sans_dns", ""))
+        return frozenset(config_sans_dns.split(",") if config_sans_dns else [])
+
+    def _get_config_organization_name(self) -> str | None:
+        return cast("str", self.model.config.get("organization_name"))
+
+    def _get_config_organization_unit_name(self) -> str | None:
+        return cast("str", self.model.config.get("organization_unit_name"))
+
+    def _get_config_email_address(self) -> str | None:
+        return cast("str", self.model.config.get("email_address"))
+
+    def _get_config_country_name(self) -> str | None:
+        return cast("str", self.model.config.get("country_name"))
+
+    def _get_config_state_or_province_name(self) -> str | None:
+        return cast("str", self.model.config.get("state_or_province_name"))
+
+    def _get_config_locality_name(self) -> str | None:
+        return cast("str", self.model.config.get("locality_name"))
+
+
+if __name__ == "__main__":
+    main(FetchLibTLSCertificatesRequirerCharm)

--- a/interfaces/tls-certificates/tests/integration/pack.sh
+++ b/interfaces/tls-certificates/tests/integration/pack.sh
@@ -39,4 +39,27 @@ for charm in 'provider' 'requirer'; do
     done
 done
 
+: pack requirer variants built on the Charmhub-hosted v4 lib, used by the upgrade tests
+: 'fetch-lib-latest' uses the newest v4 libpatch, 'fetch-lib-pre-fix' is pinned to
+: libpatch 26, from before APP mode private keys were stored as app-owned secrets
+for variant_and_lib in 'fetch-lib-latest=4' 'fetch-lib-pre-fix=4.26'; do
+    variant="${variant_and_lib%%=*}"
+    lib_version="${variant_and_lib##*=}"
+    charm_tmp_dir="$TMP_DIR/requirer-$variant"
+
+    rm -rf "$charm_tmp_dir"
+    cp --recursive --dereference "charms/requirer/$variant" "$charm_tmp_dir"
+
+    : declare the Charmhub lib at the pinned version, then fetch and pack
+    printf '\ncharm-libs:\n  - lib: tls_certificates_interface.tls_certificates\n    version: "%s"\n' \
+        "$lib_version" >> "$charm_tmp_dir/charmcraft.yaml"
+    cd "$charm_tmp_dir"
+    charmcraft fetch-libs
+    uv lock
+    charmcraft pack
+    cd -
+
+    mv "$charm_tmp_dir"/*.charm "$PACKED_DIR/requirer-$variant.charm"  # read by integration tests
+done
+
 ls "$PACKED_DIR"

--- a/interfaces/tls-certificates/tests/integration/test_tls_certificates.py
+++ b/interfaces/tls-certificates/tests/integration/test_tls_certificates.py
@@ -2,14 +2,18 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import base64
+import json
 import logging
 import pathlib
 import time
+from datetime import timedelta
 
 import jubilant
 import pytest
 
 from certificates import Certificate
+from charmlibs.interfaces import tls_certificates
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +21,8 @@ logger = logging.getLogger(__name__)
 PACKED_DIR = pathlib.Path(__file__).parent / ".packed"
 REQUIRER_LOCAL = PACKED_DIR / "requirer-local.charm"
 REQUIRER_PUBLISHED = PACKED_DIR / "requirer-published.charm"
+REQUIRER_FETCH_LIB_LATEST = PACKED_DIR / "requirer-fetch-lib-latest.charm"
+REQUIRER_FETCH_LIB_PRE_FIX = PACKED_DIR / "requirer-fetch-lib-pre-fix.charm"
 PROVIDER_LOCAL = PACKED_DIR / "provider-local.charm"
 PROVIDER_PUBLISHED = PACKED_DIR / "provider-published.charm"
 TLS_CERTIFICATES_PROVIDER_APP_NAME = "tls-certificates-provider"
@@ -28,6 +34,48 @@ def _assert_certificate_fields(task: jubilant.Task):
     assert "ca" in task.results and task.results["ca"] is not None
     assert "certificate" in task.results and task.results["certificate"] is not None
     assert "chain" in task.results and task.results["chain"] is not None
+
+
+def _base64(pem: str) -> str:
+    return base64.b64encode(pem.encode()).decode()
+
+
+def _get_outstanding_csrs(juju: jubilant.Juju, manual_tls_unit: str) -> list[str]:
+    """Return the CSRs the manual-tls-certificates charm has not signed yet."""
+    try:
+        task = juju.run(manual_tls_unit, "get-outstanding-certificate-requests")
+    except jubilant.TaskError:
+        return []
+    return [request["csr"] for request in json.loads(task.results.get("result", "[]"))]
+
+
+def _wait_for_outstanding_csr(juju: jubilant.Juju, manual_tls_unit: str) -> str:
+    timeout = time.time() + 600
+    while time.time() < timeout:
+        csrs = _get_outstanding_csrs(juju, manual_tls_unit)
+        if csrs:
+            return csrs[0]
+        time.sleep(10)
+    raise TimeoutError(f"No outstanding certificate request appeared on {manual_tls_unit}")
+
+
+def _sign_csr(csr_str: str) -> tuple[str, str]:
+    """Sign a CSR with a locally generated CA, returning (certificate, ca_certificate) PEMs."""
+    ca_private_key = tls_certificates.PrivateKey.generate()
+    ca = tls_certificates.Certificate.generate_self_signed_ca(
+        attributes=tls_certificates.CertificateRequestAttributes(
+            common_name="integration-test-ca", is_ca=True
+        ),
+        private_key=ca_private_key,
+        validity=timedelta(days=365),
+    )
+    certificate = tls_certificates.Certificate.generate(
+        csr=tls_certificates.CertificateSigningRequest.from_string(csr_str),
+        ca=ca,
+        ca_private_key=ca_private_key,
+        validity=timedelta(days=365),
+    )
+    return str(certificate), str(ca)
 
 
 class TestIntegration:
@@ -74,6 +122,96 @@ class TestIntegration:
         # retrieve certs and validate
         task = juju.run(f"{requirer_app_name}/0", "get-certificate")
         _assert_certificate_fields(task)
+
+        # tear down so that the rest of the tests can run as normal
+        juju.remove_application(requirer_app_name, provider_app_name)
+
+    @pytest.mark.upgrade
+    @pytest.mark.parametrize(
+        "legacy_charm",
+        [
+            pytest.param(REQUIRER_FETCH_LIB_PRE_FIX, id="pre-app-owned-key-fix"),
+            pytest.param(REQUIRER_FETCH_LIB_LATEST, id="latest-charmhub-lib"),
+        ],
+    )
+    def test_given_charmhub_lib_app_mode_deployment_when_upgraded_then_certificate_is_preserved(
+        self, juju: jubilant.Juju, legacy_charm: pathlib.Path
+    ):
+        """Upgrading an APP mode deployment must not regenerate the key, CSR, or certificate.
+
+        Deployments made with the Charmhub v4 lib store the APP mode private key
+        under a label this library treats as legacy, either unit-owned (before
+        the fix in https://github.com/canonical/charmlibs/pull/267) or app-owned
+        (after it). On refresh, the library must migrate that key instead of
+        generating a new one (https://github.com/canonical/charmlibs/issues/565).
+
+        The provider is manual-tls-certificates, which only signs CSRs through
+        operator actions. If the refresh regenerated the key, its CSR would be
+        replaced and never signed, so the requirer could not be active with its
+        original certificate afterwards.
+        """
+        requirer_app_name = legacy_charm.stem
+        provider_app_name = f"{requirer_app_name}-provider"
+        requirer_unit = f"{requirer_app_name}/0"
+        provider_unit = f"{provider_app_name}/0"
+
+        juju.deploy(
+            legacy_charm,
+            app=requirer_app_name,
+            base="ubuntu@22.04",
+            config={"mode": "app"},
+        )
+        juju.deploy(
+            "manual-tls-certificates",
+            app=provider_app_name,
+            channel="1/stable",
+            base="ubuntu@24.04",
+        )
+        juju.integrate(requirer_app_name, provider_app_name)
+        juju.wait(
+            lambda status: jubilant.all_agents_idle(status, requirer_app_name, provider_app_name),
+            timeout=1000,
+        )
+
+        # sign the requirer's CSR and provide the certificate manually
+        csr = _wait_for_outstanding_csr(juju, provider_unit)
+        certificate, ca_certificate = _sign_csr(csr)
+        juju.run(
+            provider_unit,
+            "provide-certificate",
+            {
+                "certificate-signing-request": _base64(csr),
+                "certificate": _base64(certificate),
+                "ca-certificate": _base64(ca_certificate),
+                "ca-chain": _base64(ca_certificate),
+            },
+        )
+        juju.wait(
+            lambda status: (
+                jubilant.all_active(status, requirer_app_name, provider_app_name)
+                and jubilant.all_agents_idle(status, requirer_app_name, provider_app_name)
+            ),
+            timeout=1000,
+        )
+        task = juju.run(requirer_unit, "get-certificate")
+        _assert_certificate_fields(task)
+        certificate_before_upgrade = task.results["certificate"]
+
+        # upgrade to the local charm built on the current library
+        juju.refresh(requirer_app_name, path=REQUIRER_LOCAL)
+        juju.wait(
+            lambda status: (
+                jubilant.all_active(status, requirer_app_name)
+                and jubilant.all_agents_idle(status, requirer_app_name)
+            ),
+            timeout=1000,
+        )
+
+        # the certificate survived the upgrade and no new CSR was requested
+        task = juju.run(requirer_unit, "get-certificate")
+        _assert_certificate_fields(task)
+        assert task.results["certificate"] == certificate_before_upgrade
+        assert not _get_outstanding_csrs(juju, provider_unit)
 
         # tear down so that the rest of the tests can run as normal
         juju.remove_application(requirer_app_name, provider_app_name)

--- a/interfaces/tls-certificates/tests/unit/test_requires.py
+++ b/interfaces/tls-certificates/tests/unit/test_requires.py
@@ -312,7 +312,7 @@ class TestTLSCertificatesRequiresV4:
             state_out.secrets, f"{LIBID}-private-key-0-{certificates_relation.endpoint}"
         )
         assert self.private_key_secret_exists(
-            state_out.secrets, f"{LIBID}-private-key-{certificates_relation.endpoint}"
+            state_out.secrets, f"{LIBID}-private-key-app-{certificates_relation.endpoint}"
         )
 
     def test_given_app_and_unit_mode_when_relation_created_and_not_leader_then_only_unit_private_key_is_generated(
@@ -340,7 +340,7 @@ class TestTLSCertificatesRequiresV4:
             state_out.secrets, f"{LIBID}-private-key-0-{certificates_relation.endpoint}"
         )
         assert not self.private_key_secret_exists(
-            state_out.secrets, f"{LIBID}-private-key-{certificates_relation.endpoint}"
+            state_out.secrets, f"{LIBID}-private-key-app-{certificates_relation.endpoint}"
         )
 
     def test_given_app_and_unit_mode_with_private_key_when_relation_created_then_no_private_key_secrets_are_created(
@@ -370,6 +370,173 @@ class TestTLSCertificatesRequiresV4:
         assert not self.private_key_secret_exists(
             state_out.secrets, f"{LIBID}-private-key-0-{certificates_relation.endpoint}"
         )
+        assert not self.private_key_secret_exists(
+            state_out.secrets, f"{LIBID}-private-key-app-{certificates_relation.endpoint}"
+        )
+
+    @patch(BASE_CHARM_DIR + "._app_or_unit", MagicMock(return_value=Mode.APP))
+    def test_given_legacy_unit_owned_app_private_key_when_relation_changed_then_key_is_migrated_to_app_owned_secret(
+        self,
+    ):
+        private_key = generate_private_key()
+        certificates_relation = testing.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-provider",
+        )
+        legacy_secret = Secret(
+            {"private-key": private_key},
+            label=f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            owner="unit",
+        )
+        state_in = testing.State(
+            leader=True,
+            relations={certificates_relation},
+            config={"common_name": "example.com", "is_ca": False},
+            secrets={legacy_secret},
+        )
+
+        state_out = self.ctx.run(self.ctx.on.relation_changed(certificates_relation), state_in)
+
+        migrated_secret = state_out.get_secret(
+            label=f"{LIBID}-private-key-app-{certificates_relation.endpoint}"
+        )
+        assert migrated_secret.owner == "app"
+        assert migrated_secret.latest_content == {"private-key": private_key}
+        assert not self.private_key_secret_exists(
+            state_out.secrets, f"{LIBID}-private-key-{certificates_relation.endpoint}"
+        )
+
+    @patch(BASE_CHARM_DIR + "._app_or_unit", MagicMock(return_value=Mode.APP))
+    def test_given_legacy_app_owned_private_key_when_relation_changed_then_key_is_migrated_to_new_label(
+        self,
+    ):
+        private_key = generate_private_key()
+        certificates_relation = testing.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-provider",
+        )
+        legacy_secret = Secret(
+            {"private-key": private_key},
+            label=f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            owner="app",
+        )
+        state_in = testing.State(
+            leader=True,
+            relations={certificates_relation},
+            config={"common_name": "example.com", "is_ca": False},
+            secrets={legacy_secret},
+        )
+
+        state_out = self.ctx.run(self.ctx.on.relation_changed(certificates_relation), state_in)
+
+        migrated_secret = state_out.get_secret(
+            label=f"{LIBID}-private-key-app-{certificates_relation.endpoint}"
+        )
+        assert migrated_secret.owner == "app"
+        assert migrated_secret.latest_content == {"private-key": private_key}
+        assert not self.private_key_secret_exists(
+            state_out.secrets, f"{LIBID}-private-key-{certificates_relation.endpoint}"
+        )
+
+    @patch(BASE_CHARM_DIR + "._app_or_unit", MagicMock(return_value=Mode.APP))
+    def test_given_legacy_app_private_key_and_matching_csr_when_relation_changed_then_csr_is_not_regenerated(
+        self,
+    ):
+        private_key = generate_private_key()
+        csr = generate_csr(
+            private_key=private_key,
+            common_name="example.com",
+        )
+        app_data = {
+            "certificate_signing_requests": json.dumps([
+                {
+                    "certificate_signing_request": csr,
+                    "ca": False,
+                }
+            ])
+        }
+        certificates_relation = testing.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-provider",
+            local_app_data=app_data,
+        )
+        legacy_secret = Secret(
+            {"private-key": private_key},
+            label=f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            owner="unit",
+        )
+        state_in = testing.State(
+            leader=True,
+            relations={certificates_relation},
+            config={"common_name": "example.com", "is_ca": False},
+            secrets={legacy_secret},
+        )
+
+        state_out = self.ctx.run(self.ctx.on.relation_changed(certificates_relation), state_in)
+
+        relation = state_out.get_relation(certificates_relation.id)
+        assert relation.local_app_data == app_data
+
+    @patch(BASE_CHARM_DIR + "._app_or_unit", MagicMock(return_value=Mode.APP))
+    def test_given_legacy_app_private_key_when_relation_changed_and_not_leader_then_key_is_not_migrated(
+        self,
+    ):
+        private_key = generate_private_key()
+        certificates_relation = testing.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-provider",
+        )
+        legacy_secret = Secret(
+            {"private-key": private_key},
+            label=f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            owner="unit",
+        )
+        state_in = testing.State(
+            leader=False,
+            relations={certificates_relation},
+            config={"common_name": "example.com", "is_ca": False},
+            secrets={legacy_secret},
+        )
+
+        state_out = self.ctx.run(self.ctx.on.relation_changed(certificates_relation), state_in)
+
+        assert self.private_key_secret_exists(
+            state_out.secrets, f"{LIBID}-private-key-{certificates_relation.endpoint}"
+        )
+        assert not self.private_key_secret_exists(
+            state_out.secrets, f"{LIBID}-private-key-app-{certificates_relation.endpoint}"
+        )
+
+    def test_given_legacy_app_private_key_when_relation_broken_then_legacy_secret_is_removed(
+        self,
+    ):
+        private_key = generate_private_key()
+        certificates_relation = testing.Relation(
+            endpoint="certificates",
+            interface="tls-certificates",
+            remote_app_name="certificate-provider",
+        )
+        legacy_secret = Secret(
+            {"private-key": private_key},
+            label=f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            owner="unit",
+        )
+        state_in = testing.State(
+            leader=True,
+            relations={certificates_relation},
+            config={"common_name": "example.com", "is_ca": False},
+            secrets={legacy_secret},
+        )
+
+        with patch.object(
+            DummyTLSCertificatesRequirerCharm, "_app_or_unit", return_value=Mode.APP
+        ):
+            state_out = self.ctx.run(self.ctx.on.relation_broken(certificates_relation), state_in)
+
         assert not self.private_key_secret_exists(
             state_out.secrets, f"{LIBID}-private-key-{certificates_relation.endpoint}"
         )
@@ -2056,7 +2223,7 @@ class TestTLSCertificatesRequiresV4:
         )
         private_key_secret = Secret(
             {"private-key": str(private_key)},
-            label=f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            label=f"{LIBID}-private-key-app-{certificates_relation.endpoint}",
             owner="app",
         )
         state_in = testing.State(
@@ -2279,7 +2446,7 @@ class TestTLSCertificatesRequiresV4:
 
         private_key_secret = Secret(
             {"private-key": str(private_key)},
-            label=f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            label=f"{LIBID}-private-key-app-{certificates_relation.endpoint}",
             owner="app",
         )
 
@@ -2297,7 +2464,7 @@ class TestTLSCertificatesRequiresV4:
 
         assert not self.private_key_secret_exists(
             state_out.secrets,
-            f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            f"{LIBID}-private-key-app-{certificates_relation.endpoint}",
         )
 
     def test_given_non_leader_unit_when_relation_broken_then_app_secrets_are_not_cleaned_up(self):
@@ -2318,7 +2485,7 @@ class TestTLSCertificatesRequiresV4:
 
         private_key_secret = Secret(
             {"private-key": str(private_key)},
-            label=f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            label=f"{LIBID}-private-key-app-{certificates_relation.endpoint}",
             owner="app",
         )
 
@@ -2336,7 +2503,7 @@ class TestTLSCertificatesRequiresV4:
 
         assert self.private_key_secret_exists(
             state_out.secrets,
-            f"{LIBID}-private-key-{certificates_relation.endpoint}",
+            f"{LIBID}-private-key-app-{certificates_relation.endpoint}",
         )
 
     def test_given_certificate_secrets_when_relation_broken_then_secrets_are_cleaned_up(self):


### PR DESCRIPTION
This PR allows users to update from the previously-bugged version of the library where private keys were created for the unit instead of the app even in app mode to the new version where this is no longer an issue.