### PR TITLE
feat(snap): clean error tracebacks

### DIFF
--- a/snap/src/charmlibs/snap/_errors.py
+++ b/snap/src/charmlibs/snap/_errors.py
@@ -69,12 +69,9 @@ class Error(Exception):
         return str(self._value)
 
     def __str__(self) -> str:
-        # Surface `value` when it adds information the message doesn't already carry -- most
-        # importantly the snap name in snapd's terse 'snap not installed' error, whose message
-        # omits it. Only non-empty string values are appended, and only when not already present
-        # in the message: structured values (e.g. option-not-found's {'SnapName', 'Key'}) are
-        # already reflected in the message and would be noisy here. The raw value and the full
-        # detail remain available via the `value` property and `repr`.
+        # Surface `value` when it adds information the message doesn't already carry.
+        # Most useful for NotFoundError, with message 'snap not installed' and value '<snap>'.
+        # Skip OptionNotFoundError's non-string value, which is redundant with its message.
         value = self._value
         if isinstance(value, str) and value and value not in self._message:
             return f'{self._message} ({value})'

--- a/snap/src/charmlibs/snap/_errors.py
+++ b/snap/src/charmlibs/snap/_errors.py
@@ -68,6 +68,18 @@ class Error(Exception):
         """
         return str(self._value)
 
+    def __str__(self) -> str:
+        # Surface `value` when it adds information the message doesn't already carry -- most
+        # importantly the snap name in snapd's terse 'snap not installed' error, whose message
+        # omits it. Only non-empty string values are appended, and only when not already present
+        # in the message: structured values (e.g. option-not-found's {'SnapName', 'Key'}) are
+        # already reflected in the message and would be noisy here. The raw value and the full
+        # detail remain available via the `value` property and `repr`.
+        value = self._value
+        if isinstance(value, str) and value and value not in self._message:
+            return f'{self._message} ({value})'
+        return self._message
+
     def __repr__(self) -> str:
         return (
             f'{type(self).__module__}.{type(self).__name__}('

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -96,10 +96,11 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
         if error := _utils.check_installed_or_system(snap):
             raise error from None
         raise
-    # NOTE: snapd returns {} for an installed snap with no config and for a missing snap.
-    # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
-    # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
-    if not config and keys is None and (error := _utils.check_installed_or_system(snap)):
+    # Empty result when all config was requested: error if the snap isn't installed.
+    if (not config) and (keys is None) and (error := _utils.check_installed_or_system(snap)):
+        # NOTE: snapd returns {} for an installed snap with no config and for a missing snap.
+        # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
+        # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
         raise error
     assert isinstance(config, dict)
     return typing.cast('dict[str, Any]', config)

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -84,8 +84,7 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
             # NOTE: This is the library's only eager installed-check: with no conf request to
             # make, probing is the only way to tell an installed snap ({}) from an absent one.
             # Everywhere else we probe reactively, once a request has actually failed.
-            error = _utils.probe_not_installed(snap)
-            if error is not None:
+            if error := _utils.check_installed(snap):
                 raise error
             return {}
         params = {'keys': ','.join(keys)}
@@ -99,14 +98,13 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
         # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
         # Raised with 'from None': the option-not-found error snapd sent for the absent snap
         # is misleading, and chaining it would only expose the internal probe.
-        error = _utils.probe_not_installed(snap)
-        if error is not None:
+        if error := _utils.check_installed(snap):
             raise error from None
         raise
     # NOTE: snapd returns {} for an installed snap with no config and for a missing snap.
     # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
     # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
-    if keys is None and not config and (error := _utils.probe_not_installed(snap)) is not None:
+    if not config and keys is None and (error := _utils.check_installed(snap)):
         raise error
     assert isinstance(config, dict)
     return typing.cast('dict[str, Any]', config)

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -81,7 +81,11 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
             # NOTE: snapd returns the full configuration if no keys are specified.
             # We pass this behaviour through for keys=None, but for keys=[] we return
             # an empty dict, since the caller explicitly requested no keys.
-            _utils.raise_if_snap_not_installed_or_system(snap)
+            # NOTE: This is the library's only eager installed-check: with no conf request to
+            # make, probing is the only way to tell an installed snap ({}) from an absent one.
+            # Everywhere else we probe reactively, once a request has actually failed.
+            if not _utils.snap_installed(snap):
+                raise _utils.not_installed_error(snap)
             return {}
         params = {'keys': ','.join(keys)}
     else:
@@ -92,13 +96,16 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
         # NOTE: snapd reports option-not-found both for a missing key and for a missing snap.
         # The CLI returns 'error: snap "foo" has no "bar" configuration' in both cases.
         # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
-        _utils.raise_if_snap_not_installed_or_system(snap)
+        # Raised with 'from None': the option-not-found error snapd sent for the absent snap
+        # is misleading, and chaining it would only expose the internal probe.
+        if not _utils.snap_installed(snap):
+            raise _utils.not_installed_error(snap) from None
         raise
-    if keys is None and not config:
-        # NOTE: snapd returns {} for an installed snap with no config and for a missing snap.
-        # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
-        # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
-        _utils.raise_if_snap_not_installed_or_system(snap)
+    # NOTE: snapd returns {} for an installed snap with no config and for a missing snap.
+    # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
+    # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
+    if keys is None and not config and not _utils.snap_installed(snap):
+        raise _utils.not_installed_error(snap)
     assert isinstance(config, dict)
     return typing.cast('dict[str, Any]', config)
 

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -81,7 +81,7 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
             # NOTE: snapd returns the full configuration if no keys are specified.
             # We pass this behaviour through for keys=None, but for keys=[] we return
             # an empty dict, since the caller explicitly requested no keys.
-            if error := _utils.check_installed(snap):
+            if error := _utils.check_installed_or_system(snap):
                 raise error
             return {}
         params = {'keys': ','.join(keys)}
@@ -93,13 +93,13 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
         # NOTE: snapd reports option-not-found both for a missing key and for a missing snap.
         # The CLI returns 'error: snap "foo" has no "bar" configuration' in both cases.
         # For symmetry with PUT (set/unset), we convert to NotFoundError here for a missing snap.
-        if error := _utils.check_installed(snap):
+        if error := _utils.check_installed_or_system(snap):
             raise error from None
         raise
     # NOTE: snapd returns {} for an installed snap with no config and for a missing snap.
     # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
     # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
-    if not config and keys is None and (error := _utils.check_installed(snap)):
+    if not config and keys is None and (error := _utils.check_installed_or_system(snap)):
         raise error
     assert isinstance(config, dict)
     return typing.cast('dict[str, Any]', config)

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -84,8 +84,9 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
             # NOTE: This is the library's only eager installed-check: with no conf request to
             # make, probing is the only way to tell an installed snap ({}) from an absent one.
             # Everywhere else we probe reactively, once a request has actually failed.
-            if not _utils.snap_installed(snap):
-                raise _utils.not_installed_error(snap)
+            error = _utils.probe_not_installed(snap)
+            if error is not None:
+                raise error
             return {}
         params = {'keys': ','.join(keys)}
     else:
@@ -98,14 +99,15 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
         # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
         # Raised with 'from None': the option-not-found error snapd sent for the absent snap
         # is misleading, and chaining it would only expose the internal probe.
-        if not _utils.snap_installed(snap):
-            raise _utils.not_installed_error(snap) from None
+        error = _utils.probe_not_installed(snap)
+        if error is not None:
+            raise error from None
         raise
     # NOTE: snapd returns {} for an installed snap with no config and for a missing snap.
     # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
     # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
-    if keys is None and not config and not _utils.snap_installed(snap):
-        raise _utils.not_installed_error(snap)
+    if keys is None and not config and (error := _utils.probe_not_installed(snap)) is not None:
+        raise error
     assert isinstance(config, dict)
     return typing.cast('dict[str, Any]', config)
 

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -81,9 +81,6 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
             # NOTE: snapd returns the full configuration if no keys are specified.
             # We pass this behaviour through for keys=None, but for keys=[] we return
             # an empty dict, since the caller explicitly requested no keys.
-            # NOTE: This is the library's only eager installed-check: with no conf request to
-            # make, probing is the only way to tell an installed snap ({}) from an absent one.
-            # Everywhere else we probe reactively, once a request has actually failed.
             if error := _utils.check_installed(snap):
                 raise error
             return {}
@@ -95,9 +92,7 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
     except _errors.OptionNotFoundError:
         # NOTE: snapd reports option-not-found both for a missing key and for a missing snap.
         # The CLI returns 'error: snap "foo" has no "bar" configuration' in both cases.
-        # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
-        # Raised with 'from None': the option-not-found error snapd sent for the absent snap
-        # is misleading, and chaining it would only expose the internal probe.
+        # For symmetry with PUT (set/unset), we convert to NotFoundError here for a missing snap.
         if error := _utils.check_installed(snap):
             raise error from None
         raise

--- a/snap/src/charmlibs/snap/_snapd_interfaces.py
+++ b/snap/src/charmlibs/snap/_snapd_interfaces.py
@@ -70,7 +70,11 @@ def connect(plug: tuple[str, str], slot: tuple[str, str] | str | None = None) ->
         _client.post('/v2/interfaces', body=data)
     except _errors.APIError:
         # Turn snapd's empty-kind 'snap is not installed' error into a typed NotFoundError.
-        _raise_if_snaps_not_installed_or_system(plug_snap, slot_snap)
+        # Raised with 'from None' so the caller gets one traceback naming the missing snap,
+        # rather than a chained one exposing the internal probe.
+        absent = _not_installed_snap(plug_snap, slot_snap)
+        if absent is not None:
+            raise _utils.not_installed_error(absent) from None
         raise
 
 
@@ -144,7 +148,11 @@ def disconnect(
         pass  # Follow the snap CLI's lead and suppress this error.
     except _errors.APIError:
         # Turn snapd's empty-kind 'snap is not installed' error into a typed NotFoundError.
-        _raise_if_snaps_not_installed_or_system(plug_snap, slot_snap)
+        # Raised with 'from None' so the caller gets one traceback naming the missing snap,
+        # rather than a chained one exposing the internal probe.
+        absent = _not_installed_snap(plug_snap, slot_snap)
+        if absent is not None:
+            raise _utils.not_installed_error(absent) from None
         raise
 
 
@@ -158,17 +166,21 @@ def _snap_and_name(spec: tuple[str, str] | str | None) -> tuple[str, str]:
     return snap, name
 
 
-def _raise_if_snaps_not_installed_or_system(plug_snap: str, slot_snap: str) -> None:
-    """Convert an empty-kind 'snap is not installed' API error into a typed NotFoundError.
+def _not_installed_snap(plug_snap: str, slot_snap: str) -> str | None:
+    """Return the first of the named snaps that isn't installed, or None if they all are.
 
     snapd validates the plug snap before the slot snap (daemon/api_interfaces.go), reporting a
     not-installed snap as an empty-kind ``APIError`` before any plug/slot resolution. We probe the
     named snaps in the same order -- plug snap first -- so the ``NotFoundError`` names the same
     snap snapd would blame. Empty (auto-resolved) sides are skipped, and the ``system``/``core``
-    aliases are skipped because snapd serves them without the core snap being installed. If both
-    named snaps are installed, this returns and the caller re-raises the original error.
+    aliases count as installed because snapd serves them without the core snap being installed.
+    If both named snaps are installed, this returns ``None`` and the caller re-raises the
+    original error.
+
+    This returns the snap rather than raising so that the caller's ``raise ... from None`` is the
+    last frame in the traceback, with no uninformative wrapper frame below it.
     """
-    if plug_snap:
-        _utils.raise_if_snap_not_installed_or_system(plug_snap)
-    if slot_snap:
-        _utils.raise_if_snap_not_installed_or_system(slot_snap)
+    for snap in (plug_snap, slot_snap):
+        if snap and not _utils.snap_installed(snap):
+            return snap
+    return None

--- a/snap/src/charmlibs/snap/_snapd_interfaces.py
+++ b/snap/src/charmlibs/snap/_snapd_interfaces.py
@@ -72,9 +72,9 @@ def connect(plug: tuple[str, str], slot: tuple[str, str] | str | None = None) ->
         # Turn snapd's empty-kind 'snap is not installed' error into a typed NotFoundError.
         # Raised with 'from None' so the caller gets one traceback naming the missing snap,
         # rather than a chained one exposing the internal probe.
-        absent = _not_installed_snap(plug_snap, slot_snap)
-        if absent is not None:
-            raise _utils.not_installed_error(absent) from None
+        error = _first_not_installed(plug_snap, slot_snap)
+        if error is not None:
+            raise error from None
         raise
 
 
@@ -150,9 +150,9 @@ def disconnect(
         # Turn snapd's empty-kind 'snap is not installed' error into a typed NotFoundError.
         # Raised with 'from None' so the caller gets one traceback naming the missing snap,
         # rather than a chained one exposing the internal probe.
-        absent = _not_installed_snap(plug_snap, slot_snap)
-        if absent is not None:
-            raise _utils.not_installed_error(absent) from None
+        error = _first_not_installed(plug_snap, slot_snap)
+        if error is not None:
+            raise error from None
         raise
 
 
@@ -166,8 +166,8 @@ def _snap_and_name(spec: tuple[str, str] | str | None) -> tuple[str, str]:
     return snap, name
 
 
-def _not_installed_snap(plug_snap: str, slot_snap: str) -> str | None:
-    """Return the first of the named snaps that isn't installed, or None if they all are.
+def _first_not_installed(plug_snap: str, slot_snap: str) -> _errors.NotFoundError | None:
+    """Return the not-installed error for the first named snap that is absent, or None if all are.
 
     snapd validates the plug snap before the slot snap (daemon/api_interfaces.go), reporting a
     not-installed snap as an empty-kind ``APIError`` before any plug/slot resolution. We probe the
@@ -177,10 +177,10 @@ def _not_installed_snap(plug_snap: str, slot_snap: str) -> str | None:
     If both named snaps are installed, this returns ``None`` and the caller re-raises the
     original error.
 
-    This returns the snap rather than raising so that the caller's ``raise ... from None`` is the
+    This returns the error rather than raising so that the caller's ``raise ... from None`` is the
     last frame in the traceback, with no uninformative wrapper frame below it.
     """
     for snap in (plug_snap, slot_snap):
-        if snap and not _utils.snap_installed(snap):
-            return snap
+        if snap and (error := _utils.probe_not_installed(snap)) is not None:
+            return error
     return None

--- a/snap/src/charmlibs/snap/_snapd_interfaces.py
+++ b/snap/src/charmlibs/snap/_snapd_interfaces.py
@@ -72,8 +72,7 @@ def connect(plug: tuple[str, str], slot: tuple[str, str] | str | None = None) ->
         # Turn snapd's empty-kind 'snap is not installed' error into a typed NotFoundError.
         # Raised with 'from None' so the caller gets one traceback naming the missing snap,
         # rather than a chained one exposing the internal probe.
-        error = _first_not_installed(plug_snap, slot_snap)
-        if error is not None:
+        if error := _first_not_installed(plug_snap, slot_snap):
             raise error from None
         raise
 
@@ -150,8 +149,7 @@ def disconnect(
         # Turn snapd's empty-kind 'snap is not installed' error into a typed NotFoundError.
         # Raised with 'from None' so the caller gets one traceback naming the missing snap,
         # rather than a chained one exposing the internal probe.
-        error = _first_not_installed(plug_snap, slot_snap)
-        if error is not None:
+        if error := _first_not_installed(plug_snap, slot_snap):
             raise error from None
         raise
 
@@ -181,6 +179,6 @@ def _first_not_installed(plug_snap: str, slot_snap: str) -> _errors.NotFoundErro
     last frame in the traceback, with no uninformative wrapper frame below it.
     """
     for snap in (plug_snap, slot_snap):
-        if snap and (error := _utils.probe_not_installed(snap)) is not None:
+        if snap and (error := _utils.check_installed(snap)):
             return error
     return None

--- a/snap/src/charmlibs/snap/_snapd_interfaces.py
+++ b/snap/src/charmlibs/snap/_snapd_interfaces.py
@@ -170,6 +170,6 @@ def _first_not_installed(plug_snap: str, slot_snap: str) -> _errors.NotFoundErro
     aliases count as installed because snapd serves them without the core snap being installed.
     """
     for snap in (plug_snap, slot_snap):
-        if snap and (error := _utils.check_installed(snap)):
+        if snap and (error := _utils.check_installed_or_system(snap)):
             return error
     return None

--- a/snap/src/charmlibs/snap/_snapd_interfaces.py
+++ b/snap/src/charmlibs/snap/_snapd_interfaces.py
@@ -70,8 +70,6 @@ def connect(plug: tuple[str, str], slot: tuple[str, str] | str | None = None) ->
         _client.post('/v2/interfaces', body=data)
     except _errors.APIError:
         # Turn snapd's empty-kind 'snap is not installed' error into a typed NotFoundError.
-        # Raised with 'from None' so the caller gets one traceback naming the missing snap,
-        # rather than a chained one exposing the internal probe.
         if error := _first_not_installed(plug_snap, slot_snap):
             raise error from None
         raise
@@ -147,8 +145,6 @@ def disconnect(
         pass  # Follow the snap CLI's lead and suppress this error.
     except _errors.APIError:
         # Turn snapd's empty-kind 'snap is not installed' error into a typed NotFoundError.
-        # Raised with 'from None' so the caller gets one traceback naming the missing snap,
-        # rather than a chained one exposing the internal probe.
         if error := _first_not_installed(plug_snap, slot_snap):
             raise error from None
         raise
@@ -165,18 +161,13 @@ def _snap_and_name(spec: tuple[str, str] | str | None) -> tuple[str, str]:
 
 
 def _first_not_installed(plug_snap: str, slot_snap: str) -> _errors.NotFoundError | None:
-    """Return the not-installed error for the first named snap that is absent, or None if all are.
+    """Return a NotFoundError for the first named snap that is absent.
 
     snapd validates the plug snap before the slot snap (daemon/api_interfaces.go), reporting a
     not-installed snap as an empty-kind ``APIError`` before any plug/slot resolution. We probe the
     named snaps in the same order -- plug snap first -- so the ``NotFoundError`` names the same
-    snap snapd would blame. Empty (auto-resolved) sides are skipped, and the ``system``/``core``
+    snap snapd would blame. Empty (auto-resolved) sides are skipped. Note the ``system``/``core``
     aliases count as installed because snapd serves them without the core snap being installed.
-    If both named snaps are installed, this returns ``None`` and the caller re-raises the
-    original error.
-
-    This returns the error rather than raising so that the caller's ``raise ... from None`` is the
-    last frame in the traceback, with no uninformative wrapper frame below it.
     """
     for snap in (plug_snap, slot_snap):
         if snap and (error := _utils.check_installed(snap)):

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -27,8 +27,8 @@ def check_installed(snap: str) -> _errors.NotFoundError | None:
 
     Returns ``None`` when the snap is installed, and for the ``system``/``core`` aliases, which
     snapd serves whether or not the core snap is installed (so they are never treated as absent).
-    Otherwise probes ``GET /v2/snaps/{snap}`` and returns snapd's own :class:`NotFoundError`
-    unchanged when it reports the snap absent, ready for the caller to ``raise``.
+    Otherwise probes ``GET /v2/snaps/{snap}`` and returns snapd's own :class:`NotFoundError` when
+    it reports the snap absent, ready for the caller to ``raise``.
 
     The error-or-``None`` return supports the ``if error := check_installed(snap): raise error``
     idiom at the call sites (with ``from None`` where an error is already being handled).
@@ -39,8 +39,10 @@ def check_installed(snap: str) -> _errors.NotFoundError | None:
     interface endpoints, which name the snap in the message directly, but we don't hand-construct
     an error to paper over that -- the value and ``str()`` carry the name either way.
 
-    Raise the returned error with ``from None`` when converting an error snapd has already
-    reported, so the caller sees a single traceback instead of a chained one exposing this probe.
+    Its traceback is cleared before returning: snapd's error was raised deep inside this probe's
+    ``GET /v2/snaps/{snap}``, and re-raising it with that traceback attached would expose the
+    internal probe. Cleared, a ``raise`` at the call site produces a single traceback that starts
+    there. Pair the ``raise`` with ``from None`` to also drop any error being handled.
     """
     # NOTE: snapd's conf endpoints treat 'system' as an alias for 'core', and interface requests
     # remap 'system'/'core' to the snapd snap, so both names are served without the core snap.
@@ -51,7 +53,7 @@ def check_installed(snap: str) -> _errors.NotFoundError | None:
     try:
         _client.get(f'/v2/snaps/{snap}')
     except _errors.NotFoundError as e:
-        return e
+        return e.with_traceback(None)
     return None
 
 

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -19,25 +19,44 @@ from __future__ import annotations
 import datetime
 import sys
 
-from . import _client
+from . import _client, _errors
 
 
-def raise_if_snap_not_installed_or_system(snap: str) -> None:
-    """Raise NotFoundError if the snap is not installed, unless it names a system snap.
+def snap_installed(snap: str) -> bool:
+    """Return whether the snap is installed, treating the system snap names as always installed.
 
     snapd treats ``'system'`` as an alias for ``'core'`` on its config endpoints, and remaps both
     ``'system'`` and ``'core'`` to the always-present snapd snap on its interface endpoints, so
-    operations on these names succeed whether or not the core snap is installed. For those names
-    the installed check is skipped; for any other name this probes ``/v2/snaps/{snap}``, which
-    raises :class:`NotFoundError` if the snap is not installed.
+    operations on these names succeed whether or not the core snap is installed. Those names are
+    reported as installed without probing; any other name is probed with ``GET /v2/snaps/{snap}``.
     """
     # NOTE: snapd's conf endpoints treat 'system' as an alias for 'core', and interface requests
     # remap 'system'/'core' to the snapd snap, so both names are served without the core snap.
     # /v2/snaps/system always 404s (a hardcoded alias, not a real snap) and /v2/snaps/core 404s
-    # when the core snap is absent, so probing either would turn a working call into NotFoundError.
+    # when the core snap is absent, so probing either would report a working call as not installed.
     if snap in ('system', 'core'):
-        return
-    _client.get(f'/v2/snaps/{snap}')  # Raises NotFoundError if the snap isn't installed.
+        return True
+    try:
+        _client.get(f'/v2/snaps/{snap}')
+    except _errors.NotFoundError:
+        return False
+    return True
+
+
+def not_installed_error(snap: str) -> _errors.NotFoundError:
+    """Build the typed error to raise for a snap that isn't installed.
+
+    The message matches snapd's own wording for this case, as returned by the conf PUT and the
+    interface endpoints, so the error names the snap even when it was detected by the
+    :func:`snap_installed` probe, whose ``GET /v2/snaps/{snap}`` reports only 'snap not installed'
+    with the name in ``value``.
+
+    Raise this with ``from None`` when converting an error snapd has already reported, so the
+    caller sees a single traceback instead of a chained one exposing the internal probe.
+    """
+    return _errors.NotFoundError(
+        f'snap "{snap}" is not installed', kind='snap-not-found', value=snap
+    )
 
 
 def normalize_channel(channel: str) -> str:

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -23,17 +23,18 @@ from . import _client, _errors
 
 
 def probe_not_installed(snap: str) -> _errors.NotFoundError | None:
-    """Probe whether the snap is installed, returning the typed error to raise if it isn't.
+    """Probe whether the snap is installed, returning snapd's not-installed error if it isn't.
 
     Returns ``None`` when the snap is installed, and for the ``system``/``core`` aliases, which
     snapd serves whether or not the core snap is installed (so they are never treated as absent).
-    Otherwise probes ``GET /v2/snaps/{snap}`` and, when snapd reports the snap absent, returns a
-    :class:`NotFoundError` whose message names the snap, ready for the caller to ``raise``.
+    Otherwise probes ``GET /v2/snaps/{snap}`` and returns snapd's own :class:`NotFoundError`
+    unchanged when it reports the snap absent, ready for the caller to ``raise``.
 
-    The message is composed rather than passed through from the probe's own error, which says
-    only 'snap not installed' with the name in ``value``. Naming the snap matches snapd's own
-    wording on the conf PUT and interface endpoints, so every operation reports a missing snap
-    the same way.
+    The error is snapd's, not one we build: its message is the terse 'snap not installed' with
+    the snap name in ``value`` (which ``str()`` surfaces as 'snap not installed (name)'), and it
+    carries snapd's real ``status_code``. It reads a little differently from the conf PUT and
+    interface endpoints, which name the snap in the message directly, but we don't hand-construct
+    an error to paper over that -- the value and ``str()`` carry the name either way.
 
     Raise the returned error with ``from None`` when converting an error snapd has already
     reported, so the caller sees a single traceback instead of a chained one exposing this probe.
@@ -46,10 +47,8 @@ def probe_not_installed(snap: str) -> _errors.NotFoundError | None:
         return None
     try:
         _client.get(f'/v2/snaps/{snap}')
-    except _errors.NotFoundError:
-        return _errors.NotFoundError(
-            f'snap "{snap}" is not installed', kind='snap-not-found', value=snap
-        )
+    except _errors.NotFoundError as e:
+        return e
     return None
 
 

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -22,11 +22,12 @@ import sys
 from . import _client, _errors
 
 
-def check_installed(snap: str) -> _errors.NotFoundError | None:
+def check_installed_or_system(snap: str) -> _errors.NotFoundError | None:
     """Return NotFoundError if the snap is not installed or a system/core alias.
 
     Returns ``None`` when the snap is installed, and for the ``system``/``core`` aliases, which
     snapd handles config and interfaces for whether or not the core snap is installed as a snap.
+    Check if this system handling is appropriate if using this function with other snapd endpoints.
     Otherwise probes ``GET /v2/snaps/{snap}`` and returns snapd's own :class:`NotFoundError` when
     it reports the snap absent, ready for the caller to ``raise``.
     """

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -22,13 +22,16 @@ import sys
 from . import _client, _errors
 
 
-def probe_not_installed(snap: str) -> _errors.NotFoundError | None:
-    """Probe whether the snap is installed, returning snapd's not-installed error if it isn't.
+def check_installed(snap: str) -> _errors.NotFoundError | None:
+    """Check whether the snap is installed, returning snapd's not-installed error if it isn't.
 
     Returns ``None`` when the snap is installed, and for the ``system``/``core`` aliases, which
     snapd serves whether or not the core snap is installed (so they are never treated as absent).
     Otherwise probes ``GET /v2/snaps/{snap}`` and returns snapd's own :class:`NotFoundError`
     unchanged when it reports the snap absent, ready for the caller to ``raise``.
+
+    The error-or-``None`` return supports the ``if error := check_installed(snap): raise error``
+    idiom at the call sites (with ``from None`` where an error is already being handled).
 
     The error is snapd's, not one we build: its message is the terse 'snap not installed' with
     the snap name in ``value`` (which ``str()`` surfaces as 'snap not installed (name)'), and it

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -23,26 +23,12 @@ from . import _client, _errors
 
 
 def check_installed(snap: str) -> _errors.NotFoundError | None:
-    """Check whether the snap is installed, returning snapd's not-installed error if it isn't.
+    """Return NotFoundError if the snap is not installed or a system/core alias.
 
     Returns ``None`` when the snap is installed, and for the ``system``/``core`` aliases, which
-    snapd serves whether or not the core snap is installed (so they are never treated as absent).
+    snapd handles config and interfaces for whether or not the core snap is installed as a snap.
     Otherwise probes ``GET /v2/snaps/{snap}`` and returns snapd's own :class:`NotFoundError` when
     it reports the snap absent, ready for the caller to ``raise``.
-
-    The error-or-``None`` return supports the ``if error := check_installed(snap): raise error``
-    idiom at the call sites (with ``from None`` where an error is already being handled).
-
-    The error is snapd's, not one we build: its message is the terse 'snap not installed' with
-    the snap name in ``value`` (which ``str()`` surfaces as 'snap not installed (name)'), and it
-    carries snapd's real ``status_code``. It reads a little differently from the conf PUT and
-    interface endpoints, which name the snap in the message directly, but we don't hand-construct
-    an error to paper over that -- the value and ``str()`` carry the name either way.
-
-    Its traceback is cleared before returning: snapd's error was raised deep inside this probe's
-    ``GET /v2/snaps/{snap}``, and re-raising it with that traceback attached would expose the
-    internal probe. Cleared, a ``raise`` at the call site produces a single traceback that starts
-    there. Pair the ``raise`` with ``from None`` to also drop any error being handled.
     """
     # NOTE: snapd's conf endpoints treat 'system' as an alias for 'core', and interface requests
     # remap 'system'/'core' to the snapd snap, so both names are served without the core snap.
@@ -53,7 +39,7 @@ def check_installed(snap: str) -> _errors.NotFoundError | None:
     try:
         _client.get(f'/v2/snaps/{snap}')
     except _errors.NotFoundError as e:
-        return e.with_traceback(None)
+        return e.with_traceback(None)  # Clean error with no traceback for the caller to raise.
     return None
 
 

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -22,41 +22,35 @@ import sys
 from . import _client, _errors
 
 
-def snap_installed(snap: str) -> bool:
-    """Return whether the snap is installed, treating the system snap names as always installed.
+def probe_not_installed(snap: str) -> _errors.NotFoundError | None:
+    """Probe whether the snap is installed, returning the typed error to raise if it isn't.
 
-    snapd treats ``'system'`` as an alias for ``'core'`` on its config endpoints, and remaps both
-    ``'system'`` and ``'core'`` to the always-present snapd snap on its interface endpoints, so
-    operations on these names succeed whether or not the core snap is installed. Those names are
-    reported as installed without probing; any other name is probed with ``GET /v2/snaps/{snap}``.
+    Returns ``None`` when the snap is installed, and for the ``system``/``core`` aliases, which
+    snapd serves whether or not the core snap is installed (so they are never treated as absent).
+    Otherwise probes ``GET /v2/snaps/{snap}`` and, when snapd reports the snap absent, returns a
+    :class:`NotFoundError` whose message names the snap, ready for the caller to ``raise``.
+
+    The message is composed rather than passed through from the probe's own error, which says
+    only 'snap not installed' with the name in ``value``. Naming the snap matches snapd's own
+    wording on the conf PUT and interface endpoints, so every operation reports a missing snap
+    the same way.
+
+    Raise the returned error with ``from None`` when converting an error snapd has already
+    reported, so the caller sees a single traceback instead of a chained one exposing this probe.
     """
     # NOTE: snapd's conf endpoints treat 'system' as an alias for 'core', and interface requests
     # remap 'system'/'core' to the snapd snap, so both names are served without the core snap.
     # /v2/snaps/system always 404s (a hardcoded alias, not a real snap) and /v2/snaps/core 404s
     # when the core snap is absent, so probing either would report a working call as not installed.
     if snap in ('system', 'core'):
-        return True
+        return None
     try:
         _client.get(f'/v2/snaps/{snap}')
     except _errors.NotFoundError:
-        return False
-    return True
-
-
-def not_installed_error(snap: str) -> _errors.NotFoundError:
-    """Build the typed error to raise for a snap that isn't installed.
-
-    The message matches snapd's own wording for this case, as returned by the conf PUT and the
-    interface endpoints, so the error names the snap even when it was detected by the
-    :func:`snap_installed` probe, whose ``GET /v2/snaps/{snap}`` reports only 'snap not installed'
-    with the name in ``value``.
-
-    Raise this with ``from None`` when converting an error snapd has already reported, so the
-    caller sees a single traceback instead of a chained one exposing the internal probe.
-    """
-    return _errors.NotFoundError(
-        f'snap "{snap}" is not installed', kind='snap-not-found', value=snap
-    )
+        return _errors.NotFoundError(
+            f'snap "{snap}" is not installed', kind='snap-not-found', value=snap
+        )
+    return None
 
 
 def normalize_channel(channel: str) -> str:

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -93,6 +93,11 @@ def test_get_sync_error_snap_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _client.get(f'/v2/snaps/{_ABSENT_SNAP}')
     assert ctx.value.kind == 'snap-not-found'
+    # This endpoint is what _utils.snap_installed probes with, and its message is generic (the
+    # snap name is in `value` only). That's why callers translating a not-installed snap into a
+    # typed error compose their own message rather than reusing the probe's.
+    assert ctx.value.message == 'snap not installed'
+    assert str(ctx.value.value) == _ABSENT_SNAP
 
 
 def test_get_sync_error_no_kind():

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -93,7 +93,7 @@ def test_get_sync_error_snap_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _client.get(f'/v2/snaps/{_ABSENT_SNAP}')
     assert ctx.value.kind == 'snap-not-found'
-    # This endpoint is what _utils.probe_not_installed probes with; its message is terse, with the
+    # This endpoint is what _utils.check_installed probes with; its message is terse, with the
     # snap name in `value`. get()/connect()/disconnect() raise this very error unchanged, relying
     # on str() to surface the name rather than building their own message.
     assert ctx.value.message == 'snap not installed'

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -93,9 +93,9 @@ def test_get_sync_error_snap_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _client.get(f'/v2/snaps/{_ABSENT_SNAP}')
     assert ctx.value.kind == 'snap-not-found'
-    # This endpoint is what _utils.snap_installed probes with, and its message is generic (the
-    # snap name is in `value` only). That's why callers translating a not-installed snap into a
-    # typed error compose their own message rather than reusing the probe's.
+    # This endpoint is what _utils.probe_not_installed probes with, and its message is generic
+    # (the snap name is in `value` only). That's why callers translating a not-installed snap into
+    # a typed error compose their own message rather than reusing the probe's.
     assert ctx.value.message == 'snap not installed'
     assert str(ctx.value.value) == _ABSENT_SNAP
 

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -93,11 +93,12 @@ def test_get_sync_error_snap_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _client.get(f'/v2/snaps/{_ABSENT_SNAP}')
     assert ctx.value.kind == 'snap-not-found'
-    # This endpoint is what _utils.probe_not_installed probes with, and its message is generic
-    # (the snap name is in `value` only). That's why callers translating a not-installed snap into
-    # a typed error compose their own message rather than reusing the probe's.
+    # This endpoint is what _utils.probe_not_installed probes with; its message is terse, with the
+    # snap name in `value`. get()/connect()/disconnect() raise this very error unchanged, relying
+    # on str() to surface the name rather than building their own message.
     assert ctx.value.message == 'snap not installed'
     assert str(ctx.value.value) == _ABSENT_SNAP
+    assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
 def test_get_sync_error_no_kind():

--- a/snap/tests/functional/test_snapd_conf.py
+++ b/snap/tests/functional/test_snapd_conf.py
@@ -179,6 +179,19 @@ def test_get_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP, ['any-key'])
     assert ctx.value.kind == 'snap-not-found'
+    # Consistent with set/unset (see test_set_not_installed_snap_raises_snap_not_found), rather
+    # than the generic 'snap not installed' the /v2/snaps/{snap} probe itself returns.
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+    assert str(ctx.value.value) == _ABSENT_SNAP
+
+
+def test_get_not_installed_snap_error_is_not_chained():
+    # snapd's misleading option-not-found error is suppressed ('raise ... from None'), so the
+    # traceback is a single error and doesn't expose the internal /v2/snaps/{snap} probe.
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        _snapd_conf.get(_ABSENT_SNAP, ['any-key'])
+    assert ctx.value.__cause__ is None
+    assert ctx.value.__suppress_context__
 
 
 def test_get_all_not_installed_snap_raises_not_found():
@@ -188,6 +201,9 @@ def test_get_all_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP)
     assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+    # No error was being handled when this was raised, so there's nothing to chain.
+    assert ctx.value.__context__ is None
 
 
 def test_raw_get_all_not_installed_snap_returns_empty_dict():
@@ -226,6 +242,7 @@ def test_get_empty_keys_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP, [])
     assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
 
 
 def test_get_keys_of_only_empty_strings_returns_full_config():
@@ -301,12 +318,16 @@ def test_set_not_installed_snap_raises_snap_not_found(config: dict[str, Any]):
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.set(_ABSENT_SNAP, config)
     assert ctx.value.kind == 'snap-not-found'
+    # Pins snapd's own wording for a not-installed snap: get() raises the same message when its
+    # probe finds the snap absent, so all three conf operations report it identically.
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
 
 
 def test_unset_not_installed_snap_raises_snap_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.unset(_ABSENT_SNAP, ['test-key'])
     assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/functional/test_snapd_conf.py
+++ b/snap/tests/functional/test_snapd_conf.py
@@ -179,10 +179,13 @@ def test_get_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP, ['any-key'])
     assert ctx.value.kind == 'snap-not-found'
-    # Consistent with set/unset (see test_set_not_installed_snap_raises_snap_not_found), rather
-    # than the generic 'snap not installed' the /v2/snaps/{snap} probe itself returns.
-    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+    # get() raises snapd's own /v2/snaps/{snap} probe error unchanged: a terse message with the
+    # snap name in value, which str() surfaces as 'snap not installed (<snap>)'. This reads
+    # differently from set/unset (whose PUT error names the snap in the message) -- we pass each
+    # endpoint's wording through rather than hand-building an error to normalise them.
+    assert ctx.value.message == 'snap not installed'
     assert str(ctx.value.value) == _ABSENT_SNAP
+    assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
 def test_get_not_installed_snap_error_is_not_chained():
@@ -201,7 +204,8 @@ def test_get_all_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP)
     assert ctx.value.kind == 'snap-not-found'
-    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+    assert ctx.value.message == 'snap not installed'
+    assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
     # No error was being handled when this was raised, so there's nothing to chain.
     assert ctx.value.__context__ is None
 
@@ -242,7 +246,8 @@ def test_get_empty_keys_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP, [])
     assert ctx.value.kind == 'snap-not-found'
-    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+    assert ctx.value.message == 'snap not installed'
+    assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
 def test_get_keys_of_only_empty_strings_returns_full_config():
@@ -318,8 +323,9 @@ def test_set_not_installed_snap_raises_snap_not_found(config: dict[str, Any]):
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_conf.set(_ABSENT_SNAP, config)
     assert ctx.value.kind == 'snap-not-found'
-    # Pins snapd's own wording for a not-installed snap: get() raises the same message when its
-    # probe finds the snap absent, so all three conf operations report it identically.
+    # set/unset surface snapd's PUT error directly, which names the snap in the message. get()
+    # differs -- it raises the terse /v2/snaps probe error (name in value) -- because snapd words
+    # its two endpoints differently and we pass each through rather than normalising them.
     assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
 
 

--- a/snap/tests/functional/test_snapd_interfaces.py
+++ b/snap/tests/functional/test_snapd_interfaces.py
@@ -329,17 +329,19 @@ def test_disconnect_all_empty_raises():
 # ---------------------------------------------------------------------------
 
 
-# The probe hits /v2/snaps/{name}, whose not-found error carries a generic message
-# ('snap not installed') with the snap name only in `value`. The raised error doesn't reuse that
-# message: it names the snap, matching snapd's own wording on /v2/interfaces (and on conf PUT).
+# The probe hits /v2/snaps/{name}, whose not-found error carries a terse message
+# ('snap not installed') with the snap name in `value`. connect/disconnect raise that error
+# unchanged; str() surfaces the name as 'snap not installed (<snap>)'. This reads differently
+# from snapd's /v2/interfaces wording, which we deliberately don't reconstruct.
 
 
 def test_connect_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_interfaces.connect((_ABSENT_SNAP, 'home'))
     assert ctx.value.kind == 'snap-not-found'
-    assert _ABSENT_SNAP in str(ctx.value.value)
-    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert ctx.value.message == 'snap not installed'
+    assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
 def test_connect_not_installed_snap_error_is_not_chained():
@@ -355,16 +357,18 @@ def test_disconnect_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_interfaces.disconnect((_ABSENT_SNAP, 'home'))
     assert ctx.value.kind == 'snap-not-found'
-    assert _ABSENT_SNAP in str(ctx.value.value)
-    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert ctx.value.message == 'snap not installed'
+    assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
 def test_connect_slot_snap_not_installed_raises_not_found():
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd_interfaces.connect((_SNAP, _PLUG), (_ABSENT_SNAP, _PLUG))
     assert ctx.value.kind == 'snap-not-found'
-    assert _ABSENT_SNAP in str(ctx.value.value)
-    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert ctx.value.message == 'snap not installed'
+    assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/functional/test_snapd_interfaces.py
+++ b/snap/tests/functional/test_snapd_interfaces.py
@@ -330,7 +330,8 @@ def test_disconnect_all_empty_raises():
 
 
 # The probe hits /v2/snaps/{name}, whose not-found error carries a generic message
-# ('snap not installed') and puts the snap name in `value` (unlike the /v2/interfaces message).
+# ('snap not installed') with the snap name only in `value`. The raised error doesn't reuse that
+# message: it names the snap, matching snapd's own wording on /v2/interfaces (and on conf PUT).
 
 
 def test_connect_not_installed_snap_raises_not_found():
@@ -338,6 +339,16 @@ def test_connect_not_installed_snap_raises_not_found():
         _snapd_interfaces.connect((_ABSENT_SNAP, 'home'))
     assert ctx.value.kind == 'snap-not-found'
     assert _ABSENT_SNAP in str(ctx.value.value)
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
+
+
+def test_connect_not_installed_snap_error_is_not_chained():
+    # The original API error is suppressed ('raise ... from None'), so the traceback is a single
+    # error naming the snap, with no 'During handling of the above exception' probe noise.
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        _snapd_interfaces.connect((_ABSENT_SNAP, 'home'))
+    assert ctx.value.__cause__ is None
+    assert ctx.value.__suppress_context__
 
 
 def test_disconnect_not_installed_snap_raises_not_found():
@@ -345,6 +356,7 @@ def test_disconnect_not_installed_snap_raises_not_found():
         _snapd_interfaces.disconnect((_ABSENT_SNAP, 'home'))
     assert ctx.value.kind == 'snap-not-found'
     assert _ABSENT_SNAP in str(ctx.value.value)
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
 
 
 def test_connect_slot_snap_not_installed_raises_not_found():
@@ -352,6 +364,7 @@ def test_connect_slot_snap_not_installed_raises_not_found():
         _snapd_interfaces.connect((_SNAP, _PLUG), (_ABSENT_SNAP, _PLUG))
     assert ctx.value.kind == 'snap-not-found'
     assert _ABSENT_SNAP in str(ctx.value.value)
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/unit/test_errors.py
+++ b/snap/tests/unit/test_errors.py
@@ -85,5 +85,25 @@ def test_snap_error():
     assert 'the-value' in r
     assert '400' in r
     assert 'Bad Request' in r
-    # str() is just the message
-    assert str(err) == 'the message'
+    # str() appends a string value that adds information the message doesn't already carry.
+    assert str(err) == 'the message (the-value)'
+
+
+def test_str_appends_informative_string_value():
+    def s(message: str, value: object) -> str:
+        return str(_errors.Error(message, kind='k', value=value))
+
+    # A non-empty string value not already in the message is appended in parentheses -- this is
+    # what surfaces the snap name in snapd's terse 'snap not installed' error.
+    assert s('snap not installed', 'hello-world') == 'snap not installed (hello-world)'
+    # Not appended when it would be redundant: value already present in the message ...
+    assert s('snap "hello-world" is not installed', 'hello-world') == (
+        'snap "hello-world" is not installed'
+    )
+    # ... or empty ...
+    assert s('boom', '') == 'boom'
+    # ... or not a plain string (e.g. option-not-found's {'SnapName', 'Key'} dict, whose contents
+    # the message already spells out -- rendering the dict here would just be noise).
+    assert s('snap "lxd" has no "k" configuration option', {'SnapName': 'lxd', 'Key': 'k'}) == (
+        'snap "lxd" has no "k" configuration option'
+    )

--- a/snap/tests/unit/test_errors.py
+++ b/snap/tests/unit/test_errors.py
@@ -89,21 +89,24 @@ def test_snap_error():
     assert str(err) == 'the message (the-value)'
 
 
-def test_str_appends_informative_string_value():
-    def s(message: str, value: object) -> str:
-        return str(_errors.Error(message, kind='k', value=value))
-
-    # A non-empty string value not already in the message is appended in parentheses -- this is
-    # what surfaces the snap name in snapd's terse 'snap not installed' error.
-    assert s('snap not installed', 'hello-world') == 'snap not installed (hello-world)'
-    # Not appended when it would be redundant: value already present in the message ...
-    assert s('snap "hello-world" is not installed', 'hello-world') == (
-        'snap "hello-world" is not installed'
-    )
-    # ... or empty ...
-    assert s('boom', '') == 'boom'
-    # ... or not a plain string (e.g. option-not-found's {'SnapName', 'Key'} dict, whose contents
-    # the message already spells out -- rendering the dict here would just be noise).
-    assert s('snap "lxd" has no "k" configuration option', {'SnapName': 'lxd', 'Key': 'k'}) == (
-        'snap "lxd" has no "k" configuration option'
-    )
+@pytest.mark.parametrize(
+    ('message', 'value', 'expected'),
+    [
+        ('snap not installed', 'hello-world', 'snap not installed (hello-world)'),
+        # Not appended when the value appears in the message.
+        (
+            'snap "hello-world" is not installed',
+            'hello-world',
+            'snap "hello-world" is not installed',
+        ),
+        ('boom', '', 'boom'),  # Not appended when the value is empty.
+        # Not appended when the value is not a string.
+        (
+            'snap "lxd" has no "k" configuration option',
+            {'SnapName': 'lxd', 'Key': 'k'},
+            'snap "lxd" has no "k" configuration option',
+        ),
+    ],
+)
+def test_str_appends_informative_string_value(message: str, value: object, expected: str):
+    assert str(_errors.Error(message, kind='some-kind', value=value)) == expected

--- a/snap/tests/unit/test_snapd_conf.py
+++ b/snap/tests/unit/test_snapd_conf.py
@@ -89,10 +89,11 @@ class TestGetEmptyKeys:
         )
         with pytest.raises(NotFoundError) as ctx:
             _snapd_conf.get('hello-world', [])
-        # The probe's generic message is replaced with one naming the snap, and the probe's own
-        # error isn't chained -- it was handled, not propagated.
-        assert ctx.value.message == 'snap "hello-world" is not installed'
+        # snapd's own probe error is raised unchanged: terse message, snap name in value (which
+        # str() surfaces). Not chained -- the probe's error was handled, not propagated.
+        assert ctx.value.message == 'snap not installed'
         assert ctx.value.value == 'hello-world'
+        assert str(ctx.value) == 'snap not installed (hello-world)'
         assert ctx.value.__context__ is None
 
     def test_get_empty_keys_system_not_probed(self, mock_client: MockClient):
@@ -106,20 +107,27 @@ class TestGetAbsentSnapProbe:
     # empty configuration), so get() probes /v2/snaps/{snap} on those paths to raise
     # NotFoundError, consistent with set and unset. See the functional tests for captured
     # responses.
-    _OPTION_NOT_FOUND = OptionNotFoundError(
-        'snap "hello-world" has no "mykey" configuration option',
-        kind='option-not-found',
-        value="{'SnapName': 'hello-world', 'Key': 'mykey'}",
-    )
-    _SNAP_NOT_FOUND = NotFoundError(
-        'snap not installed', kind='snap-not-found', value='hello-world'
-    )
+    # Built fresh per call, not shared: raising an exception mutates its __context__, and the
+    # probe now re-raises snapd's own error object, so a shared instance would leak chaining
+    # state between tests (in production each probe gets a freshly parsed exception).
+    @staticmethod
+    def _option_not_found() -> OptionNotFoundError:
+        return OptionNotFoundError(
+            'snap "hello-world" has no "mykey" configuration option',
+            kind='option-not-found',
+            # snapd sends this value as a JSON object, not a string (see the conf fixture).
+            value={'SnapName': 'hello-world', 'Key': 'mykey'},
+        )
+
+    @staticmethod
+    def _snap_not_found() -> NotFoundError:
+        return NotFoundError('snap not installed', kind='snap-not-found', value='hello-world')
 
     def test_missing_key_on_installed_snap_reraises_option_not_found(
         self, mock_client: MockClient
     ):
         mock_client.get.side_effect = [
-            self._OPTION_NOT_FOUND,
+            self._option_not_found(),
             result_of('snap_info_hello_world.json'),
         ]
         with pytest.raises(OptionNotFoundError):
@@ -128,18 +136,19 @@ class TestGetAbsentSnapProbe:
         assert probe_call.args[0] == '/v2/snaps/hello-world'
 
     def test_missing_key_on_absent_snap_raises_not_found(self, mock_client: MockClient):
-        mock_client.get.side_effect = [self._OPTION_NOT_FOUND, self._SNAP_NOT_FOUND]
+        mock_client.get.side_effect = [self._option_not_found(), self._snap_not_found()]
         with pytest.raises(NotFoundError) as ctx:
             _snapd_conf.get('hello-world', ['mykey'])
-        assert ctx.value.message == 'snap "hello-world" is not installed'
+        assert ctx.value.message == 'snap not installed'
         assert ctx.value.value == 'hello-world'
+        assert str(ctx.value) == 'snap not installed (hello-world)'
 
     def test_missing_key_on_absent_snap_does_not_chain_option_not_found(
         self, mock_client: MockClient
     ):
         # The misleading option-not-found error snapd sent for the absent snap is suppressed
         # ('raise ... from None'), so the user sees a single traceback.
-        mock_client.get.side_effect = [self._OPTION_NOT_FOUND, self._SNAP_NOT_FOUND]
+        mock_client.get.side_effect = [self._option_not_found(), self._snap_not_found()]
         with pytest.raises(NotFoundError) as ctx:
             _snapd_conf.get('hello-world', ['mykey'])
         assert ctx.value.__cause__ is None
@@ -148,11 +157,11 @@ class TestGetAbsentSnapProbe:
     def test_get_all_empty_on_absent_snap_raises_not_found(self, mock_client: MockClient):
         # A bare conf GET on an absent snap is a 200 with an empty result, so the probe is
         # what turns it into an error.
-        mock_client.get.side_effect = [{}, self._SNAP_NOT_FOUND]
+        mock_client.get.side_effect = [{}, self._snap_not_found()]
         with pytest.raises(NotFoundError) as ctx:
             _snapd_conf.get('hello-world')
-        assert ctx.value.message == 'snap "hello-world" is not installed'
-        assert ctx.value.value == 'hello-world'
+        assert ctx.value.message == 'snap not installed'
+        assert str(ctx.value) == 'snap not installed (hello-world)'
         assert ctx.value.__context__ is None
 
     def test_get_all_empty_on_installed_snap_returns_empty_dict(self, mock_client: MockClient):
@@ -166,7 +175,7 @@ class TestGetAbsentSnapProbe:
 
     def test_missing_key_on_system_is_not_probed(self, mock_client: MockClient):
         # /v2/snaps/system always 404s while its conf is served, so system names skip the probe.
-        mock_client.get.side_effect = self._OPTION_NOT_FOUND
+        mock_client.get.side_effect = self._option_not_found()
         with pytest.raises(OptionNotFoundError):
             _snapd_conf.get('system', ['mykey'])
         mock_client.get.assert_called_once()

--- a/snap/tests/unit/test_snapd_conf.py
+++ b/snap/tests/unit/test_snapd_conf.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import traceback
 from typing import TYPE_CHECKING
 
 import pytest
@@ -153,6 +154,15 @@ class TestGetAbsentSnapProbe:
             _snapd_conf.get('hello-world', ['mykey'])
         assert ctx.value.__cause__ is None
         assert ctx.value.__suppress_context__
+
+    def test_missing_key_on_absent_snap_traceback_excludes_probe(self, mock_client: MockClient):
+        # check_installed clears the probe's traceback, so the re-raised error starts at get()'s
+        # own raise and never walks back through the internal /v2/snaps/{snap} probe GET.
+        mock_client.get.side_effect = [self._option_not_found(), self._snap_not_found()]
+        with pytest.raises(NotFoundError) as ctx:
+            _snapd_conf.get('hello-world', ['mykey'])
+        files = [frame.filename for frame in traceback.extract_tb(ctx.value.__traceback__)]
+        assert not any(f.endswith('_utils.py') for f in files)
 
     def test_get_all_empty_on_absent_snap_raises_not_found(self, mock_client: MockClient):
         # A bare conf GET on an absent snap is a 200 with an empty result, so the probe is

--- a/snap/tests/unit/test_snapd_conf.py
+++ b/snap/tests/unit/test_snapd_conf.py
@@ -87,8 +87,13 @@ class TestGetEmptyKeys:
         mock_client.get.side_effect = NotFoundError(
             'snap not installed', kind='snap-not-found', value='hello-world'
         )
-        with pytest.raises(NotFoundError):
+        with pytest.raises(NotFoundError) as ctx:
             _snapd_conf.get('hello-world', [])
+        # The probe's generic message is replaced with one naming the snap, and the probe's own
+        # error isn't chained -- it was handled, not propagated.
+        assert ctx.value.message == 'snap "hello-world" is not installed'
+        assert ctx.value.value == 'hello-world'
+        assert ctx.value.__context__ is None
 
     def test_get_empty_keys_system_not_probed(self, mock_client: MockClient):
         # system/core skip the installed-snap probe entirely, so no network call is made.
@@ -124,15 +129,31 @@ class TestGetAbsentSnapProbe:
 
     def test_missing_key_on_absent_snap_raises_not_found(self, mock_client: MockClient):
         mock_client.get.side_effect = [self._OPTION_NOT_FOUND, self._SNAP_NOT_FOUND]
-        with pytest.raises(NotFoundError):
+        with pytest.raises(NotFoundError) as ctx:
             _snapd_conf.get('hello-world', ['mykey'])
+        assert ctx.value.message == 'snap "hello-world" is not installed'
+        assert ctx.value.value == 'hello-world'
+
+    def test_missing_key_on_absent_snap_does_not_chain_option_not_found(
+        self, mock_client: MockClient
+    ):
+        # The misleading option-not-found error snapd sent for the absent snap is suppressed
+        # ('raise ... from None'), so the user sees a single traceback.
+        mock_client.get.side_effect = [self._OPTION_NOT_FOUND, self._SNAP_NOT_FOUND]
+        with pytest.raises(NotFoundError) as ctx:
+            _snapd_conf.get('hello-world', ['mykey'])
+        assert ctx.value.__cause__ is None
+        assert ctx.value.__suppress_context__
 
     def test_get_all_empty_on_absent_snap_raises_not_found(self, mock_client: MockClient):
         # A bare conf GET on an absent snap is a 200 with an empty result, so the probe is
         # what turns it into an error.
         mock_client.get.side_effect = [{}, self._SNAP_NOT_FOUND]
-        with pytest.raises(NotFoundError):
+        with pytest.raises(NotFoundError) as ctx:
             _snapd_conf.get('hello-world')
+        assert ctx.value.message == 'snap "hello-world" is not installed'
+        assert ctx.value.value == 'hello-world'
+        assert ctx.value.__context__ is None
 
     def test_get_all_empty_on_installed_snap_returns_empty_dict(self, mock_client: MockClient):
         mock_client.get.side_effect = [{}, result_of('snap_info_hello_world.json')]

--- a/snap/tests/unit/test_snapd_interfaces.py
+++ b/snap/tests/unit/test_snapd_interfaces.py
@@ -20,8 +20,9 @@ def _api_error(message: str = 'boom') -> APIError:
     return APIError(message, kind='', value='', status_code=400)
 
 
-def _not_found(message: str = 'not found') -> NotFoundError:
-    return NotFoundError(message, kind='snap-not-found', value='', status_code=404)
+def _not_found(snap: str = 'absent') -> NotFoundError:
+    # Mirrors snapd's GET /v2/snaps/{snap}: a terse message with the snap name in `value`.
+    return NotFoundError('snap not installed', kind='snap-not-found', value=snap, status_code=404)
 
 
 class TestConnect:
@@ -94,7 +95,7 @@ class TestConnect:
 
         def fake_get(path: str, query: object = None) -> dict[str, object]:
             if path == '/v2/snaps/absent-slot':
-                raise _not_found()
+                raise _not_found('absent-slot')
             return {}  # plug snap is installed
 
         mock_client.get.side_effect = fake_get
@@ -104,17 +105,20 @@ class TestConnect:
         assert mock_client.get.call_args_list[0].args[0] == '/v2/snaps/installed-plug'
         assert ctx.value.value == 'absent-slot'
 
-    def test_connect_not_found_names_snap_and_does_not_chain(self, mock_client: MockClient):
-        # The typed error keeps snapd's descriptive wording (the probe's own message is the
-        # generic 'snap not installed'), and 'raise ... from None' suppresses the original
-        # API error so the user sees a single traceback without the internal probe.
+    def test_connect_not_found_is_snapd_probe_error_and_does_not_chain(
+        self, mock_client: MockClient
+    ):
+        # snapd's own probe error is raised unchanged -- terse message, snap name in value (which
+        # str() surfaces) -- rather than a hand-built one. 'raise ... from None' suppresses the
+        # original API error, so the user sees a single traceback without the internal probe.
         mock_client.post.side_effect = _api_error('snap "absent" is not installed')
-        mock_client.get.side_effect = _not_found()
+        mock_client.get.side_effect = _not_found('absent')
         with pytest.raises(NotFoundError) as ctx:
             _snapd_interfaces.connect(('absent', 'home'))
-        assert ctx.value.message == 'snap "absent" is not installed'
+        assert ctx.value.message == 'snap not installed'
         assert ctx.value.kind == 'snap-not-found'
         assert ctx.value.value == 'absent'
+        assert str(ctx.value) == 'snap not installed (absent)'
         assert ctx.value.__cause__ is None
         assert ctx.value.__suppress_context__
 
@@ -208,14 +212,15 @@ class TestDisconnect:
         _snapd_interfaces.disconnect(('vlc', 'mount-observe'), forget=True)  # Should not raise.
 
     def test_disconnect_probes_and_raises_not_found(self, mock_client: MockClient):
-        # disconnect also converts a not-installed API error into a typed NotFoundError,
-        # naming the snap and without chaining the original error.
+        # disconnect also raises snapd's probe error for a not-installed snap, with the name in
+        # value/str and without chaining the original error.
         mock_client.post.side_effect = _api_error('snap "absent" is not installed')
-        mock_client.get.side_effect = _not_found()
+        mock_client.get.side_effect = _not_found('absent')
         with pytest.raises(NotFoundError) as ctx:
             _snapd_interfaces.disconnect(('absent', 'p'))
-        assert ctx.value.message == 'snap "absent" is not installed'
+        assert ctx.value.message == 'snap not installed'
         assert ctx.value.value == 'absent'
+        assert str(ctx.value) == 'snap not installed (absent)'
         assert ctx.value.__cause__ is None
         assert ctx.value.__suppress_context__
 

--- a/snap/tests/unit/test_snapd_interfaces.py
+++ b/snap/tests/unit/test_snapd_interfaces.py
@@ -98,10 +98,25 @@ class TestConnect:
             return {}  # plug snap is installed
 
         mock_client.get.side_effect = fake_get
-        with pytest.raises(NotFoundError):
+        with pytest.raises(NotFoundError) as ctx:
             _snapd_interfaces.connect(('installed-plug', 'p'), ('absent-slot', 's'))
         # The plug snap is probed before the slot snap (matching snapd's blame order).
         assert mock_client.get.call_args_list[0].args[0] == '/v2/snaps/installed-plug'
+        assert ctx.value.value == 'absent-slot'
+
+    def test_connect_not_found_names_snap_and_does_not_chain(self, mock_client: MockClient):
+        # The typed error keeps snapd's descriptive wording (the probe's own message is the
+        # generic 'snap not installed'), and 'raise ... from None' suppresses the original
+        # API error so the user sees a single traceback without the internal probe.
+        mock_client.post.side_effect = _api_error('snap "absent" is not installed')
+        mock_client.get.side_effect = _not_found()
+        with pytest.raises(NotFoundError) as ctx:
+            _snapd_interfaces.connect(('absent', 'home'))
+        assert ctx.value.message == 'snap "absent" is not installed'
+        assert ctx.value.kind == 'snap-not-found'
+        assert ctx.value.value == 'absent'
+        assert ctx.value.__cause__ is None
+        assert ctx.value.__suppress_context__
 
     def test_connect_reraises_original_when_snaps_installed(self, mock_client: MockClient):
         # If the probe finds every named snap installed, the original API error is re-raised
@@ -193,11 +208,25 @@ class TestDisconnect:
         _snapd_interfaces.disconnect(('vlc', 'mount-observe'), forget=True)  # Should not raise.
 
     def test_disconnect_probes_and_raises_not_found(self, mock_client: MockClient):
-        # disconnect also converts a not-installed API error into a typed NotFoundError.
-        mock_client.post.side_effect = _api_error()
+        # disconnect also converts a not-installed API error into a typed NotFoundError,
+        # naming the snap and without chaining the original error.
+        mock_client.post.side_effect = _api_error('snap "absent" is not installed')
         mock_client.get.side_effect = _not_found()
-        with pytest.raises(NotFoundError):
+        with pytest.raises(NotFoundError) as ctx:
             _snapd_interfaces.disconnect(('absent', 'p'))
+        assert ctx.value.message == 'snap "absent" is not installed'
+        assert ctx.value.value == 'absent'
+        assert ctx.value.__cause__ is None
+        assert ctx.value.__suppress_context__
+
+    def test_disconnect_reraises_original_when_snaps_installed(self, mock_client: MockClient):
+        # As for connect: if every named snap is installed, the original error is re-raised.
+        original = _api_error('snap "installed" has no plug named "foo"')
+        mock_client.post.side_effect = original
+        mock_client.get.return_value = {}  # all probed snaps installed
+        with pytest.raises(APIError) as ctx:
+            _snapd_interfaces.disconnect(('installed', 'foo'))
+        assert ctx.value is original
 
     def test_disconnect_unchanged_suppressed_before_probe(self, mock_client: MockClient):
         # _InterfacesUnchangedError is caught before the not-installed probe: it is suppressed,


### PR DESCRIPTION
This PR reworks how `charmlibs.snap` raises errors when probing for if a snap is installed (which we do to provide cleaner, typed errors for operations that fail if the snap isn't installed, but which snapd doesn't return a nice typed error for). In particular, when probing in an error path, we want to avoid the dreaded and confusing chained traceback with "During handling of the above exception, another exception occurred". 

With this PR we have short tracebacks like:
```
Traceback (most recent call last):
  File "_snapd_conf.py", line 102, in get
    raise error from None
charmlibs.snap._errors.NotFoundError: snap not installed (myapp)
```

To facilitate using snapd's returned errors from our installation probe (get), we expand the `__str__` of `Error` in this PR to include `(value)` if it's a string and not already present in the error message.