### PR TITLE
feat(snap): add get_one and rename info to list_one

### DIFF
--- a/snap/src/charmlibs/snap/__init__.py
+++ b/snap/src/charmlibs/snap/__init__.py
@@ -18,7 +18,7 @@ Use :func:`ensure` to ensure that a snap is installed, optionally on a specific 
 or revision.
 
 Manually manage snap installation with :func:`install`, :func:`refresh`, and :func:`remove`.
-Use :func:`info` to query the current state of an installed snap.
+Use :func:`list_one` to query the current state of an installed snap.
 
 Also manage:
 
@@ -86,10 +86,10 @@ from ._snapd_logs import (
     logs,
 )
 from ._snapd_snaps import (
-    Info,
+    InstalledInfo,
     hold,
-    info,
     install,
+    list_one,
     refresh,
     remove,
     unhold,
@@ -104,7 +104,7 @@ __all__ = [
     'ChannelNotAvailableError',
     'ConnectionError',
     'Error',
-    'Info',
+    'InstalledInfo',
     'LogEntry',
     'NeedsClassicError',
     'NotFoundError',
@@ -118,8 +118,8 @@ __all__ = [
     'ensure',
     'get',
     'hold',
-    'info',
     'install',
+    'list_one',
     'logs',
     'refresh',
     'remove',

--- a/snap/src/charmlibs/snap/__init__.py
+++ b/snap/src/charmlibs/snap/__init__.py
@@ -24,7 +24,7 @@ Also manage:
 
 - Automatic refreshes with :func:`hold` and :func:`unhold`.
 - Services with :func:`start`, :func:`stop`, and :func:`restart`.
-- Config with :func:`get`, :func:`set`, and :func:`unset`.
+- Config with :func:`get`, :func:`get_one`, :func:`set`, and :func:`unset`.
 - Connections between snaps with :func:`connect` and :func:`disconnect`.
 - Application aliases with :func:`alias` and :func:`unalias`.
 
@@ -74,6 +74,7 @@ from ._snapd_apps import (
 )
 from ._snapd_conf import (
     get,
+    get_one,
     set,  # noqa: A004 (shadowing a Python builtin)
     unset,
 )
@@ -117,6 +118,7 @@ __all__ = [
     'disconnect',
     'ensure',
     'get',
+    'get_one',
     'hold',
     'install',
     'list_one',

--- a/snap/src/charmlibs/snap/_functions.py
+++ b/snap/src/charmlibs/snap/_functions.py
@@ -75,7 +75,7 @@ def ensure(
         ChangeError: If the install or refresh fails after starting (for example, a hook errors).
         Error: (or a subtype) if the snap could not be installed or refreshed for another reason.
     """
-    info = _get_info(snap)
+    info = _installed_info(snap)
     if info is None:  # Not installed.
         _snapd_snaps.install(snap, channel=channel, revision=revision, classic=classic)
         return True
@@ -97,9 +97,9 @@ def ensure(
     return _snapd_snaps.refresh(snap, channel=channel, classic=classic)
 
 
-def _get_info(snap: str) -> _snapd_snaps.Info | None:
-    """Get snap info, raising an error if the snap is not installed."""
+def _installed_info(snap: str) -> _snapd_snaps.InstalledInfo | None:
+    """Return the snap's local state, or None if it is not installed."""
     try:
-        return _snapd_snaps.info(snap)
+        return _snapd_snaps.list_one(snap)
     except _errors.NotFoundError:
         return None

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -115,9 +115,7 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
 def get_one(snap: str, key: str) -> Any:
     """Get the value of a single snap configuration key.
 
-    The single-value counterpart of :func:`get`, which always returns a dict so that it can
-    report several keys at once. Use this when one key is wanted and the dict would only be
-    unwrapped again.
+    ``get_one(snap, key)`` returns ``value``, while ``get(snap, key)`` returns ``{key: value}``.
 
     Args:
         snap: The name of the snap to read configuration from.

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 # /v2/snaps/{snap}/conf
 
 
-# Getting one config value looks like get(s, [k])[k]. In future we could add a get_one(s) helper.
 # Get with keys=None returns the entire config, following the CLI (get_all is unnecessary).
+# Reading a single value is get_one, defined below in terms of this function.
 def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
     """Get snap configuration.
 
@@ -110,6 +110,41 @@ def get(snap: str, keys: Iterable[str] | None = None) -> dict[str, Any]:
         raise error
     assert isinstance(config, dict)
     return typing.cast('dict[str, Any]', config)
+
+
+def get_one(snap: str, key: str) -> Any:
+    """Get the value of a single snap configuration key.
+
+    The single-value counterpart of :func:`get`, which always returns a dict so that it can
+    report several keys at once. Use this when one key is wanted and the dict would only be
+    unwrapped again.
+
+    Args:
+        snap: The name of the snap to read configuration from.
+        key: The configuration key to read. Nested options may be accessed with dotted notation,
+            for example ``'server.port'``.
+
+    Returns:
+        The configured value, which may be any JSON type, including a nested dict for a key
+        that names a subtree.
+
+    Raises:
+        ValueError: if the snap name is empty, blank, or is not a single path segment, or if the
+            key is empty, blank, or contains a comma or surrounding whitespace.
+        NotFoundError: if the snap is not installed. Never raised for ``system`` or ``core``,
+            whose configuration is served whether or not the core snap is installed.
+        OptionNotFoundError: if the key has no value stored in the snap's configuration. See
+            :func:`get` for why snapd cannot distinguish an unrecognised key from an unset one.
+
+    ::
+
+        get_one('foo', 'client')  # {'timeout': 30}
+        get_one('foo', 'client.timeout')  # 30
+    """
+    # NOTE: get() rejects any key its 'keys' query parameter would alter, and raises
+    # OptionNotFoundError for a key that isn't set, so the result is keyed by exactly the key
+    # requested and this subscript can't raise KeyError.
+    return get(snap, [key])[key]
 
 
 def unset(snap: str, keys: Iterable[str]) -> None:

--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 # /v2/snaps/{snap}
 
 
-class Info:
+class InstalledInfo:
     def __init__(
         self,
         name: str,
@@ -98,17 +98,19 @@ class Info:
         return self._hold
 
 
-def info(snap: str) -> Info:
-    """Get information about an installed snap.
+def list_one(snap: str) -> InstalledInfo:
+    """Get information about a single installed snap.
 
-    This function implements the semantics of the `snap list` command,
-    restricted to a single snap.
+    This function implements the semantics of the ``snap list`` command, restricted to a single
+    snap: it reports the local state of an installed snap and never queries the snap store.
+    It is named for that command rather than ``snap info``, which reports what the store offers
+    for a snap -- the channels available and their revisions -- and is not implemented here.
 
     Args:
         snap: the name of the snap.
 
     Returns:
-        An Info object with information about the snap.
+        An :class:`InstalledInfo` object with information about the snap.
 
     Raises:
         ValueError: if the snap name is empty or is not a single path segment.
@@ -118,7 +120,7 @@ def info(snap: str) -> Info:
     info_dict = _client.get(f'/v2/snaps/{_utils.snap_path_segment(snap)}')
     assert isinstance(info_dict, dict)
     info_dict = typing.cast('dict[str, str]', info_dict)
-    return Info._from_dict(info_dict)
+    return InstalledInfo._from_dict(info_dict)
 
 
 def install(
@@ -298,7 +300,7 @@ def hold(snap: str, duration: datetime.timedelta | int | float | None = None) ->
     data = {'action': 'hold', 'hold-level': 'general', 'time': until}
     # NOTE: The API returns an error with no 'kind' when holding a non-installed snap.
     # The CLI raises an error in this case, so we pre-emptively check if the snap is installed.
-    info(snap)  # Raise NotFoundError if not installed.
+    list_one(snap)  # Raise NotFoundError if not installed.
     _client.post(path, body=data)
 
 

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -34,7 +34,7 @@ def snap_path_segment(snap: str) -> str:
     Percent-encoding alone is not enough to guarantee that:
 
     - snapd's router (gorilla/mux) matches on the *decoded* path, so ``%2F`` is still a path
-      separator to it: without this check ``info('hello-world/conf')`` would reach
+      separator to it: without this check ``list_one('hello-world/conf')`` would reach
       ``/v2/snaps/hello-world/conf`` and return that snap's configuration.
     - ``urllib.parse.quote`` leaves ``.`` unencoded, so a ``.`` or ``..`` name would still make
       the path non-canonical, which mux answers with a ``301`` to the cleaned path.
@@ -84,7 +84,7 @@ def normalize_channel(channel: str) -> str:
     Channels may be specified as a track or risk only, or as "track/risk",
     "risk/branch", or "track/risk/branch". Snapd fills in the defaults and records the
     *resolved* value, so a channel must be normalized the same way before it can be
-    compared with the channel from :func:`info`.
+    compared with the channel from :func:`list_one`.
 
     This mirrors ``channel.Full`` in snapd: a lone risk gets the ``latest`` track, a lone
     track gets the ``stable`` risk, and a leading risk in a two part channel means the
@@ -116,7 +116,7 @@ def resolve_channel(channel: str, tracking: str) -> str:
 
     Args:
         channel: The requested channel, or an empty string to keep the tracked channel.
-        tracking: The channel the snap currently tracks, as reported by ``Info.tracking``.
+        tracking: The channel the snap currently tracks, as reported by ``InstalledInfo.tracking``.
             Empty for a snap that isn't installed, or was installed from a local file.
     """
     if not channel:

--- a/snap/tests/functional/conftest.py
+++ b/snap/tests/functional/conftest.py
@@ -18,7 +18,7 @@ from charmlibs.snap import _client, _functions
 from charmlibs.snap import _snapd_snaps as _snapd
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
     from typing import ParamSpec, TypeVar
 
     _P = ParamSpec('_P')
@@ -74,6 +74,44 @@ def ensure_removed(*snaps: str) -> None:
 def ensure_installed(*snaps: str, channel: str | None = None, classic: bool = False) -> None:
     for snap_name in snaps:
         retry_on_rate_limit(snap.ensure)(snap_name, channel=channel, classic=classic, update=False)
+
+
+# Test helper for the parts of `snap list` the library deliberately doesn't implement: listing
+# several snaps in one request, and listing every installed revision rather than just the current
+# one. list_one covers the single-snap case charms actually need, and these calls are local and
+# cheap, so a charm wanting several can loop -- which is why this lives here and not in the API.
+def _list(  # pyright: ignore[reportUnusedFunction] (imported by the test modules)
+    snaps: str | Iterable[str] | None,
+    *,
+    all: bool = False,  # noqa: A002 (shadowing a Python builtin)
+) -> list[_snapd.InstalledInfo]:
+    """List installed snaps, as `snap list` does.
+
+    Args:
+        snaps: Snap names to list, as a single name or an iterable of names. If ``None``, every
+            installed snap is listed. If an empty iterable, nothing is listed.
+        all: If ``True``, list every installed revision of each snap rather than only the current
+            one, as `snap list --all` does. A snap keeps its previous revision after a refresh,
+            so a name can appear more than once and the result is no longer one entry per snap.
+
+    Unlike `snap list`, a name that isn't installed is not an error: /v2/snaps filters rather
+    than failing, and nothing here reconstructs the error the CLI would print. That, and the
+    per-revision result shape under ``all``, are the two reasons this isn't library API.
+    """
+    query: dict[str, str] = {}
+    if snaps is not None:
+        names = [snaps] if isinstance(snaps, str) else list(snaps)
+        # NOTE: An empty 'snaps' value is not "no snaps" to snapd -- it parses away, leaving the
+        # unfiltered query, which answers with every installed snap. So no names means no request.
+        if not names:
+            return []
+        query['snaps'] = ','.join(names)
+    if all:
+        query['select'] = 'all'
+    result = _client.get('/v2/snaps', query=query or None)
+    assert isinstance(result, list)
+    result = typing.cast('list[dict[str, str]]', result)
+    return [_snapd.InstalledInfo._from_dict(info_dict) for info_dict in result]
 
 
 @functools.cache  # Cached to avoid repeated store queries.

--- a/snap/tests/functional/conftest.py
+++ b/snap/tests/functional/conftest.py
@@ -67,7 +67,7 @@ def retry_on_rate_limit(func: Callable[_P, _T]) -> Callable[_P, _T]:
 
 def ensure_removed(*snaps: str) -> None:
     for snap_name in snaps:
-        if _functions._get_info(snap_name) is not None:
+        if _functions._installed_info(snap_name) is not None:
             snap.remove(snap_name)
 
 
@@ -77,7 +77,7 @@ def ensure_installed(*snaps: str, channel: str | None = None, classic: bool = Fa
 
 
 @functools.cache  # Cached to avoid repeated store queries.
-def list_channels(snap: str) -> dict[str, _snapd.Info]:
+def list_channels(snap: str) -> dict[str, _snapd.InstalledInfo]:
     """List information about all channels of a snap available in the store.
 
     Sources channel/revision info from the store, so that tests can assert against the
@@ -93,6 +93,11 @@ def list_channels(snap: str) -> dict[str, _snapd.Info]:
     # Store results are keyed by channel and have no tracking channel, so the key is supplied as
     # both: Info.tracking reads 'tracking-channel', which only an installed snap has.
     return {
-        k: _snapd.Info._from_dict({'name': snap, 'channel': k, 'tracking-channel': k, **v})
+        k: _snapd.InstalledInfo._from_dict({
+            'name': snap,
+            'channel': k,
+            'tracking-channel': k,
+            **v,
+        })
         for k, v in channels.items()
     }

--- a/snap/tests/functional/test_functions.py
+++ b/snap/tests/functional/test_functions.py
@@ -27,7 +27,7 @@ _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
 def test_ensure_revision_no_op_if_same_revision():
     ensure_installed('hello-world')
-    current_revision = _snapd.info('hello-world').revision
+    current_revision = _snapd.list_one('hello-world').revision
     result = _functions.ensure('hello-world', revision=int(current_revision))
     assert result is False
 
@@ -36,18 +36,18 @@ def test_ensure_revision_no_op_if_same_revision_and_update_true():
     # update is ignored when a revision is specified: the revision fully determines which
     # revision to be on, so there's nothing to update to.
     ensure_installed('hello-world')
-    current_revision = _snapd.info('hello-world').revision
+    current_revision = _snapd.list_one('hello-world').revision
     result = _functions.ensure('hello-world', revision=int(current_revision), update=True)
     assert result is False
 
 
 def test_ensure_revision_refreshes_on_different_revision():
     ensure_installed('hello-world')
-    original_revision = _snapd.info('hello-world').revision
+    original_revision = _snapd.list_one('hello-world').revision
     older_revision = int(original_revision) - 1
     did_something = _functions.ensure('hello-world', revision=older_revision)
     assert did_something is True
-    assert _snapd.info('hello-world').revision == str(older_revision)
+    assert _snapd.list_one('hello-world').revision == str(older_revision)
 
 
 def test_ensure_no_op_update_false():
@@ -72,7 +72,7 @@ def test_ensure_refreshes_on_different_channel():
     ensure_installed('hello-world', channel='latest/stable')
     did_something = _functions.ensure('hello-world', channel='latest/candidate')
     assert did_something is True
-    assert _snapd.info('hello-world').tracking == 'latest/candidate'
+    assert _snapd.list_one('hello-world').tracking == 'latest/candidate'
 
 
 def test_ensure_no_updates_available_returns_false():
@@ -91,7 +91,7 @@ def test_ensure_revision_installs_if_not_present():
     ensure_removed('hello-world')
     did_something = _functions.ensure('hello-world', revision=28)
     assert did_something is True
-    assert _snapd.info('hello-world').revision == '28'
+    assert _snapd.list_one('hello-world').revision == '28'
 
 
 def test_ensure_revision_without_channel_tracks_latest_stable():
@@ -100,7 +100,7 @@ def test_ensure_revision_without_channel_tracks_latest_stable():
     # one -- moves the snap to latest/stable's revision.
     ensure_removed('hello-world')
     _functions.ensure('hello-world', revision=28)
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.revision == '28'
     assert info.tracking == 'latest/stable'
 
@@ -110,7 +110,7 @@ def test_ensure_channel_and_revision_installs_and_tracks_channel():
     edge = list_channels('hello-world')['latest/edge'].revision
     did_something = _functions.ensure('hello-world', channel='latest/edge', revision=edge)
     assert did_something is True
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.revision == edge
     assert info.tracking == 'latest/edge'
 
@@ -134,7 +134,7 @@ def test_ensure_same_revision_different_channel_switches_tracking():
     _functions.ensure('hello-world', channel='latest/edge', revision=revision)
     did_something = _functions.ensure('hello-world', channel='latest/stable', revision=revision)
     assert did_something is True
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.revision == revision
     assert info.tracking == 'latest/stable'
 
@@ -143,19 +143,19 @@ def test_ensure_installs_if_not_present():
     ensure_removed('hello-world')
     did_something = _functions.ensure('hello-world')
     assert did_something is True
-    assert _snapd.info('hello-world').name == 'hello-world'
+    assert _snapd.list_one('hello-world').name == 'hello-world'
 
 
 def test_ensure_installs_at_default_channel():
     ensure_removed('hello-world')
     _functions.ensure('hello-world')
-    assert _snapd.info('hello-world').tracking == 'latest/stable'
+    assert _snapd.list_one('hello-world').tracking == 'latest/stable'
 
 
 def test_ensure_installs_at_specified_channel():
     ensure_removed('hello-world')
     _functions.ensure('hello-world', channel='latest/candidate')
-    assert _snapd.info('hello-world').tracking == 'latest/candidate'
+    assert _snapd.list_one('hello-world').tracking == 'latest/candidate'
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +194,7 @@ def test_ensure_revision_installs_classic():
     channel = 'latest/stable' if 'latest/stable' in channels else next(iter(channels))
     revision = channels[channel].revision
     _functions.ensure('charmcraft', channel=channel, revision=revision, classic=True)
-    info = _snapd.info('charmcraft')
+    info = _snapd.list_one('charmcraft')
     assert info.classic is True
     assert info.revision == revision
 
@@ -208,7 +208,7 @@ def test_ensure_needs_classic_raises():
 def test_ensure_installs_classic():
     ensure_removed('charmcraft')
     _functions.ensure('charmcraft', classic=True)
-    assert _snapd.info('charmcraft').classic is True
+    assert _snapd.list_one('charmcraft').classic is True
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +230,7 @@ def test_ensure_empty_channel_installs_on_default_channel() -> None:
     ensure_removed('hello-world')
     did_something = _functions.ensure('hello-world', channel='')
     assert did_something is True
-    assert _snapd.info('hello-world').tracking == 'latest/stable'
+    assert _snapd.list_one('hello-world').tracking == 'latest/stable'
 
 
 def test_ensure_empty_channel_refreshes_when_installed() -> None:

--- a/snap/tests/functional/test_snapd_conf.py
+++ b/snap/tests/functional/test_snapd_conf.py
@@ -30,13 +30,6 @@ _KEY2 = 'test-functional-key2'
 _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
 
-# Test helper and possible future candidate for library public API.
-def _get_one(snap: str, key: str, /) -> Any:
-    """Get a single snap configuration key."""
-    config = _snapd_conf.get(snap, [key])
-    return config[key]
-
-
 def _cleanup(*keys: str) -> None:
     """Unset test keys to avoid contaminating other tests."""
     _snapd_conf.unset(_SNAP, [_KEY, *keys])
@@ -50,51 +43,51 @@ def _cleanup(*keys: str) -> None:
 def test_set_and_get_bool_true():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: True})
-    assert _get_one(_SNAP, _KEY) is True
+    assert _snapd_conf.get_one(_SNAP, _KEY) is True
     _cleanup()
 
 
 def test_set_and_get_bool_false():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: False})
-    assert _get_one(_SNAP, _KEY) is False
+    assert _snapd_conf.get_one(_SNAP, _KEY) is False
     _cleanup()
 
 
 def test_set_and_get_integer():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 42})
-    assert _get_one(_SNAP, _KEY) == 42
+    assert _snapd_conf.get_one(_SNAP, _KEY) == 42
     _cleanup()
 
 
 def test_set_and_get_float():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 3.14})
-    assert _get_one(_SNAP, _KEY) == 3.14
+    assert _snapd_conf.get_one(_SNAP, _KEY) == 3.14
     _cleanup()
 
 
 def test_set_and_get_string():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'hello'})
-    assert _get_one(_SNAP, _KEY) == 'hello'
+    assert _snapd_conf.get_one(_SNAP, _KEY) == 'hello'
     _cleanup()
 
 
 def test_set_and_get_list():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: [1, 2, 3]})
-    assert _get_one(_SNAP, _KEY) == [1, 2, 3]
+    assert _snapd_conf.get_one(_SNAP, _KEY) == [1, 2, 3]
     _cleanup()
 
 
 def test_set_and_get_dict():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: {'a': 1, 'b': 'two'}})
-    assert _get_one(_SNAP, _KEY) == {'a': 1, 'b': 'two'}
+    assert _snapd_conf.get_one(_SNAP, _KEY) == {'a': 1, 'b': 'two'}
     # Dotted notation reads back a single nested value.
-    assert _get_one(_SNAP, f'{_KEY}.a') == 1
+    assert _snapd_conf.get_one(_SNAP, f'{_KEY}.a') == 1
     _cleanup()
 
 
@@ -228,6 +221,68 @@ def test_get_all_installed_snap_with_no_config_returns_empty_dict():
 
 
 # ---------------------------------------------------------------------------
+# get_one
+#
+# The single-value counterpart of get, used throughout this file to read back what was set.
+# It is get(snap, [key])[key], so it inherits every error get raises; the tests below pin that
+# it unwraps the value rather than changing which request is made or what fails.
+# ---------------------------------------------------------------------------
+
+
+def test_get_one_returns_the_value_not_a_dict():
+    ensure_installed(_SNAP, channel='latest/edge')
+    _snapd_conf.set(_SNAP, {_KEY: 'value'})
+    assert _snapd_conf.get_one(_SNAP, _KEY) == 'value'
+    assert _snapd_conf.get(_SNAP, [_KEY]) == {_KEY: 'value'}
+    _cleanup()
+
+
+def test_get_one_returns_a_subtree_for_a_key_that_names_one():
+    # A key naming a subtree yields the whole nested dict -- get_one unwraps get's result by
+    # one level, it doesn't flatten the value.
+    ensure_installed(_SNAP, channel='latest/edge')
+    _snapd_conf.set(_SNAP, {_KEY: {'nested': {'deep': 1}}})
+    assert _snapd_conf.get_one(_SNAP, _KEY) == {'nested': {'deep': 1}}
+    _cleanup()
+
+
+def test_get_one_dotted_key_returns_the_leaf():
+    ensure_installed(_SNAP, channel='latest/edge')
+    _snapd_conf.set(_SNAP, {_KEY: {'nested': 'value'}})
+    assert _snapd_conf.get_one(_SNAP, f'{_KEY}.nested') == 'value'
+    _cleanup()
+
+
+def test_get_one_missing_key_raises_option_not_found():
+    # Never a KeyError: get raises before there is a dict to subscript.
+    ensure_installed(_SNAP, channel='latest/edge')
+    with pytest.raises(_errors.OptionNotFoundError) as ctx:
+        _snapd_conf.get_one(_SNAP, 'key-that-should-not-exist')
+    assert ctx.value.kind == 'option-not-found'
+
+
+def test_get_one_not_installed_snap_raises_not_found():
+    with pytest.raises(_errors.NotFoundError) as ctx:
+        _snapd_conf.get_one(_ABSENT_SNAP, 'any-key')
+    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value.message == 'snap not installed'
+
+
+@pytest.mark.parametrize('key', ['', ' ', '\t', ',', 'a,b', ' a', 'a\n'])
+def test_get_one_rejects_keys_that_snapd_would_alter(key: str):
+    # The same client-side rejection get applies: a key snapd's 'keys' parsing would alter or
+    # drop is a ValueError rather than a request, which is also what makes the subscript safe.
+    with pytest.raises(ValueError):
+        _snapd_conf.get_one(_SNAP, key)
+
+
+@pytest.mark.parametrize('snap', ['', '.', '..', 'lxd/conf'])
+def test_get_one_invalid_snap_name_raises_value_error(snap: str):
+    with pytest.raises(ValueError):
+        _snapd_conf.get_one(snap, _KEY)
+
+
+# ---------------------------------------------------------------------------
 # get: keys=[] ("give me nothing") vs keys=None ("give me everything")
 # ---------------------------------------------------------------------------
 
@@ -345,7 +400,7 @@ def test_unset_empty_keys_is_noop():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value'})
     _snapd_conf.unset(_SNAP, [])  # Should not raise, and should not touch existing config.
-    assert _get_one(_SNAP, _KEY) == 'value'
+    assert _snapd_conf.get_one(_SNAP, _KEY) == 'value'
     _cleanup()
 
 
@@ -395,7 +450,7 @@ def test_set_empty_dict_is_noop():
     ensure_installed(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'before-empty-set'})
     _snapd_conf.set(_SNAP, {})
-    assert _get_one(_SNAP, _KEY) == 'before-empty-set'
+    assert _snapd_conf.get_one(_SNAP, _KEY) == 'before-empty-set'
     _cleanup()
 
 
@@ -468,7 +523,7 @@ def test_raw_put_unusable_key_rolls_back_the_valid_keys():
     _snapd_conf.set(_SNAP, {_KEY: 'before'})
     with pytest.raises(_errors.ChangeError):
         _client.put(f'/v2/snaps/{_SNAP}/conf', body={'': 'value', _KEY: 'after'})
-    assert _get_one(_SNAP, _KEY) == 'before'
+    assert _snapd_conf.get_one(_SNAP, _KEY) == 'before'
     _cleanup()
 
 

--- a/snap/tests/functional/test_snapd_local.py
+++ b/snap/tests/functional/test_snapd_local.py
@@ -152,7 +152,7 @@ def remove_hello_world():
 def test_install_local(snap_v1: Path):
     ensure_removed('test-snap')
     install_local(snap_v1, dangerous=True)
-    info = _snapd.info('test-snap')
+    info = _snapd.list_one('test-snap')
     assert info.name == 'test-snap'
     assert info.version == '1.0'
 
@@ -162,15 +162,15 @@ def test_install_local_already_installed(snap_v1: Path):
     ensure_removed('test-snap')
     install_local(snap_v1, dangerous=True)
     install_local(snap_v1, dangerous=True)  # Second call must succeed.
-    assert _snapd.info('test-snap').version == '1.0'
+    assert _snapd.list_one('test-snap').version == '1.0'
 
 
 def test_install_local_upgrades(snap_v1: Path, snap_v2: Path):
     ensure_removed('test-snap')
     install_local(snap_v1, dangerous=True)
-    assert _snapd.info('test-snap').version == '1.0'
+    assert _snapd.list_one('test-snap').version == '1.0'
     install_local(snap_v2, dangerous=True)
-    assert _snapd.info('test-snap').version == '2.0'
+    assert _snapd.list_one('test-snap').version == '2.0'
 
 
 def test_install_local_without_dangerous_raises(snap_v1: Path):
@@ -195,7 +195,7 @@ def test_install_local_classic_without_classic_flag_raises(classic_snap_v1: Path
 def test_install_local_classic(classic_snap_v1: Path):
     ensure_removed('test-classic-snap')
     install_local(classic_snap_v1, dangerous=True, classic=True)
-    info = _snapd.info('test-classic-snap')
+    info = _snapd.list_one('test-classic-snap')
     assert info.name == 'test-classic-snap'
     assert info.version == '1.0'
 
@@ -210,7 +210,7 @@ def test_ack_and_install(hello_world_download: tuple[Path, Path]):
     ensure_removed('hello-world')
     ack(assert_file.read_bytes())
     install_local(snap_file)  # dangerous=False — assertions are in the DB.
-    assert _snapd.info('hello-world').name == 'hello-world'
+    assert _snapd.list_one('hello-world').name == 'hello-world'
 
 
 def test_ack_is_idempotent(hello_world_download: tuple[Path, Path]):

--- a/snap/tests/functional/test_snapd_snaps.py
+++ b/snap/tests/functional/test_snapd_snaps.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Functional tests for _snapd_snaps: info, install, remove, refresh, hold, unhold.
+"""Functional tests for _snapd_snaps: list_one, install, remove, refresh, hold, unhold.
 
 Tests are ordered to minimise snap install/remove churn.  All tests that need
 hello-world *installed* run first, then all tests that need it *removed*, then
@@ -28,12 +28,12 @@ _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 # Test helper and possible future candidate for library public API.
 # _list_snaps is an independent oracle (hits /v2/snaps) for the info()/missing-ok tests.
 # list_channels (from conftest) sources store channel/revision info for install/refresh tests.
-def _list_snaps() -> list[_snapd.Info]:
+def _list_snaps() -> list[_snapd.InstalledInfo]:
     """List all installed snaps."""
     info_dicts = _client.get('/v2/snaps')
     assert isinstance(info_dicts, list)
     info_dicts = typing.cast('list[dict[str, str]]', info_dicts)
-    return [_snapd.Info._from_dict(info_dict) for info_dict in info_dicts]
+    return [_snapd.InstalledInfo._from_dict(info_dict) for info_dict in info_dicts]
 
 
 # ---------------------------------------------------------------------------
@@ -41,9 +41,9 @@ def _list_snaps() -> list[_snapd.Info]:
 # ---------------------------------------------------------------------------
 
 
-def test_info_installed():
+def test_list_one_installed():
     ensure_installed('hello-world')
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.name == 'hello-world'
     assert info.tracking
     assert info.revision
@@ -52,9 +52,9 @@ def test_info_installed():
     assert 'hello-world' in {s.name for s in _list_snaps()}
 
 
-def test_info_fields():
+def test_list_one_fields():
     ensure_installed('hello-world')
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.classic is False
     assert info.hold is None
 
@@ -69,7 +69,7 @@ def test_refresh_no_updates_returns_false():
     ensure_installed('hello-world', channel='latest/stable')
     result = retry_on_rate_limit(_snapd.refresh)('hello-world', channel='latest/stable')
     assert result is False
-    assert _snapd.info('hello-world').tracking == 'latest/stable'
+    assert _snapd.list_one('hello-world').tracking == 'latest/stable'
 
 
 def test_refresh_channel():
@@ -77,7 +77,7 @@ def test_refresh_channel():
     # Pre-flight: confirm the target channel exists before refreshing to it.
     assert 'latest/candidate' in list_channels('hello-world')
     retry_on_rate_limit(_snapd.refresh)('hello-world', channel='latest/candidate')
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.tracking == 'latest/candidate'
 
 
@@ -99,7 +99,7 @@ def test_hold_with_duration():
     ensure_installed('hello-world')
     try:
         _snapd.hold('hello-world', duration=datetime.timedelta(days=2))
-        info = _snapd.info('hello-world')
+        info = _snapd.list_one('hello-world')
         assert info.hold is not None
         assert info.hold - datetime.datetime.now().astimezone() > datetime.timedelta(days=1)
     finally:
@@ -110,7 +110,7 @@ def test_hold_forever():
     ensure_installed('hello-world')
     try:
         _snapd.hold('hello-world')
-        info = _snapd.info('hello-world')
+        info = _snapd.list_one('hello-world')
         # When held forever, snapd returns a far-future timestamp.
         assert info.hold is not None
     finally:
@@ -130,9 +130,9 @@ def test_hold_already_held_no_error():
 def test_unhold():
     ensure_installed('hello-world')
     _snapd.hold('hello-world')
-    assert _snapd.info('hello-world').hold is not None
+    assert _snapd.list_one('hello-world').hold is not None
     _snapd.unhold('hello-world')
-    assert _snapd.info('hello-world').hold is None
+    assert _snapd.list_one('hello-world').hold is None
 
 
 def test_remove():
@@ -140,7 +140,7 @@ def test_remove():
     ensure_installed('hello-world')
     _snapd.remove('hello-world')
     with pytest.raises(_errors.NotFoundError):
-        _snapd.info('hello-world')
+        _snapd.list_one('hello-world')
 
 
 # ---------------------------------------------------------------------------
@@ -149,12 +149,12 @@ def test_remove():
 # ---------------------------------------------------------------------------
 
 
-def test_info_missing_raises():
+def test_list_one_missing_raises():
     ensure_removed('hello-world')
     # Independent oracle: the snap really is absent from /v2/snaps.
     assert 'hello-world' not in {s.name for s in _list_snaps()}
     with pytest.raises(_errors.NotFoundError) as ctx:
-        _snapd.info('hello-world')
+        _snapd.list_one('hello-world')
     assert ctx.value.kind == 'snap-not-found'
 
 
@@ -219,7 +219,7 @@ def test_install_revision_not_available_raises():
 def test_install():
     ensure_removed('hello-world')
     retry_on_rate_limit(_snapd.install)('hello-world')
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.name == 'hello-world'
     assert info.tracking == 'latest/stable'
     # The installed revision should match the store's current latest/stable revision.
@@ -231,7 +231,7 @@ def test_install_channel():
     # Pre-flight: confirm the target channel actually exists in the store.
     assert 'latest/candidate' in list_channels('hello-world')
     retry_on_rate_limit(_snapd.install)('hello-world', channel='latest/candidate')
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.tracking == 'latest/candidate'
 
 
@@ -242,7 +242,7 @@ def test_install_revision():
     current = int(list_channels('hello-world')['latest/stable'].revision)
     previous = current - 1
     retry_on_rate_limit(_snapd.install)('hello-world', revision=previous)
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.revision == str(previous)
 
 
@@ -261,7 +261,7 @@ def test_install_needs_classic_raises():
 def test_install_classic():
     ensure_removed('charmcraft')
     retry_on_rate_limit(_snapd.install)('charmcraft', classic=True)
-    info = _snapd.info('charmcraft')
+    info = _snapd.list_one('charmcraft')
     assert info.classic is True
 
 
@@ -282,7 +282,7 @@ def test_install_channel_and_revision():
     ensure_removed('hello-world')
     edge = list_channels('hello-world')['latest/edge'].revision
     retry_on_rate_limit(_snapd.install)('hello-world', channel='latest/edge', revision=edge)
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.revision == edge
     assert info.tracking == 'latest/edge'
 
@@ -304,7 +304,7 @@ def test_refresh_channel_and_revision():
     ensure_installed('hello-world', channel='latest/stable')
     edge = list_channels('hello-world')['latest/edge'].revision
     retry_on_rate_limit(_snapd.refresh)('hello-world', channel='latest/edge', revision=edge)
-    info = _snapd.info('hello-world')
+    info = _snapd.list_one('hello-world')
     assert info.revision == edge
     assert info.tracking == 'latest/edge'
 
@@ -313,6 +313,6 @@ def test_refresh_revision_already_installed_still_refreshes():
     # Snapd runs a full refresh when a revision is specified, even if that revision is already
     # installed, so refresh reports that it did something. ensure() relies on knowing this.
     ensure_installed('hello-world')
-    current = _snapd.info('hello-world').revision
+    current = _snapd.list_one('hello-world').revision
     result = retry_on_rate_limit(_snapd.refresh)('hello-world', revision=current)
     assert result is True

--- a/snap/tests/functional/test_snapd_snaps.py
+++ b/snap/tests/functional/test_snapd_snaps.py
@@ -12,28 +12,22 @@ tests that inherently install/remove as part of the test logic.
 from __future__ import annotations
 
 import datetime
-import typing
+from typing import cast
 
 import pytest
 
 from charmlibs.snap import _client, _errors
 from charmlibs.snap import _snapd_snaps as _snapd
-from conftest import ensure_installed, ensure_removed, list_channels, retry_on_rate_limit
+from conftest import _list, ensure_installed, ensure_removed, list_channels, retry_on_rate_limit
 
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
 _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
 
-# Test helper and possible future candidate for library public API.
-# _list_snaps is an independent oracle (hits /v2/snaps) for the info()/missing-ok tests.
-# list_channels (from conftest) sources store channel/revision info for install/refresh tests.
-def _list_snaps() -> list[_snapd.InstalledInfo]:
-    """List all installed snaps."""
-    info_dicts = _client.get('/v2/snaps')
-    assert isinstance(info_dicts, list)
-    info_dicts = typing.cast('list[dict[str, str]]', info_dicts)
-    return [_snapd.InstalledInfo._from_dict(info_dict) for info_dict in info_dicts]
+# _list (from conftest) is an independent oracle (hits /v2/snaps) for the list_one and
+# missing-ok tests. list_channels (also conftest) sources store channel/revision info for the
+# install and refresh tests.
 
 
 # ---------------------------------------------------------------------------
@@ -48,8 +42,9 @@ def test_list_one_installed():
     assert info.tracking
     assert info.revision
     assert info.version
-    # Independent oracle: /v2/snaps (list) should agree with /v2/snaps/{snap} (info).
-    assert 'hello-world' in {s.name for s in _list_snaps()}
+    # Independent oracle: the /v2/snaps collection should agree with the /v2/snaps/{snap} that
+    # list_one reads.
+    assert 'hello-world' in {s.name for s in _list(None)}
 
 
 def test_list_one_fields():
@@ -152,7 +147,7 @@ def test_remove():
 def test_list_one_missing_raises():
     ensure_removed('hello-world')
     # Independent oracle: the snap really is absent from /v2/snaps.
-    assert 'hello-world' not in {s.name for s in _list_snaps()}
+    assert 'hello-world' not in {s.name for s in _list(None)}
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd.list_one('hello-world')
     assert ctx.value.kind == 'snap-not-found'
@@ -183,7 +178,7 @@ def test_refresh_not_installed_raises_base_snap_error():
 
 
 def test_hold_not_installed_raises_snap_not_found_error():
-    # hold() calls info() first, which raises NotFoundError with a proper kind.
+    # hold() calls list_one() first, which raises NotFoundError with a proper kind.
     ensure_removed('hello-world')
     with pytest.raises(_errors.NotFoundError) as ctx:
         _snapd.hold('hello-world')
@@ -316,3 +311,80 @@ def test_refresh_revision_already_installed_still_refreshes():
     current = _snapd.list_one('hello-world').revision
     result = retry_on_rate_limit(_snapd.refresh)('hello-world', revision=current)
     assert result is True
+
+
+# ---------------------------------------------------------------------------
+# /v2/snaps as a collection — what `snap list` does that the library doesn't
+#
+# list_one is per-snap and reports only the current revision. The endpoint can do more: name
+# several snaps in one request, and (with select=all) report every revision installed. Both are
+# exercised through the _list test helper rather than library API, and the tests below pin the
+# snapd behaviour that keeps them out of it.
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_retains_the_previous_revision():
+    # A refresh doesn't discard the revision it replaced: snapd keeps it installed but inactive.
+    # So `snap list --all` reports the snap twice and names are no longer unique -- which is why
+    # `all` would change the shape of any plural result, and stays a test-only concern here.
+    ensure_removed('hello-world')
+    current = str(list_channels('hello-world')['latest/stable'].revision)
+    previous = str(int(current) - 1)
+    retry_on_rate_limit(_snapd.install)('hello-world', revision=previous)
+    retry_on_rate_limit(_snapd.refresh)('hello-world', revision=current)
+    # The current revision is all that list_one and an unqualified list report.
+    assert _snapd.list_one('hello-world').revision == current
+    assert [i.revision for i in _list('hello-world')] == [current]
+    # The replaced revision is still installed, and only all=True reveals it.
+    assert sorted(i.revision for i in _list('hello-world', all=True)) == sorted([
+        previous,
+        current,
+    ])
+
+
+def test_list_several_snaps_in_one_request():
+    ensure_installed('hello-world')
+    ensure_installed('charmcraft', classic=True)
+    listed = {i.name: i for i in _list(['hello-world', 'charmcraft'])}
+    assert set(listed) == {'hello-world', 'charmcraft'}
+    # The collection agrees with the per-snap endpoint list_one reads.
+    for name, info in listed.items():
+        assert info.revision == _snapd.list_one(name).revision
+
+
+def test_list_bare_name_and_single_element_list_agree():
+    ensure_installed('hello-world')
+    assert [i.name for i in _list('hello-world')] == [i.name for i in _list(['hello-world'])]
+
+
+def test_list_absent_snap_is_filtered_rather_than_an_error():
+    # snapd filters instead of failing, so an absent name is simply missing from the result with
+    # nothing to distinguish it from one that was never asked for. A plural API would have to
+    # reconstruct the error client-side; list_one gets snapd's own, which is the shape we keep.
+    ensure_installed('hello-world')
+    assert [i.name for i in _list(['hello-world', _ABSENT_SNAP])] == ['hello-world']
+    assert _list(_ABSENT_SNAP) == []
+    with pytest.raises(_errors.NotFoundError):
+        _snapd.list_one(_ABSENT_SNAP)
+
+
+def test_list_no_names_lists_nothing_but_none_lists_everything():
+    ensure_installed('hello-world')
+    assert _list([]) == []
+    assert _list(None) != []
+
+
+def test_raw_api_empty_snaps_value_lists_everything():
+    # The trap the helper avoids by making no request at all: snapd drops empty entries when it
+    # parses 'snaps', so an empty value leaves the unfiltered query and answers with every
+    # installed snap. Passing one through would turn a request for no snaps into a request for
+    # all of them -- the same quirk the conf 'keys' and logs 'names' parameters have.
+    #
+    # Compared by name: snapd does not return these in a stable order.
+    ensure_installed('hello-world')
+    everything = {i.name for i in _list(None)}
+    assert everything
+    result = _client.get('/v2/snaps', query={'snaps': ''})
+    assert isinstance(result, list)
+    unfiltered = cast('list[dict[str, str]]', result)
+    assert {s['name'] for s in unfiltered} == everything

--- a/snap/tests/unit/test_empty_or_blank.py
+++ b/snap/tests/unit/test_empty_or_blank.py
@@ -33,7 +33,7 @@ _CALLS: dict[str, Callable[[str], object]] = {
     'get': lambda v: snap.get(v),
     'get (key)': lambda v: snap.get('lxd', [v]),
     'hold': lambda v: snap.hold(v),
-    'info': lambda v: snap.info(v),
+    'list_one': lambda v: snap.list_one(v),
     'install': lambda v: snap.install(v),
     'logs': lambda v: snap.logs(v),
     'refresh': lambda v: snap.refresh(v),
@@ -154,7 +154,7 @@ _MAX_FRAMES = 3
 
 # ensure is a composition of the other public functions rather than a call to an endpoint of its
 # own, and doesn't check the snap name itself: whichever function it reaches first does it. That
-# leaves the deepest traceback in the library -- ensure, its _get_info probe, info,
+# leaves the deepest traceback in the library -- ensure, its _installed_info probe, list_one,
 # snap_path_segment and the check -- which is the price of not duplicating the check in a layer
 # that doesn't own it.
 _COMPOSITE_FUNCTIONS = {'ensure'}

--- a/snap/tests/unit/test_empty_or_blank.py
+++ b/snap/tests/unit/test_empty_or_blank.py
@@ -32,6 +32,8 @@ _CALLS: dict[str, Callable[[str], object]] = {
     'ensure': lambda v: snap.ensure(v),
     'get': lambda v: snap.get(v),
     'get (key)': lambda v: snap.get('lxd', [v]),
+    'get_one': lambda v: snap.get_one(v, 'mykey'),
+    'get_one (key)': lambda v: snap.get_one('lxd', v),
     'hold': lambda v: snap.hold(v),
     'list_one': lambda v: snap.list_one(v),
     'install': lambda v: snap.install(v),
@@ -152,12 +154,15 @@ def test_error_is_raised_one_frame_below_the_function_the_caller_called():
 # it returns the encoded name and so has to call the check itself.
 _MAX_FRAMES = 3
 
-# ensure is a composition of the other public functions rather than a call to an endpoint of its
-# own, and doesn't check the snap name itself: whichever function it reaches first does it. That
-# leaves the deepest traceback in the library -- ensure, its _installed_info probe, list_one,
-# snap_path_segment and the check -- which is the price of not duplicating the check in a layer
-# that doesn't own it.
-_COMPOSITE_FUNCTIONS = {'ensure'}
+# Some public functions are compositions of other public functions rather than calls to an
+# endpoint of their own, and don't check their arguments themselves: whichever function they
+# reach first does it. That puts the check one or more frames deeper than the rule above
+# allows, which is the price of not duplicating the check in a layer that doesn't own it.
+#
+# ensure leaves the deepest traceback in the library -- ensure, its _installed_info probe,
+# list_one, snap_path_segment and the check. get_one delegates to get, which validates both
+# the snap name and the key before making a request.
+_COMPOSITE_FUNCTIONS = {'ensure', 'get_one'}
 
 
 @pytest.mark.parametrize('name', sorted(_CALLS) + sorted(_BLANK_ONLY_CALLS))

--- a/snap/tests/unit/test_functions.py
+++ b/snap/tests/unit/test_functions.py
@@ -18,8 +18,8 @@ def make_info(
     revision: int | str = 29,
     classic: bool = False,
     hold: str | None = None,
-) -> _snapd.Info:
-    return _snapd.Info(
+) -> _snapd.InstalledInfo:
+    return _snapd.InstalledInfo(
         name='hello-world',
         tracking=tracking,
         revision=revision,
@@ -31,15 +31,15 @@ def make_info(
 
 @dataclass
 class MockSnapd:
-    info: MagicMock
+    list_one: MagicMock
     install: MagicMock
     refresh: MagicMock
 
 
 @pytest.fixture
 def mock_snapd(monkeypatch: pytest.MonkeyPatch) -> MockSnapd:
-    mocks = MockSnapd(info=MagicMock(), install=MagicMock(), refresh=MagicMock())
-    monkeypatch.setattr(_snapd, 'info', mocks.info)
+    mocks = MockSnapd(list_one=MagicMock(), install=MagicMock(), refresh=MagicMock())
+    monkeypatch.setattr(_snapd, 'list_one', mocks.list_one)
     monkeypatch.setattr(_snapd, 'install', mocks.install)
     monkeypatch.setattr(_snapd, 'refresh', mocks.refresh)
     return mocks
@@ -48,26 +48,26 @@ def mock_snapd(monkeypatch: pytest.MonkeyPatch) -> MockSnapd:
 class TestGetInfo:
     def test_installed(self, mock_snapd: MockSnapd):
         expected = make_info()
-        mock_snapd.info.return_value = expected
-        result = _functions._get_info('hello-world')
-        mock_snapd.info.assert_called_once_with('hello-world')
+        mock_snapd.list_one.return_value = expected
+        result = _functions._installed_info('hello-world')
+        mock_snapd.list_one.assert_called_once_with('hello-world')
         assert result is expected
 
     def test_not_installed_returns_none(self, mock_snapd: MockSnapd):
-        mock_snapd.info.side_effect = NotFoundError(
+        mock_snapd.list_one.side_effect = NotFoundError(
             'snap "hello-world" is not installed',
             kind='snap-not-found',
             value='',
             status_code=404,
             status='Not Found',
         )
-        result = _functions._get_info('hello-world')
+        result = _functions._installed_info('hello-world')
         assert result is None
 
 
 class TestEnsureInstalls:
     def test_not_installed(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = None
+        mock_snapd.list_one.return_value = None
         result = _functions.ensure('hello-world')
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel=None, revision=None, classic=False
@@ -75,14 +75,14 @@ class TestEnsureInstalls:
         assert result is True
 
     def test_not_installed_channel(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = None
+        mock_snapd.list_one.return_value = None
         _functions.ensure('hello-world', channel='edge')
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel='edge', revision=None, classic=False
         )
 
     def test_not_installed_revision(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = None
+        mock_snapd.list_one.return_value = None
         result = _functions.ensure('hello-world', revision=5)
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel=None, revision=5, classic=False
@@ -90,14 +90,14 @@ class TestEnsureInstalls:
         assert result is True
 
     def test_not_installed_channel_and_revision(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = None
+        mock_snapd.list_one.return_value = None
         _functions.ensure('hello-world', channel='edge', revision=5)
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel='edge', revision=5, classic=False
         )
 
     def test_not_installed_classic(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = None
+        mock_snapd.list_one.return_value = None
         _functions.ensure('hello-world', classic=True)
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel=None, revision=None, classic=True
@@ -106,7 +106,7 @@ class TestEnsureInstalls:
 
 class TestEnsureChannel:
     def test_installed_different_channel(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(tracking='latest/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         result = _functions.ensure('hello-world', channel='edge')
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel='edge', revision=None, classic=False
@@ -114,7 +114,7 @@ class TestEnsureChannel:
         assert result is True
 
     def test_installed_same_channel_update_true(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(tracking='latest/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         mock_snapd.refresh.return_value = True
         result = _functions.ensure('hello-world', channel='latest/stable')
         mock_snapd.refresh.assert_called_once_with(
@@ -123,19 +123,19 @@ class TestEnsureChannel:
         assert result is True
 
     def test_installed_same_channel_update_false(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(tracking='latest/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         result = _functions.ensure('hello-world', channel='latest/stable', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     def test_installed_no_channel_update_false(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info()
+        mock_snapd.list_one.return_value = make_info()
         result = _functions.ensure('hello-world', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     def test_installed_normalized_channel(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(tracking='latest/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         result = _functions.ensure('hello-world', channel='stable', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
@@ -143,13 +143,13 @@ class TestEnsureChannel:
     def test_risk_only_channel_inherits_track(self, mock_snapd: MockSnapd):
         # 'edge' resolves to '3.6/edge' for a snap on the 3.6 track, not to 'latest/edge',
         # so a snap already on '3.6/edge' is left alone rather than refreshed every call.
-        mock_snapd.info.return_value = make_info(tracking='3.6/edge')
+        mock_snapd.list_one.return_value = make_info(tracking='3.6/edge')
         result = _functions.ensure('hello-world', channel='edge', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     def test_risk_only_channel_inherits_track_when_different(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(tracking='3.6/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='3.6/stable')
         result = _functions.ensure('hello-world', channel='edge')
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel='edge', revision=None, classic=False
@@ -157,7 +157,7 @@ class TestEnsureChannel:
         assert result is True
 
     def test_no_updates_available_returns_false(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(tracking='latest/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         mock_snapd.refresh.return_value = False
         result = _functions.ensure('hello-world', channel='latest/stable')
         assert result is False
@@ -165,7 +165,7 @@ class TestEnsureChannel:
     def test_empty_channel_treated_as_none(self, mock_snapd: MockSnapd):
         # channel='' is falsy, so it's treated the same as channel=None:
         # no channel-mismatch refresh, and with update=False no refresh at all.
-        mock_snapd.info.return_value = make_info(tracking='latest/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         result = _functions.ensure('hello-world', channel='', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
@@ -173,20 +173,20 @@ class TestEnsureChannel:
 
 class TestEnsureRevision:
     def test_installed_same_revision(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(revision=5)
+        mock_snapd.list_one.return_value = make_info(revision=5)
         result = _functions.ensure('hello-world', revision=5)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     @pytest.mark.parametrize('revision', [5, '5'])
     def test_revision_may_be_int_or_str(self, mock_snapd: MockSnapd, revision: int | str):
-        mock_snapd.info.return_value = make_info(revision=5)
+        mock_snapd.list_one.return_value = make_info(revision=5)
         result = _functions.ensure('hello-world', revision=revision)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     def test_installed_different_revision(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(revision=5)
+        mock_snapd.list_one.return_value = make_info(revision=5)
         result = _functions.ensure('hello-world', revision=6)
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel=None, revision=6, classic=False
@@ -196,7 +196,7 @@ class TestEnsureRevision:
     def test_same_revision_different_channel_refreshes(self, mock_snapd: MockSnapd):
         # The revision is already installed, but the snap tracks the wrong channel, so it
         # still needs a refresh -- snapd moves the tracking channel without changing revision.
-        mock_snapd.info.return_value = make_info(tracking='latest/stable', revision=5)
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable', revision=5)
         result = _functions.ensure('hello-world', channel='edge', revision=5)
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel='edge', revision=5, classic=False
@@ -206,7 +206,7 @@ class TestEnsureRevision:
     @pytest.mark.parametrize('update', [True, False])
     def test_update_ignored_when_revision_matches(self, mock_snapd: MockSnapd, update: bool):
         # A revision fully specifies what to install, so there's nothing to update to.
-        mock_snapd.info.return_value = make_info(tracking='latest/stable', revision=5)
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable', revision=5)
         result = _functions.ensure('hello-world', channel='stable', revision=5, update=update)
         mock_snapd.refresh.assert_not_called()
         assert result is False
@@ -214,11 +214,11 @@ class TestEnsureRevision:
 
 class TestEnsureClassic:
     def test_classic_passed_to_refresh(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(tracking='latest/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         _functions.ensure('hello-world', channel='edge', classic=True)
         assert mock_snapd.refresh.call_args.kwargs['classic'] is True
 
     def test_classic_passed_to_update_refresh(self, mock_snapd: MockSnapd):
-        mock_snapd.info.return_value = make_info(tracking='latest/stable')
+        mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         _functions.ensure('hello-world', channel='latest/stable', classic=True)
         assert mock_snapd.refresh.call_args.kwargs['classic'] is True

--- a/snap/tests/unit/test_snapd_conf.py
+++ b/snap/tests/unit/test_snapd_conf.py
@@ -220,6 +220,75 @@ class TestGetAbsentSnapProbe:
         mock_client.get.assert_called_once()
 
 
+class TestGetOne:
+    # get_one is get(snap, [key])[key], so its job is to make exactly the request get would and
+    # unwrap the result by one level. Everything else -- validation, the absent-snap probe, the
+    # errors -- is get's, and is covered above.
+    def test_get_one_returns_the_value(self, mock_client: MockClient):
+        mock_client.get.return_value = {'integer': 1}
+        assert _snapd_conf.get_one('lxd', 'integer') == 1
+
+    def test_get_one_makes_the_same_request_as_get(self, mock_client: MockClient):
+        mock_client.get.return_value = {'integer': 1}
+        _snapd_conf.get_one('lxd', 'integer')
+        mock_client.get.assert_called_once_with('/v2/snaps/lxd/conf', query={'keys': 'integer'})
+
+    def test_get_one_unwraps_by_one_level_only(self, mock_client: MockClient):
+        # A key naming a subtree keeps its structure; only the outer dict get built is removed.
+        mock_client.get.return_value = {'server': {'port': 8080}}
+        assert _snapd_conf.get_one('lxd', 'server') == {'port': 8080}
+
+    def test_get_one_dotted_key(self, mock_client: MockClient):
+        mock_client.get.return_value = {'server.port': 8080}
+        assert _snapd_conf.get_one('lxd', 'server.port') == 8080
+        assert mock_client.get.call_args.kwargs['query'] == {'keys': 'server.port'}
+
+    def test_get_one_option_not_found_propagates(self, mock_client: MockClient):
+        # The key is missing, so get raises before there is a dict to subscript: an
+        # OptionNotFoundError reaches the caller, never a KeyError.
+        mock_client.get.side_effect = OptionNotFoundError(
+            'snap "lxd" has no "mykey" configuration option',
+            kind='option-not-found',
+            value={'SnapName': 'lxd', 'Key': 'mykey'},
+        )
+        with pytest.raises(OptionNotFoundError):
+            _snapd_conf.get_one('lxd', 'mykey')
+
+    def test_get_one_not_installed_propagates(self, mock_client: MockClient):
+        mock_client.get.side_effect = NotFoundError(
+            'snap not installed', kind='snap-not-found', value='lxd'
+        )
+        with pytest.raises(NotFoundError):
+            _snapd_conf.get_one('lxd', 'mykey')
+
+    @pytest.mark.parametrize(
+        ('key', 'match'),
+        [
+            ('', 'must not be empty'),
+            (' ', 'must not be blank'),
+            (',', 'must not contain a comma'),
+            ('a,b', 'must not contain a comma'),
+            (' a', 'must not have leading or trailing whitespace'),
+        ],
+    )
+    def test_get_one_rejects_unusable_keys_without_request(
+        self, mock_client: MockClient, key: str, match: str
+    ):
+        # get's rejection of keys its query parameter would alter is what guarantees the result
+        # is keyed by exactly the key requested, and so that the subscript can't raise KeyError.
+        with pytest.raises(ValueError, match=match):
+            _snapd_conf.get_one('lxd', key)
+        mock_client.get.assert_not_called()
+
+    @pytest.mark.parametrize('snap', ['', '.', '..', 'hello-world/conf'])
+    def test_get_one_invalid_name_raises_value_error_without_request(
+        self, mock_client: MockClient, snap: str
+    ):
+        with pytest.raises(ValueError):
+            _snapd_conf.get_one(snap, 'mykey')
+        mock_client.get.assert_not_called()
+
+
 class TestSet:
     def test_set(self, mock_client: MockClient):
         _snapd_conf.set('lxd', {'mykey': 'myval'})

--- a/snap/tests/unit/test_snapd_snaps.py
+++ b/snap/tests/unit/test_snapd_snaps.py
@@ -45,9 +45,9 @@ _MINIMAL_INFO_DICT: dict[str, Any] = {
 }
 
 
-class TestInfoFromDict:
+class TestInstalledInfoFromDict:
     def test_basic_fields(self):
-        info = _snapd.Info._from_dict(_MINIMAL_INFO_DICT)
+        info = _snapd.InstalledInfo._from_dict(_MINIMAL_INFO_DICT)
         assert info.name == 'hello-world'
         assert info.version == '6.4'
         assert info.tracking == 'latest/stable'
@@ -56,14 +56,14 @@ class TestInfoFromDict:
         assert info.hold is None
 
     def test_local_revision(self):
-        info = _snapd.Info._from_dict({**_MINIMAL_INFO_DICT, 'revision': 'x1'})
+        info = _snapd.InstalledInfo._from_dict({**_MINIMAL_INFO_DICT, 'revision': 'x1'})
         assert info.revision == 'x1'
 
     def test_tracking_is_not_the_revision_source_channel(self):
         # 'channel' is the channel the installed revision came from, which can differ from the
         # channel the snap tracks -- installing a revision without a channel tracks
         # latest/stable but sources the revision from wherever it's available.
-        info = _snapd.Info._from_dict({
+        info = _snapd.InstalledInfo._from_dict({
             **_MINIMAL_INFO_DICT,
             'channel': 'edge',
             'tracking-channel': 'latest/stable',
@@ -73,20 +73,20 @@ class TestInfoFromDict:
     def test_tracking_empty_when_field_absent(self):
         # A snap installed from a local file tracks no channel: snapd omits the field entirely.
         info_dict = {k: v for k, v in _MINIMAL_INFO_DICT.items() if k != 'tracking-channel'}
-        info = _snapd.Info._from_dict({**info_dict, 'channel': ''})
+        info = _snapd.InstalledInfo._from_dict({**info_dict, 'channel': ''})
         assert info.tracking == ''
 
     @pytest.mark.parametrize('confinement', ['strict', 'devmode'])
     def test_non_classic_confinement(self, confinement: str):
-        info = _snapd.Info._from_dict({**_MINIMAL_INFO_DICT, 'confinement': confinement})
+        info = _snapd.InstalledInfo._from_dict({**_MINIMAL_INFO_DICT, 'confinement': confinement})
         assert info.classic is False
 
     def test_classic_confinement(self):
-        info = _snapd.Info._from_dict({**_MINIMAL_INFO_DICT, 'confinement': 'classic'})
+        info = _snapd.InstalledInfo._from_dict({**_MINIMAL_INFO_DICT, 'confinement': 'classic'})
         assert info.classic is True
 
     def test_hold_present(self):
-        info = _snapd.Info._from_dict(result_of('snap_info_hello_world_held.json'))
+        info = _snapd.InstalledInfo._from_dict(result_of('snap_info_hello_world_held.json'))
         assert info.hold is not None
         assert info.hold.year == 2318
 
@@ -99,34 +99,34 @@ class TestInfoFromDict:
             'enabled': True,
             'status': 'active',
         }
-        info = _snapd.Info._from_dict(info_dict)
+        info = _snapd.InstalledInfo._from_dict(info_dict)
         assert info.name == 'hello-world'
 
 
-class TestInfo:
-    def test_info_installed(self, mock_client: MockClient):
+class TestListOne:
+    def test_list_one_installed(self, mock_client: MockClient):
         mock_client.get.return_value = result_of('snap_info_hello_world.json')
-        info = _snapd.info('hello-world')
+        info = _snapd.list_one('hello-world')
         assert info.name == 'hello-world'
         assert info.revision == '29'
         mock_client.get.assert_called_once_with('/v2/snaps/hello-world')
 
-    def test_info_classic(self, mock_client: MockClient):
+    def test_list_one_classic(self, mock_client: MockClient):
         mock_client.get.return_value = result_of('snap_info_kube_proxy.json')
-        info = _snapd.info('kube-proxy')
+        info = _snapd.list_one('kube-proxy')
         assert info.classic is True
 
-    def test_info_with_hold(self, mock_client: MockClient):
+    def test_list_one_with_hold(self, mock_client: MockClient):
         mock_client.get.return_value = result_of('snap_info_hello_world_held.json')
-        info = _snapd.info('hello-world')
+        info = _snapd.list_one('hello-world')
         assert info.hold is not None
 
-    def test_info_missing_raises(self, mock_client: MockClient):
+    def test_list_one_missing_raises(self, mock_client: MockClient):
         mock_client.get.side_effect = _make_snap_not_found()
         with pytest.raises(NotFoundError):
-            _snapd.info('hello-world')
+            _snapd.list_one('hello-world')
 
-    def test_info_other_error_propagates(self, mock_client: MockClient):
+    def test_list_one_other_error_propagates(self, mock_client: MockClient):
         mock_client.get.side_effect = Error(
             'internal error',
             kind='internal-error',
@@ -135,7 +135,7 @@ class TestInfo:
             status='Internal Server Error',
         )
         with pytest.raises(Error):
-            _snapd.info('hello-world')
+            _snapd.list_one('hello-world')
 
 
 class TestInstall:
@@ -238,7 +238,7 @@ class TestRefresh:
 class TestHold:
     @pytest.fixture(autouse=True)
     def mock_info(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setattr(_snapd, 'info', MagicMock())
+        monkeypatch.setattr(_snapd, 'list_one', MagicMock())
 
     def test_hold_forever_by_default(self, mock_client: MockClient):
         _snapd.hold('hello-world')
@@ -260,7 +260,7 @@ class TestHold:
 
     def test_hold_not_installed(self, mock_client: MockClient, monkeypatch: pytest.MonkeyPatch):
         snap_not_found = NotFoundError('', kind='snap-not-found', value='')
-        monkeypatch.setattr(_snapd, 'info', MagicMock(side_effect=snap_not_found))
+        monkeypatch.setattr(_snapd, 'list_one', MagicMock(side_effect=snap_not_found))
         with pytest.raises(NotFoundError):
             _snapd.hold('hello-world')
         mock_client.post.assert_not_called()
@@ -274,7 +274,7 @@ class TestUnhold:
         )
 
 
-_PATH_FUNCTIONS = [_snapd.info, _snapd.install, _snapd.remove, _snapd.refresh, _snapd.unhold]
+_PATH_FUNCTIONS = [_snapd.list_one, _snapd.install, _snapd.remove, _snapd.refresh, _snapd.unhold]
 
 
 class TestSnapNameInPath:
@@ -295,12 +295,12 @@ class TestSnapNameInPath:
     def test_hold_invalid_name_raises_value_error_without_request(
         self, mock_client: MockClient, monkeypatch: pytest.MonkeyPatch, snap: str
     ):
-        # hold() probes info() before posting; the name is validated before either request.
-        info = MagicMock()
-        monkeypatch.setattr(_snapd, 'info', info)
+        # hold() probes list_one() before posting; the name is validated before either request.
+        list_one = MagicMock()
+        monkeypatch.setattr(_snapd, 'list_one', list_one)
         with pytest.raises(ValueError):
             _snapd.hold(snap)
-        info.assert_not_called()
+        list_one.assert_not_called()
         mock_client.post.assert_not_called()
 
     def test_install_validates_name_before_building_body(self, mock_client: MockClient):
@@ -309,5 +309,5 @@ class TestSnapNameInPath:
 
     def test_name_is_percent_encoded(self, mock_client: MockClient):
         mock_client.get.return_value = {**_MINIMAL_INFO_DICT, 'name': 'hello world'}
-        _snapd.info('hello world')
+        _snapd.list_one('hello world')
         mock_client.get.assert_called_once_with('/v2/snaps/hello%20world')


### PR DESCRIPTION
This PR's primary purpose is to rename `snap.info` to `snap.list_one`, reflecting the CLI semantics that we're following -- `snap.list_one(mysnap)` queries local information about an installed snap (erroring if it's not installed), like `snap list mysnap`. It shouldn't be named `snap.info`, as `snap info` queries the snap store about available snaps instead. This PR doesn't add `snap.list`, as charms likely don't need to query arbitrary lists of snaps. This defers adding support for `snap list --all`, which includes information about inactive snap revisions that are on the system.

To further reduce ambiguity, the `snap.Info` class is renamed to `snap.InstalledInfo`. If we ever added `snap.info` to query the store, it could return a `snap.StoreInfo`, which would have a different structure (e.g. no `tracked` channel, instead a list of available channels). This continues to keep `snap.Snap` free if we add an object-oriented API in future.

Accompanying `list_one`, this PR adds the long-discussed `get_one` accompaniment to `get`. There aren't any other functions in the library that should have a `*._one` version.