### PR TITLE
feat(snap): switch to `args: str | Iterable[str] | None` from `*args: str`

### DIFF
--- a/snap/src/charmlibs/snap/_snapd_apps.py
+++ b/snap/src/charmlibs/snap/_snapd_apps.py
@@ -16,74 +16,130 @@
 
 from __future__ import annotations
 
+import typing
 from typing import Any
 
-from . import _client, _utils
+from . import _client, _errors, _utils
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterable
 
 # /v2/apps
 
 
-def start(snap: str, *services: str, enable: bool = False) -> None:
+def start(snap: str, services: str | Iterable[str] | None = None, *, enable: bool = False) -> None:
     """Start snap services.
 
     Args:
         snap: The name of the snap whose services to start.
-        services: Names of services within the snap to start. If omitted, all of the snap's
-            services are started.
+        services: Names of services within the snap to start, as a single name or an iterable of
+            names. If ``None`` (the default), all of the snap's services are started. If an empty
+            iterable, no services are started and no request is made -- but the snap must still
+            be installed.
         enable: If ``True``, also enable the services to start automatically at boot.
 
     Raises:
-        ValueError: if the snap name or any service name is empty or blank.
-        AppNotFoundError: if the snap is not installed or the service is not found.
+        ValueError: if the snap name is empty, blank, or is not a single path segment, or if a
+            service name is empty or blank.
+        NotFoundError: if the snap is not installed.
+        AppNotFoundError: if the snap is installed but has no service with a given name, or if
+            all services were requested and the snap has no services at all.
         ChangeError: if the change fails (for example, the service fails to start).
+
+    ::
+
+        # Start every service the snap has.
+        start('lxd')
+        # Start one service.
+        start('lxd', 'daemon')
+        # Start several.
+        start('lxd', ['daemon', 'user-daemon'])
+        # Start none of them -- a no-op, but still an error if lxd isn't installed.
+        start('lxd', [])
     """
-    _utils.raise_if_empty_or_blank(snap, label='snap name')
-    _utils.raise_if_empty_or_blank(services, label='service name')
-    names = [f'{snap}.{s}' for s in services] if services else [snap]
-    data: dict[str, Any] = {'action': 'start', 'names': names}
-    if enable:
-        data['enable'] = True
-    _client.post('/v2/apps', body=data)
+    _post_action('start', snap, services, {'enable': True} if enable else None)
 
 
-def stop(snap: str, *services: str, disable: bool = False) -> None:
+def stop(snap: str, services: str | Iterable[str] | None = None, *, disable: bool = False) -> None:
     """Stop snap services.
 
     Args:
         snap: The name of the snap whose services to stop.
-        services: Names of services within the snap to stop. If omitted, all of the snap's
-            services are stopped.
+        services: Names of services within the snap to stop, as a single name or an iterable of
+            names. If ``None`` (the default), all of the snap's services are stopped. If an empty
+            iterable, no services are stopped and no request is made -- but the snap must still
+            be installed.
         disable: If ``True``, also disable the services from starting automatically at boot.
 
     Raises:
-        ValueError: if the snap name or any service name is empty or blank.
-        AppNotFoundError: if the snap is not installed or the service is not found.
+        ValueError: if the snap name is empty, blank, or is not a single path segment, or if a
+            service name is empty or blank.
+        NotFoundError: if the snap is not installed.
+        AppNotFoundError: if the snap is installed but has no service with a given name, or if
+            all services were requested and the snap has no services at all.
         ChangeError: if the change fails (for example, the service fails to stop).
     """
-    _utils.raise_if_empty_or_blank(snap, label='snap name')
-    _utils.raise_if_empty_or_blank(services, label='service name')
-    names = [f'{snap}.{s}' for s in services] if services else [snap]
-    data: dict[str, Any] = {'action': 'stop', 'names': names}
-    if disable:
-        data['disable'] = True
-    _client.post('/v2/apps', body=data)
+    _post_action('stop', snap, services, {'disable': True} if disable else None)
 
 
-def restart(snap: str, *services: str) -> None:
+def restart(snap: str, services: str | Iterable[str] | None = None) -> None:
     """Restart snap services.
 
     Args:
         snap: The name of the snap whose services to restart.
-        services: Names of services within the snap to restart. If omitted, all of the snap's
-            services are restarted.
+        services: Names of services within the snap to restart, as a single name or an iterable
+            of names. If ``None`` (the default), all of the snap's services are restarted. If an
+            empty iterable, no services are restarted and no request is made -- but the snap must
+            still be installed.
 
     Raises:
-        ValueError: if the snap name or any service name is empty or blank.
-        AppNotFoundError: if the snap is not installed or the service is not found.
+        ValueError: if the snap name is empty, blank, or is not a single path segment, or if a
+            service name is empty or blank.
+        NotFoundError: if the snap is not installed.
+        AppNotFoundError: if the snap is installed but has no service with a given name, or if
+            all services were requested and the snap has no services at all.
         ChangeError: if the change fails (for example, the service fails to restart).
     """
-    _utils.raise_if_empty_or_blank(snap, label='snap name')
-    _utils.raise_if_empty_or_blank(services, label='service name')
-    names = [f'{snap}.{s}' for s in services] if services else [snap]
-    data: dict[str, Any] = {'action': 'restart', 'names': names}
-    _client.post('/v2/apps', body=data)
+    _post_action('restart', snap, services)
+
+
+def _post_action(
+    action: str,
+    snap: str,
+    services: str | Iterable[str] | None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Validate the arguments and post an action for a snap's services to /v2/apps.
+
+    Makes no request when no services were requested, beyond confirming the snap is installed.
+    """
+    # NOTE: The name is sent in the request body rather than the path, but it's validated as a
+    # path segment all the same -- a name that isn't one can't be a snap, and the not-installed
+    # probe below builds a path from it, where an unusable name would raise ValueError from
+    # inside an exception handler and mask the error being classified.
+    _utils.raise_if_not_path_segment(snap)
+    services = None if services is None else _utils.as_list(services)
+    if services is not None:
+        _utils.raise_if_empty_or_blank(services, label='service name')
+        if not services:
+            # NOTE: No services were requested, so there is nothing to act on. The snap itself is
+            # still named, so it's checked the way a request naming a service would have checked
+            # it: asking a snap that isn't installed to do nothing is an error, not a no-op.
+            # 'system'/'core' get no special treatment here -- /v2/apps has no system alias, and
+            # core is an ordinary snap to it.
+            if error := _utils.check_installed(snap):
+                raise error
+            return
+    # NOTE: Naming the snap itself is how snapd is asked to act on all of its services.
+    names = [f'{snap}.{service}' for service in services] if services else [snap]
+    body: dict[str, Any] = {'action': action, 'names': names, **(extra or {})}
+    try:
+        _client.post('/v2/apps', body=body)
+    except _errors.AppNotFoundError:
+        # NOTE: snapd answers app-not-found both for a snap that isn't installed and for a service
+        # that an installed snap doesn't have. We probe /v2/snaps/{snap} so that an absent snap
+        # raises NotFoundError, as it does elsewhere in the library, which leaves AppNotFoundError
+        # meaning what it says: the snap is installed, but has no such service.
+        if error := _utils.check_installed(snap):
+            raise error from None
+        raise

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -33,26 +33,27 @@ logger = logging.getLogger(__name__)
 
 # Getting one config value looks like get(s, [k])[k]. In future we could add a get_one(s) helper.
 # Get with keys=None returns the entire config, following the CLI (get_all is unnecessary).
-def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
+def get(snap: str, keys: str | Iterable[str] | None = None) -> dict[str, Any]:
     """Get snap configuration.
 
     Args:
         snap: The name of the snap to read configuration from.
-        keys: Configuration keys to read. Nested options may be accessed with dotted notation,
-            for example ``['server.port']``. If ``None``, the full config is returned as a
-            nested dict. If an empty iterable, an empty dict is returned if the snap is installed.
-            Must not be a bare string.
+        keys: Configuration keys to read, as a single key or an iterable of keys. Nested options
+            may be accessed with dotted notation, for example ``'server.port'``. If ``None``, the
+            full config is returned as a nested dict. If an empty iterable, an empty dict is
+            returned if the snap is installed.
 
     Returns:
         A dict mapping each requested key to its configured value. If all keys are requested
         (keys=None), the entire config is returned as a nested dict (empty if the snap has no
         configuration). If no keys are requested (keys=[]), an empty dict is returned if the snap
-        is installed. Each dotted key queried is returned as a top-level entry.
+        is installed. Each dotted key queried is returned as a top-level entry. A single key
+        passed as a bare string is no different from passing it in a list: the result is still a
+        dict, so reading one value looks like ``get(snap, key)[key]``.
 
     Raises:
         ValueError: if the snap name is empty, blank, or is not a single path segment, or if a
             key is empty, blank, or contains a comma or surrounding whitespace.
-        TypeError: if ``keys`` is a string (must be a non-string iterable of strings, or ``None``).
         NotFoundError: if the snap is not installed. Never raised for ``system`` or ``core``,
             whose configuration is served whether or not the core snap is installed.
         OptionNotFoundError: if a requested key has no value stored in the snap's configuration.
@@ -67,24 +68,20 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
         get('foo')  # {'server': {'port': 8080}, 'client': {'timeout': 30}}
         get('foo', keys=None)  # {'server': {'port': 8080}, 'client': {'timeout': 30}}
         # Querying specific keys.
-        get('foo', ['client'])  # {'client': {'timeout': 30}}
+        get('foo', 'client')  # {'client': {'timeout': 30}}
         get('foo', ['client.timeout'])  # {'client.timeout': 30}
         get('foo', ['server', 'server.port'])  # {'server': {'port': 8080}, 'server.port': 8080}
         # Querying no keys.
         get('foo', keys=[])  # {}
-        # Invalid keys argument.
-        get('foo', keys='client')  # TypeError
     """
     path = f'/v2/snaps/{_utils.snap_path_segment(snap)}/conf'
-    if isinstance(keys, str):
-        raise TypeError('keys must be an iterable of strings, or None (not a string)')
+    keys = None if keys is None else _utils.as_list(keys)
     if keys is not None:
-        keys = list(keys)
         if not keys:
             # NOTE: snapd returns the full configuration if no keys are specified.
             # We pass this behaviour through for keys=None, but for keys=[] we return
             # an empty dict, since the caller explicitly requested no keys.
-            if error := _utils.check_installed_or_system(snap):
+            if error := _utils.check_installed(snap, skip_system=True):
                 raise error
             return {}
         # NOTE: snapd strips whitespace and drops empty keys. We make them an error up front so
@@ -99,11 +96,15 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
         # NOTE: snapd reports option-not-found both for a missing key and for a missing snap.
         # The CLI returns 'error: snap "foo" has no "bar" configuration' in both cases.
         # For symmetry with PUT (set/unset), we convert to NotFoundError here for a missing snap.
-        if error := _utils.check_installed_or_system(snap):
+        if error := _utils.check_installed(snap, skip_system=True):
             raise error from None
         raise
     # Empty result when all config was requested: error if the snap isn't installed.
-    if (not config) and (keys is None) and (error := _utils.check_installed_or_system(snap)):
+    if (
+        (not config)
+        and (keys is None)
+        and (error := _utils.check_installed(snap, skip_system=True))
+    ):
         # NOTE: snapd returns {} for an installed snap with no config and for a missing snap.
         # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
         # For symmetry with PUT (set/unset), we raise NotFoundError here for a missing snap.
@@ -112,30 +113,31 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
     return typing.cast('dict[str, Any]', config)
 
 
-def unset(snap: str, keys: Iterable[str]) -> None:
+def unset(snap: str, keys: str | Iterable[str]) -> None:
     """Unset snap configuration keys.
 
     Unsetting a key that is not currently set is a no-op and does not raise.
 
     Args:
         snap: The name of the snap to unset configuration on.
-        keys: Configuration keys to unset. Nested options may be addressed with dotted
-            notation, for example ``['server.port']``. Must not be a bare string.
-            An empty iterable is still passed to snapd, and may trigger the snap's config hook.
+        keys: Configuration keys to unset, as a single key or an iterable of keys. Nested options
+            may be addressed with dotted notation, for example ``'server.port'``. An empty
+            iterable is still passed to snapd, and may trigger the snap's config hook.
+
+            Unlike :func:`get`, there is no ``None`` meaning "all keys": snapd has no request for
+            it, and building one out of the keys :func:`get` reports would unset keys the caller
+            never named.
 
     Raises:
         ValueError: if the snap name is empty, blank, or is not a single path segment,
             or if a key is empty or blank.
-        TypeError: if ``keys`` is a string (must be a non-string iterable of strings).
         NotFoundError: if the snap is not installed.
         ChangeError: if the snap's configure hook fails. This includes unsetting any
             configuration on a snap that does not define a configure hook. A failed change
             is rolled back: no key from the request is unset.
     """
     path = f'/v2/snaps/{_utils.snap_path_segment(snap)}/conf'
-    if isinstance(keys, str):
-        raise TypeError('keys must be an iterable of strings (not a string)')
-    keys = list(keys)
+    keys = _utils.as_list(keys)
     # NOTE: snapd rejects empty or blank keys. We reject them up front for symmetry with get().
     _utils.raise_if_empty_or_blank(keys, label='config key')
     # NOTE: snap-not-found is returned for a missing snap, but not for system or core,

--- a/snap/src/charmlibs/snap/_snapd_interfaces.py
+++ b/snap/src/charmlibs/snap/_snapd_interfaces.py
@@ -182,6 +182,6 @@ def _first_not_installed(plug_snap: str, slot_snap: str) -> _errors.NotFoundErro
     serves them without the core snap being installed. Empty (auto-resolved) sides are skipped.
     """
     for snap in (plug_snap, slot_snap):
-        if snap and (error := _utils.check_installed_or_system(snap)):
+        if snap and (error := _utils.check_installed(snap, skip_system=True)):
             return error
     return None

--- a/snap/src/charmlibs/snap/_snapd_logs.py
+++ b/snap/src/charmlibs/snap/_snapd_logs.py
@@ -24,6 +24,7 @@ from . import _client, _utils
 
 if typing.TYPE_CHECKING:
     import datetime
+    from collections.abc import Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -76,13 +77,15 @@ class LogEntry:
         return f'{self._timestamp} {self._sid}[{self._pid}]: {self._message}'
 
 
-def logs(*snaps: str, limit: int | None = 10) -> list[LogEntry]:
+def logs(snaps: str | Iterable[str] | None = None, *, limit: int | None = 10) -> list[LogEntry]:
     """Retrieve recent log entries for one or more snaps.
 
     Log entries are returned in chronological order: oldest first, newest last.
 
     Args:
-        snaps: Snap names to retrieve logs for. If omitted, returns system-wide snap logs.
+        snaps: Snap names to retrieve logs for, as a single name or an iterable of names. If
+            ``None`` (the default), system-wide snap logs are returned. If an empty iterable,
+            no snaps are queried: an empty list is returned without making a request.
         limit: Maximum number of log entries to return. Must be a positive integer, or
             ``None`` to retrieve all available log entries (equivalent to ``snap logs -n all``).
 
@@ -96,11 +99,23 @@ def logs(*snaps: str, limit: int | None = 10) -> list[LogEntry]:
             contains a comma; or if ``limit`` is not ``None`` and is not a positive integer.
         NotFoundError: If a specified snap is not installed.
         AppNotFoundError: If a specified snap has no services.
+
+    ::
+
+        # System-wide snap logs.
+        logs()
+        # Logs for one snap.
+        logs('lxd')
+        # Logs for several.
+        logs(['lxd', 'kube-proxy'])
+        # Logs for no snaps at all: [], without a request.
+        logs([])
     """
     # NOTE: Snap names are joined into a single comma-separated query parameter.
     # We reject unsafe names (containing a comma), and names that snapd would drop
     # (empty or blank) or alter (leading/trailing whitespace).
-    _utils.raise_if_not_comma_list_safe(snaps, label='snap name')
+    snaps = None if snaps is None else _utils.as_list(snaps)
+    _utils.raise_if_not_comma_list_safe(snaps or (), label='snap name')
     if limit is None:
         # snapd treats n=-1 as "no limit": return all available log entries.
         n = -1
@@ -108,6 +123,12 @@ def logs(*snaps: str, limit: int | None = 10) -> list[LogEntry]:
         raise ValueError(f'limit must be a positive integer or None, not {limit!r}')
     else:
         n = limit
+    if snaps is not None and not snaps:
+        # NOTE: No snaps were named, so there are no logs to return. Unlike the /v2/apps
+        # functions, there's no separate snap argument left to check: the names are the whole
+        # request, so an empty request has nothing to be wrong about and makes no call.
+        # Arguments are still validated above, so a bad limit is an error either way.
+        return []
     query: dict[str, Any] = {'n': n}
     if snaps:
         query['names'] = ','.join(snaps)

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -24,48 +24,45 @@ import urllib.parse
 from . import _client, _errors
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Collection
+    from collections.abc import Collection, Iterable
 
 
 def snap_path_segment(snap: str) -> str:
     """Validate a snap name and encode it for use as a single URL path segment.
 
-    Raises ValueError if the name is empty or would not be a single, canonical path segment.
-    Percent-encoding alone is not enough to guarantee that:
+    Raises ValueError if the name is empty or would not be a single, canonical path segment
+    (see :func:`raise_if_not_path_segment`).
 
-    - snapd's router (gorilla/mux) matches on the *decoded* path, so ``%2F`` is still a path
-      separator to it: without this check ``info('hello-world/conf')`` would reach
-      ``/v2/snaps/hello-world/conf`` and return that snap's configuration.
-    - ``urllib.parse.quote`` leaves ``.`` unencoded, so a ``.`` or ``..`` name would still make
-      the path non-canonical, which mux answers with a ``301`` to the cleaned path.
-
-    Encoding is still applied, so that characters such as ``?`` and ``#`` in a name are sent as
+    Encoding is applied, so that characters such as ``?`` and ``#`` in a name are sent as
     part of the path instead of starting a query string or fragment.
     """
-    raise_if_empty_or_blank(snap, label='snap name')
-    if '/' in snap or snap in ('.', '..'):
-        raise ValueError(f'snap name must be a single path segment, not {snap!r}')
+    raise_if_not_path_segment(snap)
     return urllib.parse.quote(snap, safe='')
 
 
-def check_installed_or_system(snap: str) -> _errors.NotFoundError | None:
-    """Return NotFoundError if the snap is not installed or a system/core alias.
+def check_installed(snap: str, *, skip_system: bool = False) -> _errors.NotFoundError | None:
+    """Return snapd's own NotFoundError if the snap is not installed, otherwise ``None``.
 
-    Returns ``None`` when the snap is installed, and for the ``system``/``core`` aliases, which
-    snapd handles config and interfaces for whether or not the core snap is installed as a snap.
-    Check if this system handling is appropriate if using this function with other snapd endpoints.
-    Otherwise probes ``GET /v2/snaps/{snap}`` and returns snapd's own :class:`NotFoundError` when
+    Probes ``GET /v2/snaps/{snap}`` and returns the :class:`NotFoundError` snapd answers with when
     it reports the snap absent, ready for the caller to ``raise``.
 
+    Args:
+        snap: The name of the snap to check.
+        skip_system: If ``True``, treat ``system`` and ``core`` as installed without probing.
+            Pass this for endpoints snapd serves under those names whether or not the core snap
+            is installed: the conf endpoints treat ``system`` as an alias for ``core``, and
+            interface requests remap ``system``/``core`` to the snapd snap. Leave it ``False``
+            for endpoints where ``core`` is an ordinary snap and ``system`` names nothing at all,
+            such as ``/v2/apps``.
+
     Raises ValueError for a name that can't be used as a path segment (see
-    :func:`snap_path_segment`). Callers that reach this from an exception handler must skip
-    empty names, so that a ValueError can't mask the error they're classifying.
+    :func:`snap_path_segment`). Callers that reach this from an exception handler must have
+    validated the name already, so that a ValueError can't mask the error they're classifying.
     """
-    # NOTE: snapd's conf endpoints treat 'system' as an alias for 'core', and interface requests
-    # remap 'system'/'core' to the snapd snap, so both names are served without the core snap.
-    # /v2/snaps/system always 404s (a hardcoded alias, not a real snap) and /v2/snaps/core 404s
-    # when the core snap is absent, so probing either would report a working call as not installed.
-    if snap in ('system', 'core'):
+    # NOTE: /v2/snaps/system always 404s (a hardcoded alias, not a real snap) and /v2/snaps/core
+    # 404s when the core snap is absent, so probing either would report a working call -- on an
+    # endpoint that serves these names specially -- as not installed.
+    if skip_system and snap in ('system', 'core'):
         return None
     path = f'/v2/snaps/{snap_path_segment(snap)}'
     try:
@@ -153,14 +150,55 @@ def parse_timestamp(timestamp: str) -> datetime.datetime:
     return base + microseconds
 
 
+########################################################
+# Normalising arguments that take one value or several #
+########################################################
+
+
+def as_list(values: str | Iterable[str]) -> list[str]:
+    """Normalise an argument that accepts one value or several to a list.
+
+    A bare string is one value, not an iterable of its characters: ``'abc'`` means ``['abc']``.
+    Every other iterable is materialised, so that the caller can iterate it more than once --
+    to validate the values and then send them.
+
+    Callers whose argument also accepts ``None`` (meaning "all") handle that case themselves,
+    so that ``None`` is never confused with an empty iterable (meaning "none").
+    """
+    return [values] if isinstance(values, str) else list(values)
+
+
 #############################################################
 # Rejecting values snapd can't use, before making a request #
 #############################################################
 
 
+def raise_if_not_path_segment(snap: str) -> None:
+    """Raise ValueError if a snap name would not be a single, canonical URL path segment.
+
+    Percent-encoding alone is not enough to guarantee that:
+
+    - snapd's router (gorilla/mux) matches on the *decoded* path, so ``%2F`` is still a path
+      separator to it: without this check ``info('hello-world/conf')`` would reach
+      ``/v2/snaps/hello-world/conf`` and return that snap's configuration.
+    - ``urllib.parse.quote`` leaves ``.`` unencoded, so a ``.`` or ``..`` name would still make
+      the path non-canonical, which mux answers with a ``301`` to the cleaned path.
+
+    Functions that send the snap name in a request body rather than the path check it too: a name
+    that isn't a path segment can't be a snap, and :func:`check_installed` builds a path from it.
+
+    The empty and blank checks are chained here rather than delegated to
+    :func:`raise_if_empty_or_blank`, so that the error is raised no deeper in the traceback than
+    any other check (see tests/unit/test_empty_or_blank.py).
+    """
+    problem = _empty(snap) or _blank(snap) or _path_segment(snap)
+    if problem:
+        raise ValueError(_message('snap name', problem, [snap]))
+
+
 def raise_if_empty_or_blank(values: str | Collection[str], *, label: str) -> None:
     """Raise ValueError if a value is empty or contains only whitespace."""
-    values = _list(values)
+    values = as_list(values)
     for value in values:
         problem = _empty(value) or _blank(value)
         if problem:
@@ -169,7 +207,7 @@ def raise_if_empty_or_blank(values: str | Collection[str], *, label: str) -> Non
 
 def raise_if_blank(values: str | Collection[str], *, label: str) -> None:
     """Raise ValueError if a value is non-empty but contains only whitespace."""
-    values = _list(values)
+    values = as_list(values)
     for value in values:
         problem = _blank(value)
         if problem:
@@ -185,15 +223,11 @@ def raise_if_not_comma_list_safe(values: str | Collection[str], *, label: str) -
     Snapd drops empty or blank values entirely (confusing when no values means "all"), and
     silently strips leading and trailing whitespace (breaking ``get(s, [k])[k]``).
     """
-    values = _list(values)
+    values = as_list(values)
     for value in values:
         problem = _empty(value) or _blank(value) or _comma(value) or _padding(value)
         if problem:
             raise ValueError(_message(label, problem, values))
-
-
-def _list(values: str | Collection[str]) -> list[str]:
-    return [values] if isinstance(values, str) else list(values)
 
 
 def _empty(value: str) -> str | None:
@@ -205,6 +239,12 @@ def _empty(value: str) -> str | None:
 def _blank(value: str) -> str | None:
     if value and not value.strip():
         return f'must not be blank: {value!r}'
+    return None
+
+
+def _path_segment(value: str) -> str | None:
+    if '/' in value or value in ('.', '..'):
+        return f'must be a single path segment: {value!r}'
     return None
 
 

--- a/snap/tests/functional/test_snapd_apps.py
+++ b/snap/tests/functional/test_snapd_apps.py
@@ -22,6 +22,11 @@ _QUALIFIED_SERVICE = f'{_SNAP}.{_SERVICE}'
 # snap produces the same error response, avoiding unnecessary remove operations.
 _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
+# start, stop and restart share one implementation, so the argument and error contracts below
+# are asserted for all three rather than once each.
+_FUNCTIONS = [_snapd_apps.start, _snapd_apps.stop, _snapd_apps.restart]
+_IDS = ['start', 'stop', 'restart']
+
 
 # Test helper and possible future candidate for library public API.
 def _list_services(snap: str | None = None) -> list[dict[str, Any]]:
@@ -105,10 +110,11 @@ def test_start_nonexistent_service_raises():
     assert ctx.value.kind == 'app-not-found'
 
 
-def test_start_nonexistent_snap_raises():
-    with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.start('nonexistent-snap-xyz', 'service')
-    assert ctx.value.kind == 'app-not-found'
+def test_start_multiple_services():
+    # Several services at once, as a list rather than a bare name.
+    ensure_installed(_SNAP, classic=True)
+    _stop_and_disable()
+    _snapd_apps.start(_SNAP, [_SERVICE])  # Should not raise.
 
 
 # ---------------------------------------------------------------------------
@@ -153,12 +159,6 @@ def test_stop_nonexistent_service_raises():
     assert ctx.value.kind == 'app-not-found'
 
 
-def test_stop_nonexistent_snap_raises():
-    with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.stop('nonexistent-snap-xyz', 'service')
-    assert ctx.value.kind == 'app-not-found'
-
-
 # ---------------------------------------------------------------------------
 # restart
 # ---------------------------------------------------------------------------
@@ -194,34 +194,103 @@ def test_restart_nonexistent_service_raises():
     assert ctx.value.kind == 'app-not-found'
 
 
-def test_restart_nonexistent_snap_raises():
-    # kube-proxy has no snap "service" app, so this triggers app-not-found.
-    with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.restart('nonexistent-snap-xyz', 'service')
-    assert ctx.value.kind == 'app-not-found'
-
-
 # ---------------------------------------------------------------------------
 # not-installed snap (uses a never-installed name to avoid churn)
+#
+# Which error snapd answers with depends on the shape of the request. Naming the snap on its own
+# is a typed snap-not-found, but naming a service inside it is app-not-found -- the same kind it
+# uses for a service an installed snap doesn't have. start, stop and restart probe
+# /v2/snaps/{snap} on app-not-found, so an absent snap is a NotFoundError whichever way it was
+# named, and AppNotFoundError is left meaning what it says. The raw responses are pinned below.
 # ---------------------------------------------------------------------------
 
 
-def test_start_not_installed_snap_raises_app_not_found():
+@pytest.mark.parametrize('func', _FUNCTIONS, ids=_IDS)
+@pytest.mark.parametrize(
+    'services', [None, 'svc', ['svc'], []], ids=['all', 'one', 'list', 'none']
+)
+def test_not_installed_snap_raises_not_found(func: Any, services: Any):
+    # Every form of the services argument reports an absent snap as the same type and kind,
+    # including the empty list, which never reaches /v2/apps and is answered by the probe alone.
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        func(_ABSENT_SNAP, services)
+    assert ctx.value.kind == 'snap-not-found'
+    assert _ABSENT_SNAP in str(ctx.value)
+
+
+@pytest.mark.parametrize('func', _FUNCTIONS, ids=_IDS)
+@pytest.mark.parametrize('services', ['svc', ['svc'], []], ids=['one', 'list', 'none'])
+def test_not_installed_snap_converted_error_wording(func: Any, services: Any):
+    # The forms that reach the probe raise snapd's own /v2/snaps/{snap} error unchanged: a terse
+    # message with the snap name in value, which str() surfaces. Same wording as conf's get().
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        func(_ABSENT_SNAP, services)
+    assert ctx.value.message == 'snap not installed'
+    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
+
+
+@pytest.mark.parametrize('func', _FUNCTIONS, ids=_IDS)
+def test_not_installed_snap_unconverted_error_wording(func: Any):
+    # Naming no service reaches snapd as the snap's own name, which it answers with a typed
+    # snap-not-found -- already the error the library wants, so nothing is converted and snapd's
+    # wording is passed through, as set/unset pass through the conf endpoint's. The type and kind
+    # are what the library keeps consistent across endpoints, not the message.
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        func(_ABSENT_SNAP, None)
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" not found'
+
+
+@pytest.mark.parametrize('func', _FUNCTIONS, ids=_IDS)
+def test_not_installed_snap_error_is_not_chained(func: Any):
+    # snapd's misleading app-not-found is suppressed ('raise ... from None'), so the traceback is
+    # a single error that doesn't blame a service the caller may never have named.
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        func(_ABSENT_SNAP, 'svc')
+    assert ctx.value.__cause__ is None
+    assert ctx.value.__suppress_context__
+
+
+def test_raw_api_not_installed_snap_with_a_service_is_app_not_found():
+    # Pin the raw snapd behaviour the conversion relies on: naming a service inside a snap that
+    # isn't installed is app-not-found. Asserted at the _client level because start/stop/restart
+    # convert it; if snapd ever reported the absent snap directly here, this fails loudly rather
+    # than leaving the probe branch as untested dead code.
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.start(_ABSENT_SNAP, 'svc')
+        _client.post('/v2/apps', body={'action': 'start', 'names': [f'{_ABSENT_SNAP}.svc']})
     assert ctx.value.kind == 'app-not-found'
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" has no service "svc"'
 
 
-def test_stop_not_installed_snap_raises_app_not_found():
+def test_raw_api_installed_snap_without_the_service_is_indistinguishable():
+    # The other half of the conflation: the same kind and the same shape of message for a snap
+    # that is installed. Nothing in the response tells the two apart, which is why the probe
+    # exists rather than a check on the message.
+    ensure_installed('hello-world')
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.stop(_ABSENT_SNAP, 'svc')
+        _client.post('/v2/apps', body={'action': 'start', 'names': ['hello-world.svc']})
     assert ctx.value.kind == 'app-not-found'
+    assert ctx.value.message == 'snap "hello-world" has no service "svc"'
 
 
-def test_restart_not_installed_snap_raises_app_not_found():
-    with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.restart(_ABSENT_SNAP, 'svc')
-    assert ctx.value.kind == 'app-not-found'
+def test_raw_api_not_installed_snap_alone_is_snap_not_found():
+    # Naming the snap on its own is not conflated: snapd resolves the name before it looks for
+    # services, so this is already the error the library wants and no probe is made for it.
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        _client.post('/v2/apps', body={'action': 'start', 'names': [_ABSENT_SNAP]})
+    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value.message == f'snap "{_ABSENT_SNAP}" not found'
+
+
+@pytest.mark.parametrize('func', _FUNCTIONS, ids=_IDS)
+def test_system_is_not_special_here(func: Any):
+    # The conf and interfaces endpoints serve 'system' and 'core' whether or not the core snap is
+    # installed, so their not-installed probe skips both names. /v2/apps has no such alias, so
+    # they're probed like any other snap. Only 'system' is asserted on: it is never a snap, while
+    # 'core' is an ordinary one that may or may not be installed here (hello-world pulls it in).
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        func('system', [])
+    assert ctx.value.kind == 'snap-not-found'
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +336,40 @@ def test_restart_snap_with_no_services_raises():
 
 
 # ---------------------------------------------------------------------------
+# services=[] ("none of them") vs services=None ("all of them")
+# ---------------------------------------------------------------------------
+
+
+def test_empty_services_does_not_start_or_enable():
+    # The distinction the tri-state exists for: an empty list of services must not widen into
+    # "every service the snap has". Asserted on the enabled flag rather than active, since
+    # kube-proxy.daemon exits immediately (no k8s cluster) but stays enabled.
+    ensure_installed(_SNAP, classic=True)
+    _stop_and_disable()
+    assert not _service_is_enabled()
+    _snapd_apps.start(_SNAP, [], enable=True)
+    assert not _service_is_enabled()
+
+
+def test_empty_services_does_not_stop_or_disable():
+    ensure_installed(_SNAP, classic=True)
+    _stop_and_disable()
+    _snapd_apps.start(_SNAP, _SERVICE, enable=True)
+    assert _service_is_enabled()
+    _snapd_apps.stop(_SNAP, [], disable=True)
+    assert _service_is_enabled()
+    _stop_and_disable()
+
+
+@pytest.mark.parametrize('func', _FUNCTIONS, ids=_IDS)
+def test_empty_services_is_a_no_op_for_a_snap_with_no_services(func: Any):
+    # hello-world has no services at all, so naming them all is an error (asserted above) while
+    # naming none of them is not: the request is never made, and only the snap is checked.
+    ensure_installed('hello-world')
+    assert func('hello-world', []) is None
+
+
+# ---------------------------------------------------------------------------
 # empty and blank service names
 #
 # The names go in a JSON body, so snapd sees a service name exactly as passed and reports it as
@@ -277,11 +380,7 @@ def test_restart_snap_with_no_services_raises():
 
 
 @pytest.mark.parametrize('service', ['', ' ', '\t'])
-@pytest.mark.parametrize(
-    'func',
-    [_snapd_apps.start, _snapd_apps.stop, _snapd_apps.restart],
-    ids=['start', 'stop', 'restart'],
-)
+@pytest.mark.parametrize('func', _FUNCTIONS, ids=_IDS)
 def test_empty_and_blank_service_names_raise_value_error(func: Any, service: str):
     ensure_installed(_SNAP, classic=True)
     with pytest.raises(ValueError, match='service name must not be'):
@@ -308,3 +407,43 @@ def test_raw_api_unusable_service_name_aborts_the_whole_request():
             '/v2/apps',
             body={'action': 'restart', 'names': [f'{_SNAP}.', f'{_SNAP}.{_SERVICE}']},
         )
+
+
+# ---------------------------------------------------------------------------
+# empty and non-canonical snap names -> ValueError
+#
+# The snap name goes in the request body here rather than a URL path, so snapd would answer for
+# it -- but a name that isn't a single path segment can't be a snap, and the not-installed probe
+# builds a path from it, so it's rejected up front for the same reasons as in conf and info.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('snap', ['', ' ', '.', '..', 'kube-proxy/daemon'])
+@pytest.mark.parametrize(
+    'services', [None, 'svc', ['svc'], []], ids=['all', 'one', 'list', 'none']
+)
+@pytest.mark.parametrize('func', _FUNCTIONS, ids=_IDS)
+def test_invalid_snap_name_raises_value_error(func: Any, services: Any, snap: str):
+    with pytest.raises(ValueError):
+        func(snap, services)
+
+
+@pytest.mark.parametrize(
+    ('name', 'kind', 'message'),
+    [
+        ('', 'snap-not-found', 'snap "" not found'),
+        ('kube-proxy/daemon', 'snap-not-found', 'snap "kube-proxy/daemon" not found'),
+        # snapd splits a name on its first '.' before resolving it, so these two are read as a
+        # service of the snap '' rather than as the name that was sent -- and land on the
+        # app-not-found branch, where the probe would build a path out of an unusable name.
+        ('.', 'app-not-found', 'snap "" has no service ""'),
+        ('..', 'app-not-found', 'snap "" has no service "."'),
+    ],
+)
+def test_raw_api_invalid_snap_name(name: str, kind: str, message: str):
+    # What the rejection above stops us from sending. Nothing is lost by rejecting these names
+    # client-side: snapd resolves none of them to a snap either.
+    with pytest.raises(_errors.APIError) as ctx:
+        _client.post('/v2/apps', body={'action': 'start', 'names': [name]})
+    assert ctx.value.kind == kind
+    assert ctx.value.message == message

--- a/snap/tests/functional/test_snapd_conf.py
+++ b/snap/tests/functional/test_snapd_conf.py
@@ -228,6 +228,45 @@ def test_get_all_installed_snap_with_no_config_returns_empty_dict():
 
 
 # ---------------------------------------------------------------------------
+# get and unset: a bare string is one key
+#
+# A string is iterable, so a bare key would otherwise be split into single-character keys -- a
+# request for 'p', 'o', 'r', 't' rather than 'port'. Taking it as one key is what every caller
+# means by it, and is why the type checker accepting it (str is an Iterable[str]) is no longer a
+# trap. The result is still a dict, so reading one value is get(snap, key)[key].
+# ---------------------------------------------------------------------------
+
+
+def test_get_bare_string_is_one_key():
+    ensure_installed(_SNAP, channel='latest/edge')
+    _snapd_conf.set(_SNAP, {_KEY: 'value'})
+    assert _snapd_conf.get(_SNAP, _KEY) == {_KEY: 'value'}
+    assert _snapd_conf.get(_SNAP, _KEY) == _snapd_conf.get(_SNAP, [_KEY])
+    _cleanup()
+
+
+def test_get_bare_string_dotted_key():
+    ensure_installed(_SNAP, channel='latest/edge')
+    _snapd_conf.set(_SNAP, {_KEY: {'nested': 'value'}})
+    assert _snapd_conf.get(_SNAP, f'{_KEY}.nested') == {f'{_KEY}.nested': 'value'}
+    _cleanup()
+
+
+def test_get_bare_string_is_validated_like_a_key_in_a_list():
+    # A comma in a single key would still become two keys once joined into the query parameter.
+    with pytest.raises(ValueError, match='must not contain a comma'):
+        _snapd_conf.get(_SNAP, f'{_KEY},{_KEY2}')
+
+
+def test_unset_bare_string_is_one_key():
+    ensure_installed(_SNAP, channel='latest/edge')
+    _snapd_conf.set(_SNAP, {_KEY: 'value'})
+    _snapd_conf.unset(_SNAP, _KEY)
+    with pytest.raises(_errors.OptionNotFoundError):
+        _snapd_conf.get(_SNAP, _KEY)
+
+
+# ---------------------------------------------------------------------------
 # get: keys=[] ("give me nothing") vs keys=None ("give me everything")
 # ---------------------------------------------------------------------------
 
@@ -578,8 +617,12 @@ def test_conf_invalid_snap_name_raises_value_error(snap: str):
     with pytest.raises(ValueError):
         _snapd_conf.get(snap, [_KEY])
     with pytest.raises(ValueError):
+        _snapd_conf.get(snap, _KEY)  # A bare string key.
+    with pytest.raises(ValueError):
         _snapd_conf.get(snap, [])  # The installed-snap probe path.
     with pytest.raises(ValueError):
         _snapd_conf.set(snap, {_KEY: 'x'})
     with pytest.raises(ValueError):
         _snapd_conf.unset(snap, [_KEY])
+    with pytest.raises(ValueError):
+        _snapd_conf.unset(snap, _KEY)  # A bare string key.

--- a/snap/tests/functional/test_snapd_logs.py
+++ b/snap/tests/functional/test_snapd_logs.py
@@ -68,8 +68,19 @@ def test_logs_multiple_snaps():
     # Requesting logs for multiple snaps should not raise.
     ensure_installed(_SNAP, classic=True)
     ensure_installed('lxd')
-    entries = _snapd_logs.logs(_SNAP, 'lxd', limit=10)
+    entries = _snapd_logs.logs([_SNAP, 'lxd'], limit=10)
     assert isinstance(entries, list)
+
+
+def test_logs_bare_name_and_single_element_list_agree():
+    # A bare string is one snap name, not an iterable of its characters, so it queries the same
+    # logs as the same name in a list. Compared by syslog identifier, since new entries are
+    # logged all the time.
+    ensure_installed(_SNAP, classic=True)
+    from_string = {entry.sid for entry in _snapd_logs.logs(_SNAP, limit=None)}
+    from_list = {entry.sid for entry in _snapd_logs.logs([_SNAP], limit=None)}
+    assert from_string
+    assert from_list.issuperset(from_string)
 
 
 def test_logs_limit_zero_raises():
@@ -91,6 +102,27 @@ def test_logs_no_snap_args():
     # Calling logs() with no snap arguments returns system-wide logs.
     entries = _snapd_logs.logs(limit=3)
     assert isinstance(entries, list)
+
+
+# ---------------------------------------------------------------------------
+# snaps=[] ("no snaps") vs snaps=None ("system-wide")
+# ---------------------------------------------------------------------------
+
+
+def test_logs_empty_snaps_returns_no_entries():
+    # The distinction the tri-state exists for: an empty list of names must not widen into a
+    # request for every snap's logs, which is what dropping the 'names' parameter would do (and
+    # what snapd does with a 'names' value that parses away -- see the raw tests below).
+    ensure_installed(_SNAP, classic=True)
+    assert _snapd_logs.logs([], limit=None) == []
+    assert _snapd_logs.logs(None, limit=None) != []
+
+
+def test_logs_empty_snaps_still_validates_the_limit():
+    # Arguments are validated even when there's no work to do, so a bad limit is an error either
+    # way rather than depending on how many snaps were named.
+    with pytest.raises(ValueError, match='positive integer or None'):
+        _snapd_logs.logs([], limit=0)
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/unit/test_empty_or_blank.py
+++ b/snap/tests/unit/test_empty_or_blank.py
@@ -149,7 +149,10 @@ def test_error_is_raised_one_frame_below_the_function_the_caller_called():
 
 
 # The functions that validate through snap_path_segment reach the check one frame deeper, since
-# it returns the encoded name and so has to call the check itself.
+# it returns the encoded name and so has to call the check itself. The /v2/apps functions are the
+# same depth for a different reason: start, stop and restart share one implementation, and it
+# calls the check. Neither is deeper than that, which is why raise_if_not_path_segment chains the
+# empty and blank predicates itself rather than calling raise_if_empty_or_blank.
 _MAX_FRAMES = 3
 
 # ensure is a composition of the other public functions rather than a call to an endpoint of its

--- a/snap/tests/unit/test_snapd_apps.py
+++ b/snap/tests/unit/test_snapd_apps.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from charmlibs.snap import _snapd_apps
+from charmlibs.snap._errors import AppNotFoundError, NotFoundError
+from conftest import result_of
 
 if TYPE_CHECKING:
     from conftest import MockClient
@@ -20,13 +22,19 @@ class TestStart:
             '/v2/apps', body={'action': 'start', 'names': ['lxd']}
         )
 
+    def test_start_services_none_is_the_default(self, mock_client: MockClient):
+        _snapd_apps.start('lxd', services=None)
+        mock_client.post.assert_called_once_with(
+            '/v2/apps', body={'action': 'start', 'names': ['lxd']}
+        )
+
     def test_start_with_service(self, mock_client: MockClient):
         _snapd_apps.start('lxd', 'daemon')
         body = mock_client.post.call_args.kwargs['body']
         assert body['names'] == ['lxd.daemon']
 
     def test_start_multiple_services(self, mock_client: MockClient):
-        _snapd_apps.start('lxd', 'daemon', 'user-daemon')
+        _snapd_apps.start('lxd', ['daemon', 'user-daemon'])
         body = mock_client.post.call_args.kwargs['body']
         assert body['names'] == ['lxd.daemon', 'lxd.user-daemon']
 
@@ -70,10 +78,176 @@ class TestRestart:
 _FUNCTIONS = [_snapd_apps.start, _snapd_apps.stop, _snapd_apps.restart]
 
 
-class TestEmptySnapName:
+class TestServicesArgument:
+    # services=None means every service the snap has, services=[] means none of them, and a bare
+    # string means that one service. A string is iterable, so without the last rule 'daemon'
+    # would silently mean the services 'd', 'a', 'e', ...
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_bare_string_is_one_service(self, mock_client: MockClient, func: Any):
+        func('lxd', 'daemon')
+        assert mock_client.post.call_args.kwargs['body']['names'] == ['lxd.daemon']
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_single_element_list_is_the_same_as_a_bare_string(
+        self, mock_client: MockClient, func: Any
+    ):
+        func('lxd', ['daemon'])
+        assert mock_client.post.call_args.kwargs['body']['names'] == ['lxd.daemon']
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_arbitrary_iterable_is_accepted(self, mock_client: MockClient, func: Any):
+        # The names are iterated to validate them and then to build the request, so a generator
+        # must be materialised rather than consumed by the first pass.
+        func('lxd', (s for s in ('daemon', 'user-daemon')))
+        assert mock_client.post.call_args.kwargs['body']['names'] == [
+            'lxd.daemon',
+            'lxd.user-daemon',
+        ]
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_none_names_the_snap_itself(self, mock_client: MockClient, func: Any):
+        # Naming the snap is how snapd is asked to act on all of its services.
+        func('lxd', None)
+        assert mock_client.post.call_args.kwargs['body']['names'] == ['lxd']
+
+
+class TestEmptyServices:
+    # services=[] is a deliberate "no services requested", distinct from services=None ("all of
+    # them"). No action is posted, but the snap named alongside it is still checked -- asking a
+    # snap that isn't installed to do nothing is an error, not a no-op.
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_empty_services_posts_nothing(self, mock_client: MockClient, func: Any):
+        mock_client.get.return_value = result_of('snap_info_hello_world.json')
+        assert func('hello-world', []) is None
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_empty_services_probes_installed_snap(self, mock_client: MockClient, func: Any):
+        mock_client.get.return_value = result_of('snap_info_hello_world.json')
+        func('hello-world', [])
+        mock_client.get.assert_called_once_with('/v2/snaps/hello-world')
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_empty_services_not_installed_raises_not_found(
+        self, mock_client: MockClient, func: Any
+    ):
+        mock_client.get.side_effect = NotFoundError(
+            'snap not installed', kind='snap-not-found', value='hello-world'
+        )
+        with pytest.raises(NotFoundError) as ctx:
+            func('hello-world', [])
+        # snapd's own probe error is raised unchanged: terse message, snap name in value (which
+        # str() surfaces). Not chained -- the probe's error was handled, not propagated.
+        assert ctx.value.message == 'snap not installed'
+        assert ctx.value.value == 'hello-world'
+        assert str(ctx.value) == 'snap not installed (hello-world)'
+        assert ctx.value.__context__ is None
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    @pytest.mark.parametrize('snap', ['system', 'core'])
+    def test_system_names_are_probed(self, mock_client: MockClient, func: Any, snap: str):
+        # Unlike the conf and interfaces endpoints, /v2/apps has no 'system' alias and treats
+        # 'core' as an ordinary snap, so neither name skips the probe.
+        mock_client.get.side_effect = NotFoundError(
+            'snap not installed', kind='snap-not-found', value=snap
+        )
+        with pytest.raises(NotFoundError):
+            func(snap, [])
+        mock_client.get.assert_called_once_with(f'/v2/snaps/{snap}')
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_empty_services_still_validates_service_names(
+        self, mock_client: MockClient, func: Any
+    ):
+        # Nothing to validate in an empty list, but an unusable name alongside others is still
+        # rejected before the emptiness of the list is considered.
+        with pytest.raises(ValueError, match='service name must not be empty'):
+            func('hello-world', [''])
+        mock_client.get.assert_not_called()
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_empty_string_is_not_empty_services(self, mock_client: MockClient, func: Any):
+        # The one case the bare-string rule makes ambiguous: '' is one (unusable) service name,
+        # not an empty collection of them, so it's a ValueError rather than a no-op.
+        with pytest.raises(ValueError, match='service name must not be empty'):
+            func('hello-world', '')
+        mock_client.get.assert_not_called()
+        mock_client.post.assert_not_called()
+
+
+class TestAppNotFoundConversion:
+    # snapd answers app-not-found both for a snap that isn't installed and for a service an
+    # installed snap doesn't have, so start/stop/restart probe /v2/snaps/{snap} to tell them
+    # apart. An absent snap raises NotFoundError as it does elsewhere in the library, leaving
+    # AppNotFoundError to mean the snap is installed but has no such service.
+    # Built fresh per call: raising an exception mutates its __context__, so a shared instance
+    # would leak chaining state between tests.
+    @staticmethod
+    def _app_not_found() -> AppNotFoundError:
+        return AppNotFoundError(
+            'snap "hello-world" has no service "daemon"', kind='app-not-found', value=''
+        )
+
+    @staticmethod
+    def _snap_not_found() -> NotFoundError:
+        return NotFoundError('snap not installed', kind='snap-not-found', value='hello-world')
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_absent_snap_raises_not_found(self, mock_client: MockClient, func: Any):
+        mock_client.post.side_effect = self._app_not_found()
+        mock_client.get.side_effect = self._snap_not_found()
+        with pytest.raises(NotFoundError) as ctx:
+            func('hello-world', 'daemon')
+        assert ctx.value.kind == 'snap-not-found'
+        assert str(ctx.value) == 'snap not installed (hello-world)'
+        mock_client.get.assert_called_once_with('/v2/snaps/hello-world')
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_absent_snap_does_not_chain_app_not_found(self, mock_client: MockClient, func: Any):
+        # snapd's misleading app-not-found is suppressed ('raise ... from None'), so the user
+        # sees a single traceback that doesn't mention a service they may not have named.
+        mock_client.post.side_effect = self._app_not_found()
+        mock_client.get.side_effect = self._snap_not_found()
+        with pytest.raises(NotFoundError) as ctx:
+            func('hello-world', 'daemon')
+        assert ctx.value.__cause__ is None
+        assert ctx.value.__suppress_context__
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_missing_service_on_installed_snap_reraises_app_not_found(
+        self, mock_client: MockClient, func: Any
+    ):
+        mock_client.post.side_effect = self._app_not_found()
+        mock_client.get.return_value = result_of('snap_info_hello_world.json')
+        with pytest.raises(AppNotFoundError) as ctx:
+            func('hello-world', 'daemon')
+        assert ctx.value.kind == 'app-not-found'
+        mock_client.get.assert_called_once_with('/v2/snaps/hello-world')
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_snap_with_no_services_reraises_app_not_found(
+        self, mock_client: MockClient, func: Any
+    ):
+        # services=None on an installed snap with no services: the probe finds the snap, so
+        # snapd's own error stands.
+        mock_client.post.side_effect = self._app_not_found()
+        mock_client.get.return_value = result_of('snap_info_hello_world.json')
+        with pytest.raises(AppNotFoundError):
+            func('hello-world')
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    def test_successful_call_is_not_probed(self, mock_client: MockClient, func: Any):
+        func('hello-world', 'daemon')
+        mock_client.get.assert_not_called()
+
+
+class TestInvalidSnapName:
     # /v2/apps takes the snap name in the request body, where snapd already answers an empty name
     # with a typed 'snap "" not found'. We still reject it up front, so that every function in the
-    # library reports an empty snap name the same way.
+    # library reports an empty snap name the same way -- and so that the not-installed probe,
+    # which builds a URL path from the name, can't raise ValueError from inside the handler for
+    # snapd's app-not-found and mask the error being classified.
     @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
     def test_empty_name_raises_value_error_without_request(
         self, mock_client: MockClient, func: Any
@@ -87,6 +261,19 @@ class TestEmptySnapName:
         with pytest.raises(ValueError, match='must not be empty'):
             func('', 'daemon')
         mock_client.post.assert_not_called()
+
+    @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
+    @pytest.mark.parametrize('services', [None, [], ['daemon'], 'daemon'])
+    @pytest.mark.parametrize('snap', ['.', '..', 'hello-world/conf'])
+    def test_name_that_is_not_a_path_segment_raises(
+        self, mock_client: MockClient, func: Any, services: Any, snap: str
+    ):
+        # Checked for every form of the services argument, so that every path through the
+        # function reports an unusable name the same way.
+        with pytest.raises(ValueError, match='single path segment'):
+            func(snap, services)
+        mock_client.post.assert_not_called()
+        mock_client.get.assert_not_called()
 
 
 class TestEmptyOrBlankServiceName:
@@ -105,7 +292,7 @@ class TestEmptyOrBlankServiceName:
     @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)
     def test_raises_among_valid_service_names(self, mock_client: MockClient, func: Any):
         with pytest.raises(ValueError, match='service name must not be empty'):
-            func('lxd', 'daemon', '')
+            func('lxd', ['daemon', ''])
         mock_client.post.assert_not_called()
 
     @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)

--- a/snap/tests/unit/test_snapd_conf.py
+++ b/snap/tests/unit/test_snapd_conf.py
@@ -90,11 +90,36 @@ class TestGet:
         assert isinstance(result, dict)
         assert 'criu' in result
 
-    def test_get_string_keys_raises_typeerror(self, mock_client: MockClient):
-        # A bare string is iterable, so it's rejected explicitly rather than being
-        # silently split into single-character keys.
-        with pytest.raises(TypeError):
-            _snapd_conf.get('lxd', 'integer')
+    def test_get_bare_string_is_one_key(self, mock_client: MockClient):
+        # A bare string is iterable, so it means that one key rather than being silently split
+        # into single-character keys. The result is still a dict, so get(s, k)[k] holds.
+        mock_client.get.return_value = result_of('conf_lxd_single_key.json')
+        result = _snapd_conf.get('lxd', 'integer')
+        mock_client.get.assert_called_once_with('/v2/snaps/lxd/conf', query={'keys': 'integer'})
+        assert result['integer'] == 1
+
+    def test_get_bare_string_is_the_same_as_a_single_element_list(self, mock_client: MockClient):
+        mock_client.get.return_value = result_of('conf_lxd_single_key.json')
+        from_string = _snapd_conf.get('lxd', 'integer')
+        from_list = _snapd_conf.get('lxd', ['integer'])
+        assert from_string == from_list
+        assert [call.kwargs['query'] for call in mock_client.get.call_args_list] == [
+            {'keys': 'integer'},
+            {'keys': 'integer'},
+        ]
+
+    def test_get_bare_string_is_validated(self, mock_client: MockClient):
+        # A single key gets the same checks as one in a list: a comma in it would otherwise
+        # become two keys once joined into the query parameter.
+        with pytest.raises(ValueError, match='must not contain a comma'):
+            _snapd_conf.get('lxd', 'a,b')
+        mock_client.get.assert_not_called()
+
+    def test_get_empty_string_is_not_empty_keys(self, mock_client: MockClient):
+        # The one case the bare-string rule makes ambiguous: '' is one (unusable) key, not an
+        # empty collection of them, so it's a ValueError rather than the keys=[] no-op.
+        with pytest.raises(ValueError, match='must not be empty'):
+            _snapd_conf.get('lxd', '')
         mock_client.get.assert_not_called()
 
 
@@ -241,11 +266,17 @@ class TestUnset:
         body = mock_client.put.call_args.kwargs['body']
         assert body == {'a': None, 'b': None}
 
-    def test_unset_string_keys_raises_typeerror(self, mock_client: MockClient):
-        # A bare string is iterable, so it's rejected explicitly rather than being
-        # silently split into single-character keys.
-        with pytest.raises(TypeError):
-            _snapd_conf.unset('lxd', 'mykey')
+    def test_unset_bare_string_is_one_key(self, mock_client: MockClient):
+        # A bare string is iterable, so it means that one key rather than being silently split
+        # into single-character keys.
+        _snapd_conf.unset('lxd', 'mykey')
+        mock_client.put.assert_called_once_with('/v2/snaps/lxd/conf', body={'mykey': None})
+
+    def test_unset_empty_string_key_raises(self, mock_client: MockClient):
+        # The one case the bare-string rule makes ambiguous: '' is one (unusable) key, not an
+        # empty collection of them.
+        with pytest.raises(ValueError, match='must not be empty'):
+            _snapd_conf.unset('lxd', '')
         mock_client.put.assert_not_called()
 
     def test_unset_empty_keys_is_noop(self, mock_client: MockClient):
@@ -339,8 +370,8 @@ class TestSnapNameInPath:
     def test_get_empty_name_raises_value_error_for_any_keys(
         self, mock_client: MockClient, keys: Any
     ):
-        # Including keys=[] (the installed-snap probe) and a string (a TypeError otherwise),
-        # so that every path through get() reports the empty name the same way.
+        # Including keys=[] (the installed-snap probe) and a bare string, so that every path
+        # through get() reports the empty name the same way.
         with pytest.raises(ValueError, match='must not be empty'):
             _snapd_conf.get('', keys)
         mock_client.get.assert_not_called()
@@ -361,9 +392,13 @@ class TestSnapNameInPath:
             _snapd_conf.unset(snap, ['mykey'])
         mock_client.put.assert_not_called()
 
-    def test_unset_validates_name_before_keys(self, mock_client: MockClient):
+    @pytest.mark.parametrize('keys', [[], ['mykey'], 'mykey'])
+    def test_unset_empty_name_raises_value_error_for_any_keys(
+        self, mock_client: MockClient, keys: Any
+    ):
         with pytest.raises(ValueError, match='must not be empty'):
-            _snapd_conf.unset('', 'mykey')  # A string 'keys' would otherwise be a TypeError.
+            _snapd_conf.unset('', keys)
+        mock_client.put.assert_not_called()
 
     def test_name_is_percent_encoded(self, mock_client: MockClient):
         _snapd_conf.set('hello world', {'mykey': 'myval'})

--- a/snap/tests/unit/test_snapd_logs.py
+++ b/snap/tests/unit/test_snapd_logs.py
@@ -35,9 +35,22 @@ class TestLogs:
 
     def test_logs_multiple_snaps(self, mock_client: MockClient):
         mock_client.get_logs.return_value = []
-        _snapd_logs.logs('lxd', 'vlc')
+        _snapd_logs.logs(['lxd', 'vlc'])
         query = mock_client.get_logs.call_args.kwargs['query']
         assert query['names'] == 'lxd,vlc'
+
+    def test_logs_arbitrary_iterable(self, mock_client: MockClient):
+        # The names are iterated to validate them and then to build the query, so a generator
+        # must be materialised rather than consumed by the first pass.
+        mock_client.get_logs.return_value = []
+        _snapd_logs.logs(s for s in ('lxd', 'vlc'))
+        query = mock_client.get_logs.call_args.kwargs['query']
+        assert query['names'] == 'lxd,vlc'
+
+    def test_logs_single_element_list_is_the_same_as_a_bare_string(self, mock_client: MockClient):
+        mock_client.get_logs.return_value = []
+        _snapd_logs.logs(['lxd'])
+        mock_client.get_logs.assert_called_once_with(query={'n': 10, 'names': 'lxd'})
 
     def test_logs_custom_limit(self, mock_client: MockClient):
         mock_client.get_logs.return_value = []
@@ -159,6 +172,43 @@ class TestParseTimestamp:
         assert ts.hour == 16
 
 
+class TestSnapsArgument:
+    # snaps=None means system-wide logs, snaps=[] means no snaps at all, and a bare string means
+    # that one snap. A string is iterable, so without the last rule 'lxd' would silently mean the
+    # snaps 'l', 'x', 'd'.
+    def test_none_queries_system_wide_logs(self, mock_client: MockClient):
+        mock_client.get_logs.return_value = []
+        _snapd_logs.logs(None)
+        mock_client.get_logs.assert_called_once_with(query={'n': 10})
+
+    def test_empty_returns_no_entries_without_a_request(self, mock_client: MockClient):
+        # Unlike the /v2/apps functions, there's no separate snap argument left to check when
+        # the names are empty: the names are the whole request, so nothing is asked of snapd.
+        assert _snapd_logs.logs([]) == []
+        mock_client.get_logs.assert_not_called()
+
+    def test_empty_is_not_the_same_as_none(self, mock_client: MockClient):
+        # The distinction the tri-state exists for: an empty collection of names must not widen
+        # into a request for every snap's logs.
+        mock_client.get_logs.return_value = result_of('logs_lxd.json')
+        assert _snapd_logs.logs([]) == []
+        assert _snapd_logs.logs(None) != []
+
+    def test_empty_still_validates_the_limit(self, mock_client: MockClient):
+        # Arguments are validated even when there's no work to do, so a bad limit is an error
+        # either way rather than depending on how many snaps were named.
+        with pytest.raises(ValueError, match='positive integer or None'):
+            _snapd_logs.logs([], limit=0)
+        mock_client.get_logs.assert_not_called()
+
+    def test_empty_string_is_not_empty_snaps(self, mock_client: MockClient):
+        # The one case the bare-string rule makes ambiguous: '' is one (unusable) snap name, not
+        # an empty collection of them, so it's a ValueError rather than an empty result.
+        with pytest.raises(ValueError, match='must not be empty'):
+            _snapd_logs.logs('')
+        mock_client.get_logs.assert_not_called()
+
+
 class TestUnsafeSnapName:
     # The names are sent as one comma-separated query parameter, and snapd's parsing of it drops
     # blank entries, splits on commas, and strips whitespace -- so a name it alters is silently
@@ -186,7 +236,7 @@ class TestUnsafeSnapName:
     @pytest.mark.parametrize('name', ['', ' ', 'lxd,vlc', ' lxd'])
     def test_unsafe_name_among_valid_names_raises(self, mock_client: MockClient, name: str):
         with pytest.raises(ValueError):
-            _snapd_logs.logs('lxd', name)
+            _snapd_logs.logs(['lxd', name])
         mock_client.get_logs.assert_not_called()
 
     def test_name_validated_before_limit(self, mock_client: MockClient):

--- a/snap/tests/unit/test_utils.py
+++ b/snap/tests/unit/test_utils.py
@@ -13,7 +13,7 @@ from charmlibs.snap import _utils
 from charmlibs.snap._errors import NotFoundError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from conftest import MockClient
 
@@ -41,6 +41,10 @@ class TestPredicates:
             (_utils._comma, 'a', None),
             (_utils._padding, ' a', "must not have leading or trailing whitespace: ' a'"),
             (_utils._padding, 'a b', None),
+            (_utils._path_segment, 'a/b', "must be a single path segment: 'a/b'"),
+            (_utils._path_segment, '.', "must be a single path segment: '.'"),
+            (_utils._path_segment, '..', "must be a single path segment: '..'"),
+            (_utils._path_segment, 'a.b', None),  # Only '.' and '..' are non-canonical.
         ],
     )
     def test_predicate(
@@ -251,25 +255,60 @@ class TestSnapPathSegment:
         assert _utils.snap_path_segment(snap) == expected
 
 
-class TestCheckInstalledOrSystem:
+class TestAsList:
+    # A bare string is one value, not an iterable of its characters. Every function taking a
+    # 'one value or several' argument normalises it through here, so the rule is stated once.
+    @pytest.mark.parametrize(
+        ('values', 'expected'),
+        [
+            ('abc', ['abc']),
+            ('', ['']),  # Emptiness is the checks' business, not this function's.
+            ([], []),
+            (['a', 'b'], ['a', 'b']),
+            (('a', 'b'), ['a', 'b']),
+            ({'a': 1, 'b': 2}, ['a', 'b']),  # A mapping iterates its keys.
+        ],
+    )
+    def test_as_list(self, values: str | Iterable[str], expected: list[str]):
+        assert _utils.as_list(values) == expected
+
+    def test_generator_is_materialised(self):
+        # The values are iterated more than once -- to validate them and then to send them -- so
+        # a generator must be consumed here rather than passed on.
+        generator = (c for c in ('a', 'b'))
+        assert _utils.as_list(generator) == ['a', 'b']
+        assert list(generator) == []
+
+
+class TestCheckInstalled:
     def test_empty_raises_value_error_without_request(self, mock_client: MockClient):
         with pytest.raises(ValueError, match='must not be empty'):
-            _utils.check_installed_or_system('')
+            _utils.check_installed('')
         mock_client.get.assert_not_called()
 
     @pytest.mark.parametrize('snap', ['system', 'core'])
-    def test_system_names_are_not_probed(self, snap: str, mock_client: MockClient):
-        assert _utils.check_installed_or_system(snap) is None
+    def test_system_names_are_not_probed_when_skipped(self, snap: str, mock_client: MockClient):
+        assert _utils.check_installed(snap, skip_system=True) is None
         mock_client.get.assert_not_called()
 
+    @pytest.mark.parametrize('snap', ['system', 'core'])
+    def test_system_names_are_probed_by_default(self, snap: str, mock_client: MockClient):
+        # skip_system is for endpoints snapd serves under these names whether or not the core
+        # snap is installed. Elsewhere -- /v2/apps -- they get no special treatment, so an
+        # absent 'core' (and 'system', which is never a snap) is reported as not installed.
+        error = NotFoundError('snap not installed', kind='snap-not-found', value=snap)
+        mock_client.get.side_effect = error
+        assert _utils.check_installed(snap) is error
+        mock_client.get.assert_called_once_with(f'/v2/snaps/{snap}')
+
     def test_installed_snap_is_probed(self, mock_client: MockClient):
-        assert _utils.check_installed_or_system('hello world') is None
+        assert _utils.check_installed('hello world') is None
         mock_client.get.assert_called_once_with('/v2/snaps/hello%20world')
 
     def test_absent_snap_returns_not_found(self, mock_client: MockClient):
         error = NotFoundError('snap not installed', kind='snap-not-found', value='hello-world')
         mock_client.get.side_effect = error
-        assert _utils.check_installed_or_system('hello-world') is error
+        assert _utils.check_installed('hello-world') is error
 
 
 class TestNormalizeChannel:

--- a/snap/tests/unit/test_utils.py
+++ b/snap/tests/unit/test_utils.py
@@ -256,8 +256,6 @@ class TestSnapPathSegment:
 
 
 class TestAsList:
-    # A bare string is one value, not an iterable of its characters. Every function taking a
-    # 'one value or several' argument normalises it through here, so the rule is stated once.
     @pytest.mark.parametrize(
         ('values', 'expected'),
         [
@@ -267,17 +265,13 @@ class TestAsList:
             (['a', 'b'], ['a', 'b']),
             (('a', 'b'), ['a', 'b']),
             ({'a': 1, 'b': 2}, ['a', 'b']),  # A mapping iterates its keys.
+            # Callers iterate the values twice -- to validate them and then to send them -- so
+            # a one-shot iterable must come back materialised rather than passed through.
+            ((c for c in ('a', 'b')), ['a', 'b']),
         ],
     )
     def test_as_list(self, values: str | Iterable[str], expected: list[str]):
         assert _utils.as_list(values) == expected
-
-    def test_generator_is_materialised(self):
-        # The values are iterated more than once -- to validate them and then to send them -- so
-        # a generator must be consumed here rather than passed on.
-        generator = (c for c in ('a', 'b'))
-        assert _utils.as_list(generator) == ['a', 'b']
-        assert list(generator) == []
 
 
 class TestCheckInstalled:


### PR DESCRIPTION
Following the decision made in #572 to use `keys: Iterable[str] | None` rather than `*keys: str`, where `None` means 'all' and `[]` means nothing, this PR revisits the other sites in `charmlibs.snap` where we use `*args`: `logs` and services (`start`, `stop`, `restart`).

In #572 we opted to make passing a `str` for `keys` a `TypeError`, despite `str` being `Iterable[str]`, to avoid silently splitting `keys='key'` into three keys: `'k', 'e', 'y'`. However, the ergonomics of being able to type `snap.logs(mysnap)` instead of being forced to type `snap.logs([mysnap])`, and `snap.start(mysnap, myservice)` rather than `snap.start(mysnap, [myservice])` justifies reversing that decision in this PR. Instead, we treat `keys='key'` as equivalent to `keys=['key']`.

The switch to handling an empty iterable differently from snapd, treating it as a request for nothing rather than silently falling through to a request for everything, necessitates some additional machinery for services, since we now follow conf in converting `AppNotFoundError` into `NotFoundError` for `snap.start('not-installed', 'service')`, and must implement the same semantics for `snap.start('not-installed', [])`.