### PR TITLE
chore: ignore S311 in tests

### DIFF
--- a/passwd/tests/functional/test_passwd.py
+++ b/passwd/tests/functional/test_passwd.py
@@ -75,7 +75,7 @@ def test_remove_nonexistent_user() -> None:
 
 def test_add_user_with_shell() -> None:
     """Verify we can add a user with a specific shell."""
-    assert passwd.add_user(username='bob', shell='/bin/sh')  # noqa: S604
+    assert passwd.add_user(username='bob', shell='/bin/sh')
     user_info = passwd.user_exists(user='bob')
     assert user_info is not None
     assert user_info.pw_shell == '/bin/sh'

--- a/passwd/tests/functional/test_passwd.py
+++ b/passwd/tests/functional/test_passwd.py
@@ -75,7 +75,7 @@ def test_remove_nonexistent_user() -> None:
 
 def test_add_user_with_shell() -> None:
     """Verify we can add a user with a specific shell."""
-    assert passwd.add_user(username='bob', shell='/bin/sh')
+    assert passwd.add_user(username='bob', shell='/bin/sh')  # noqa: S604
     user_info = passwd.user_exists(user='bob')
     assert user_info is not None
     assert user_info.pw_shell == '/bin/sh'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,8 @@ ignore = [
     "S105",
     # Hard-coded password function argument.
     "S106",
+    # Complains about use of `random`.
+    "S311",
 
     # "Useless" expression.
     "B018",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,14 +139,19 @@ ignore = [
     # All documentation linting.
     "D",
 
-    # All security linting.
-    "S",
+    # Hard-coded password string.
+    "S105",
+    # Hard-coded password function argument.
+    "S106",
 
     # "Useless" expression.
     "B018",
 
     # Redefinition of unused (we import fixtures)
     "F811",
+
+    # Setting a permissive mask on a file or directory
+    "S103",
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,19 +139,14 @@ ignore = [
     # All documentation linting.
     "D",
 
-    # Hard-coded password string.
-    "S105",
-    # Hard-coded password function argument.
-    "S106",
+    # All security linting.
+    "S",
 
     # "Useless" expression.
     "B018",
 
     # Redefinition of unused (we import fixtures)
     "F811",
-
-    # Setting a permissive mask on a file or directory
-    "S103",
 ]
 
 [tool.ruff.lint.pydocstyle]


### PR DESCRIPTION
This PR disables the S311 `ruff` security linting rule for library tests (https://docs.astral.sh/ruff/rules/suspicious-non-cryptographic-random-usage/). This rule complains about any use of the `random` module, under the auspices of it not being cryptographically secure. This isn't relevant for tests.

The inciting incident was trying to use `random` to add jitter to a retry in tests. I considered adding an in-line noqa just for that, but we'll never want this warning in tests, so let's just disable it at the repo level.