### PR TITLE
ci: add TIOBE/TICS weekly workflow across monorepo packages

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -1,0 +1,69 @@
+name: TIOBE
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 3 * * 0'
+
+permissions: {}
+
+jobs:
+  TICS:
+    runs-on: [self-hosted, reactive, amd64, tiobe, noble]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
+      # We could store per-package coverage from the regular CI runs and merge
+      # them here, but this is cheap to do fresh and keeps the TICS run
+      # self-contained.
+      - name: Generate coverage report across packages
+        run: |
+          set -euo pipefail
+          # Discover packages the same way the rest of CI does — dynamic so
+          # new packages get picked up automatically.
+          mapfile -t packages < <(
+            uv run --no-project --script .scripts/ls.py packages \
+              --exclude-examples --exclude-placeholders \
+            | jq -r '.[]'
+          )
+          for pkg in "${packages[@]}"; do
+            # Let `just` resolve the Python version per package (uses the higher
+            # of DEFAULT_PYTHON and the package's requires-python minimum).
+            uvx --from rust-just just unit "$pkg"
+            uvx --from rust-just just combine-coverage "$pkg"
+          done
+          mkdir -p .report
+          # Merge every per-package coverage-all-*.db into one repo-root
+          # coverage.xml for the TICS action to pick up.
+          mapfile -t dbs < <(find . -path '*/.report/coverage-all-*.db' -type f)
+          if [ ${#dbs[@]} -eq 0 ]; then
+            echo "No coverage databases produced." >&2
+            exit 1
+          fi
+          uv run --with coverage coverage combine --keep "${dbs[@]}"
+          uv run --with coverage coverage xml -o .report/coverage.xml
+
+      # Note that these are dependencies for the tools that the TIOBE action will
+      # run, which is done in the global environment, rather than a venv, as we
+      # do with the unit tests.
+      - name: Install TIOBE and project dependencies
+        run: |
+          set -euo pipefail
+          # Export the monorepo's lockfile so pylint/flake8 can resolve imports
+          # from every package during static analysis.
+          uv export --no-emit-project --frozen --no-hashes > requirements.txt
+          pip install flake8 pylint -r requirements.txt --break-system-packages
+
+      - name: TICS GitHub Action
+        uses: tiobe/tics-github-action@333078bc527399e5916a166bd1a3a788be5a01a9  # v3.12.0
+        with:
+          mode: qserver
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          project: charmtech-charmlibs
+          installTics: true

--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -26,21 +26,16 @@ jobs:
           set -euo pipefail
           # Discover packages the same way the rest of CI does — dynamic so
           # new packages get picked up automatically.
-          mapfile -t packages < <(
-            uv run --no-project --script .scripts/ls.py packages \
-              --exclude-examples --exclude-placeholders \
-            | jq -r '.[]'
-          )
+          mapfile -t packages < <(.scripts/ls.py packages --exclude-examples --exclude-placeholders --no-json)
           for pkg in "${packages[@]}"; do
             # Let `just` resolve the Python version per package (uses the higher
             # of DEFAULT_PYTHON and the package's requires-python minimum).
             uvx --from rust-just just unit "$pkg"
-            uvx --from rust-just just combine-coverage "$pkg"
           done
           mkdir -p .report
-          # Merge every per-package coverage-all-*.db into one repo-root
+          # Merge every per-package coverage db into one repo-root
           # coverage.xml for the TICS action to pick up.
-          mapfile -t dbs < <(find . -path '*/.report/coverage-all-*.db' -type f)
+          mapfile -t dbs < <(find . -path '*/.report/coverage-*.db' -type f)
           if [ ${#dbs[@]} -eq 0 ]; then
             echo "No coverage databases produced." >&2
             exit 1
@@ -54,9 +49,13 @@ jobs:
       - name: Install TIOBE and project dependencies
         run: |
           set -euo pipefail
-          # Export the monorepo's lockfile so pylint/flake8 can resolve imports
-          # from every package during static analysis.
-          uv export --no-emit-project --frozen --no-hashes > requirements.txt
+          # The monorepo lockfile only pins the fast-lint tools, so export each
+          # package's own lockfile instead — that's what lets pylint/flake8
+          # resolve third-party imports during static analysis.
+          mapfile -t packages < <(.scripts/ls.py packages --exclude-examples --exclude-placeholders --no-json)
+          for pkg in "${packages[@]}"; do
+            uv export --project "$pkg" --no-emit-project --frozen --no-hashes
+          done | sort -u > requirements.txt
           pip install flake8 pylint -r requirements.txt --break-system-packages
 
       - name: TICS GitHub Action


### PR DESCRIPTION
Weekly TICS scan. Iterates all published packages (apt, nginx_k8s, passwd, pathops, rollingops, snap, sysctl, systemd), runs 'just unit' and 'just combine-coverage' per package, merges per-package coverage.db files into a repo-root .report/coverage.xml, then invokes the TICS action on the whole repo with project=charmlibs.