### PR TITLE
ci: drop redundant dependabot security config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -25,15 +25,3 @@ updates:
       test-deps:
         patterns:
           - "*"
-  # Daily security updates to individual Python packages
-  - package-ecosystem: "pip"
-    directories:
-      - "/"
-      - "/[a-z]*"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 0  # Security updates only
-    labels:
-      - "dependencies"
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
This PR drops the redundant security updates section from our `.github/dependabot.yaml` (redundant with repo-level security scanning settings), silencing [this complaint from CI](https://github.com/canonical/charmlibs/pull/391/checks?check_run_id=87775878832).