### PR TITLE
docs: correct 'deprecated' to 'legacy' in the migration guide

### DIFF
--- a/.docs/how-to/migrate.md
+++ b/.docs/how-to/migrate.md
@@ -351,7 +351,7 @@ Edit the imported pages to follow the conventions described in {ref}`how-to-add-
 The {ref}`interface library listing <interface-libs-listing>` and {ref}`general library listing <general-libs-listing>` are generated from `.docs/reference/libs.yaml`.
 
 There should already be an entry for the old Charmhub-hosted library.
-If there isn't, add one with a `deprecated` status and a description noting it has been superseded by the new `charmlibs` package.
+If there isn't, add one with a `legacy` status and a description noting it has been superseded by the new `charmlibs` package.
 
 Add a new entry for the `charmlibs` package with the new package name, source URL, status, description, and any relevant tags.
 See `.docs/reference/tags.yaml` for the full list of available tags and their assignment criteria.


### PR DESCRIPTION
This PR fixes a tiny issue in the [migration guide](https://canonical.com/juju/docs/charmlibs/).