### PR TITLE
test(snap): drop heavy snaps from functional tests

### DIFF
--- a/snap/tests/functional/conftest.py
+++ b/snap/tests/functional/conftest.py
@@ -7,10 +7,13 @@
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import random
 import time
 import typing
+import uuid
+from pathlib import Path
 from typing import Any
 
 from charmlibs import snap
@@ -23,6 +26,22 @@ if typing.TYPE_CHECKING:
 
     _P = ParamSpec('_P')
     _T = TypeVar('_T')
+
+# Snaps built from source by setup.sh before the suite runs. Tests prefer these to store snaps
+# wherever they need some capability of a snap rather than a particular snap, so that the suite
+# neither downloads hundreds of megabytes nor depends on a real-world snap keeping its shape.
+SNAPS_DIR = Path(__file__).parent / 'snaps'
+
+# Snaps used by the suite that declare no base of their own, and so are held by the core snap.
+# snapd refuses to remove core while any of them is installed ("snap is being used by snaps ..."),
+# so the tests that remove core must remove these first. Listed here because the snaps are
+# installed by one module and removed by another; a snap that declares a base doesn't belong.
+BASE_LESS_SNAPS = (
+    'hello-world',
+    'test-snap',
+    'test-snapd-classic-confinement',
+    'test-snapd-with-configure',
+)
 
 # Enable debug logging from snap library during tests.
 handler = logging.StreamHandler()
@@ -74,6 +93,80 @@ def ensure_removed(*snaps: str) -> None:
 def ensure_installed(*snaps: str, channel: str | None = None, classic: bool = False) -> None:
     for snap_name in snaps:
         retry_on_rate_limit(snap.ensure)(snap_name, channel=channel, classic=classic, update=False)
+
+
+# ---------------------------------------------------------------------------
+# Provisional ack and install_local implementations
+#
+# Built directly on _client internals: sideloading and assertion upload are not yet part of the
+# library's public API. Kept here rather than in a test module because several modules install
+# locally-built snaps.
+# ---------------------------------------------------------------------------
+
+
+def ack(assertions_data: bytes) -> None:
+    """Upload assertion(s) to snapd's local database (POST /v2/assertions)."""
+    response = _client._request('POST', '/v2/assertions', data=assertions_data)
+    response_dict = json.loads(response.read())
+    if response_dict.get('type') == 'error':
+        raise _client._make_error(response_dict)
+
+
+def install_local(path: Path, *, dangerous: bool = False, classic: bool = False) -> None:
+    """Install a local snap file via the snapd sideload API (POST /v2/snaps)."""
+    boundary = uuid.uuid4().hex
+    crlf = b'\r\n'
+
+    def form_field(name: str, value: str) -> bytes:
+        return b''.join([
+            b'--',
+            boundary.encode(),
+            crlf,
+            b'Content-Disposition: form-data; name="',
+            name.encode(),
+            b'"',
+            crlf,
+            crlf,
+            value.encode(),
+            crlf,
+        ])
+
+    body = [
+        b'--',
+        boundary.encode(),
+        crlf,
+        b'Content-Disposition: form-data; name="snap"; filename="',
+        path.name.encode(),
+        b'"',
+        crlf,
+        b'Content-Type: application/octet-stream',
+        crlf,
+        crlf,
+        path.read_bytes(),
+        crlf,
+    ]
+    if dangerous:
+        body.append(form_field('dangerous', 'true'))
+    if classic:
+        body.append(form_field('classic', 'true'))
+    body.extend([b'--', boundary.encode(), b'--', crlf])
+
+    headers = {
+        'Accept': 'application/json',
+        'Content-Type': f'multipart/form-data; boundary={boundary}',
+    }
+    response = _client._request('POST', '/v2/snaps', headers=headers, data=b''.join(body))
+    response_dict = json.loads(response.read())
+    if response_dict.get('type') == 'error':
+        raise _client._make_error(response_dict)
+    _client._Change(response_dict['change']).wait()
+
+
+def ensure_installed_local(name: str, *, version: str = '1.0', classic: bool = False) -> None:
+    """Ensure a snap built from ``SNAPS_DIR`` is installed, sideloading it if it is absent."""
+    if _functions._get_info(name) is not None:
+        return
+    install_local(SNAPS_DIR / f'{name}_{version}.snap', dangerous=True, classic=classic)
 
 
 @functools.cache  # Cached to avoid repeated store queries.

--- a/snap/tests/functional/conftest.py
+++ b/snap/tests/functional/conftest.py
@@ -32,16 +32,8 @@ if typing.TYPE_CHECKING:
 # neither downloads hundreds of megabytes nor depends on a real-world snap keeping its shape.
 SNAPS_DIR = Path(__file__).parent / 'snaps'
 
-# Snaps used by the suite that declare no base of their own, and so are held by the core snap.
-# snapd refuses to remove core while any of them is installed ("snap is being used by snaps ..."),
-# so the tests that remove core must remove these first. Listed here because the snaps are
-# installed by one module and removed by another; a snap that declares a base doesn't belong.
-BASE_LESS_SNAPS = (
-    'hello-world',
-    'test-snap',
-    'test-snapd-classic-confinement',
-    'test-snapd-with-configure',
-)
+# Snap types that are not held by the core snap even though they declare no base themselves.
+_BASE_LIKE_TYPES = frozenset({'base', 'os', 'snapd'})
 
 # Enable debug logging from snap library during tests.
 handler = logging.StreamHandler()
@@ -93,6 +85,33 @@ def ensure_removed(*snaps: str) -> None:
 def ensure_installed(*snaps: str, channel: str | None = None, classic: bool = False) -> None:
     for snap_name in snaps:
         retry_on_rate_limit(snap.ensure)(snap_name, channel=channel, classic=classic, update=False)
+
+
+def snaps_holding_core() -> list[str]:
+    """Return the installed snaps that hold the core snap, and so block its removal.
+
+    A snap is held by core when it declares no base of its own; base, os and snapd snaps declare
+    no base either but are not held by it. snapd is asked rather than a list being kept here on
+    purpose: which snaps are installed depends on what every other module has done, so a
+    hand-maintained list goes stale as soon as a test starts using a new snap -- and it fails far
+    from the change, as an unrelated core test reporting 'snap is being used by snaps ...'.
+    """
+    snaps = _client.get('/v2/snaps')
+    assert isinstance(snaps, list)
+    snaps = typing.cast('list[dict[str, Any]]', snaps)
+    return [
+        s['name'] for s in snaps if s.get('base') is None and s.get('type') not in _BASE_LIKE_TYPES
+    ]
+
+
+def remove_core_blockers() -> None:
+    """Remove every installed snap that would block removal of the core snap.
+
+    Removes whatever is holding core rather than a fixed set, so this keeps working as modules
+    add and drop snaps. Functional tests are already destructive to the machine they run on
+    (hence the workshop container), so removing a snap the suite didn't install is acceptable.
+    """
+    ensure_removed(*snaps_holding_core())
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/functional/conftest.py
+++ b/snap/tests/functional/conftest.py
@@ -32,8 +32,9 @@ if typing.TYPE_CHECKING:
 # neither downloads hundreds of megabytes nor depends on a real-world snap keeping its shape.
 SNAPS_DIR = Path(__file__).parent / 'snaps'
 
-# Snap types that are not held by the core snap even though they declare no base themselves.
-_BASE_LIKE_TYPES = frozenset({'base', 'os', 'snapd'})
+# Bases whose snaps are held by the core snap: core when declared, and no base at all, since a
+# snap that declares none gets core implicitly. snapd omits 'base' from /v2/snaps in that case.
+_CORE_BASES = frozenset({None, 'core'})
 
 # Enable debug logging from snap library during tests.
 handler = logging.StreamHandler()
@@ -88,20 +89,22 @@ def ensure_installed(*snaps: str, channel: str | None = None, classic: bool = Fa
 
 
 def snaps_holding_core() -> list[str]:
-    """Return the installed snaps that hold the core snap, and so block its removal.
+    """Return the installed app snaps that hold the core snap, and so block its removal.
 
-    A snap is held by core when it declares no base of its own; base, os and snapd snaps declare
-    no base either but are not held by it. snapd is asked rather than a list being kept here on
-    purpose: which snaps are installed depends on what every other module has done, so a
-    hand-maintained list goes stale as soon as a test starts using a new snap -- and it fails far
-    from the change, as an unrelated core test reporting 'snap is being used by snaps ...'.
+    An app snap is held by core when it runs on it: when it declares ``base: core``, or declares
+    no base at all and so gets core implicitly. Only apps are considered, so that a base, os,
+    snapd, gadget or kernel snap is never a candidate for removal no matter what it declares --
+    none of those is something a test installed, and the last two would be catastrophic to remove.
+
+    snapd is asked rather than a list being kept here on purpose: which snaps are installed
+    depends on what every other module has done, so a hand-maintained list goes stale as soon as
+    a test starts using a new snap -- and it fails far from the change, as an unrelated core test
+    reporting 'snap is being used by snaps ...'.
     """
     snaps = _client.get('/v2/snaps')
     assert isinstance(snaps, list)
     snaps = typing.cast('list[dict[str, Any]]', snaps)
-    return [
-        s['name'] for s in snaps if s.get('base') is None and s.get('type') not in _BASE_LIKE_TYPES
-    ]
+    return [s['name'] for s in snaps if s.get('type') == 'app' and s.get('base') in _CORE_BASES]
 
 
 def remove_core_blockers() -> None:

--- a/snap/tests/functional/setup.sh
+++ b/snap/tests/functional/setup.sh
@@ -9,3 +9,5 @@ mksquashfs "$SNAPS_DIR/test-snap-2.0" "$SNAPS_DIR/test-snap_2.0.snap" -noappend 
 mksquashfs "$SNAPS_DIR/test-classic-snap-1.0" "$SNAPS_DIR/test-classic-snap_1.0.snap" -noappend -comp xz -all-root -quiet
 mksquashfs "$SNAPS_DIR/test-configure-snap-1.0" "$SNAPS_DIR/test-configure-snap_1.0.snap" -noappend -comp xz -all-root -quiet
 mksquashfs "$SNAPS_DIR/test-interfaces-snap-1.0" "$SNAPS_DIR/test-interfaces-snap_1.0.snap" -noappend -comp xz -all-root -quiet
+mksquashfs "$SNAPS_DIR/test-service-snap-1.0" "$SNAPS_DIR/test-service-snap_1.0.snap" -noappend -comp xz -all-root -quiet
+mksquashfs "$SNAPS_DIR/test-other-service-snap-1.0" "$SNAPS_DIR/test-other-service-snap_1.0.snap" -noappend -comp xz -all-root -quiet

--- a/snap/tests/functional/setup.sh
+++ b/snap/tests/functional/setup.sh
@@ -1,13 +1,13 @@
 # sourced by just functional snap
 SNAPS_DIR="tests/functional/snaps"
+# Every subdirectory is a snap source tree named <snap-name>-<version>, built to
+# <snap-name>_<version>.snap. Adding a snap needs no change here: drop in the directory.
 # -all-root forces the squashfs payload to be owned by root:root. Without it, mksquashfs records
 # the uid/gid of the source files as checked out, and snapd's unsquashfs fails to sideload the snap
 # ("set_attributes ... Invalid argument") when that uid is unmapped in the container (e.g. a large
 # LDAP uid on a developer machine). Snap payloads are root-owned in any case.
-mksquashfs "$SNAPS_DIR/test-snap-1.0" "$SNAPS_DIR/test-snap_1.0.snap" -noappend -comp xz -all-root -quiet
-mksquashfs "$SNAPS_DIR/test-snap-2.0" "$SNAPS_DIR/test-snap_2.0.snap" -noappend -comp xz -all-root -quiet
-mksquashfs "$SNAPS_DIR/test-classic-snap-1.0" "$SNAPS_DIR/test-classic-snap_1.0.snap" -noappend -comp xz -all-root -quiet
-mksquashfs "$SNAPS_DIR/test-configure-snap-1.0" "$SNAPS_DIR/test-configure-snap_1.0.snap" -noappend -comp xz -all-root -quiet
-mksquashfs "$SNAPS_DIR/test-interfaces-snap-1.0" "$SNAPS_DIR/test-interfaces-snap_1.0.snap" -noappend -comp xz -all-root -quiet
-mksquashfs "$SNAPS_DIR/test-service-snap-1.0" "$SNAPS_DIR/test-service-snap_1.0.snap" -noappend -comp xz -all-root -quiet
-mksquashfs "$SNAPS_DIR/test-other-service-snap-1.0" "$SNAPS_DIR/test-other-service-snap_1.0.snap" -noappend -comp xz -all-root -quiet
+for src in "$SNAPS_DIR"/*/; do
+    dir="$(basename "${src%/}")"
+    mksquashfs "$SNAPS_DIR/$dir" "$SNAPS_DIR/${dir%-*}_${dir##*-}.snap" \
+        -noappend -comp xz -all-root -quiet
+done

--- a/snap/tests/functional/snaps/test-alias-snap-1.0/bin/hello
+++ b/snap/tests/functional/snaps/test-alias-snap-1.0/bin/hello
@@ -1,0 +1,4 @@
+#!/bin/sh
+# A command with no purpose beyond being aliasable: the alias tests need a second snap that
+# can claim an alias name, so that a conflict with the first snap's alias can be provoked.
+echo "hello from test-alias-snap"

--- a/snap/tests/functional/snaps/test-alias-snap-1.0/meta/snap.yaml
+++ b/snap/tests/functional/snaps/test-alias-snap-1.0/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-alias-snap
+version: "1.0"
+summary: Snap with a plain command, to claim an alias in charmlibs.snap functional tests
+confinement: strict
+base: core24
+apps:
+  hello:
+    command: bin/hello

--- a/snap/tests/functional/snaps/test-other-service-snap-1.0/bin/daemon
+++ b/snap/tests/functional/snaps/test-other-service-snap-1.0/bin/daemon
@@ -1,23 +1,17 @@
 #!/bin/sh
-# Daemon for charmlibs.snap functional log tests.
-#
-# Emits a fixed burst of lines on startup so that log assertions have entries to read
-# immediately after the service starts, rather than depending on how chatty some real-world
-# snap happens to be. The burst is larger than the largest limit the tests ask for.
-#
-# It then ticks slowly forever. Staying alive is the point: a daemon that exits turns every
-# subsequent start into a systemd restart, which is what forced the tests to reset the unit's
-# failure counter between cases when a real snap's service was used.
+# Second daemon for charmlibs.snap functional log tests, so that multi-snap log queries have
+# two snaps to name. Behaves exactly like test-service-snap's daemon (see that script for why),
+# except that every line it logs says which of the two wrote it.
 set -e
 
 i=0
 while [ "$i" -lt 60 ]; do
     i=$((i + 1))
-    echo "test-service-snap startup entry $i"
+    echo "test-other-service-snap startup entry $i"
 done
 
 while true; do
     i=$((i + 1))
-    echo "test-service-snap tick $i"
+    echo "test-other-service-snap tick $i"
     sleep 5
 done

--- a/snap/tests/functional/snaps/test-other-service-snap-1.0/bin/daemon
+++ b/snap/tests/functional/snaps/test-other-service-snap-1.0/bin/daemon
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Daemon for charmlibs.snap functional log tests.
+#
+# Emits a fixed burst of lines on startup so that log assertions have entries to read
+# immediately after the service starts, rather than depending on how chatty some real-world
+# snap happens to be. The burst is larger than the largest limit the tests ask for.
+#
+# It then ticks slowly forever. Staying alive is the point: a daemon that exits turns every
+# subsequent start into a systemd restart, which is what forced the tests to reset the unit's
+# failure counter between cases when a real snap's service was used.
+set -e
+
+i=0
+while [ "$i" -lt 60 ]; do
+    i=$((i + 1))
+    echo "test-service-snap startup entry $i"
+done
+
+while true; do
+    i=$((i + 1))
+    echo "test-service-snap tick $i"
+    sleep 5
+done

--- a/snap/tests/functional/snaps/test-other-service-snap-1.0/meta/snap.yaml
+++ b/snap/tests/functional/snaps/test-other-service-snap-1.0/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-other-service-snap
+version: "1.0"
+summary: Second snap with a logging daemon, for multi-snap log queries
+confinement: strict
+base: core24
+apps:
+  daemon:
+    command: bin/daemon
+    daemon: simple

--- a/snap/tests/functional/snaps/test-service-snap-1.0/bin/daemon
+++ b/snap/tests/functional/snaps/test-service-snap-1.0/bin/daemon
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Daemon for charmlibs.snap functional log tests.
+#
+# Emits a fixed burst of lines on startup so that log assertions have entries to read
+# immediately after the service starts, rather than depending on how chatty some real-world
+# snap happens to be. The burst is larger than the largest limit the tests ask for.
+#
+# It then ticks slowly forever. Staying alive is the point: a daemon that exits turns every
+# subsequent start into a systemd restart, which is what forced the tests to reset the unit's
+# failure counter between cases when a real snap's service was used.
+set -e
+
+i=0
+while [ "$i" -lt 60 ]; do
+    i=$((i + 1))
+    echo "test-service-snap startup entry $i"
+done
+
+while true; do
+    i=$((i + 1))
+    echo "test-service-snap tick $i"
+    sleep 5
+done

--- a/snap/tests/functional/snaps/test-service-snap-1.0/meta/snap.yaml
+++ b/snap/tests/functional/snaps/test-service-snap-1.0/meta/snap.yaml
@@ -1,0 +1,9 @@
+name: test-service-snap
+version: "1.0"
+summary: Snap with a logging daemon for charmlibs.snap functional tests
+confinement: strict
+base: core24
+apps:
+  daemon:
+    command: bin/daemon
+    daemon: simple

--- a/snap/tests/functional/test_alive.py
+++ b/snap/tests/functional/test_alive.py
@@ -17,7 +17,7 @@ from charmlibs.snap import _client
 def test_snap_store_reachable():
     # GET /v2/find hits the snap store; a non-empty result confirms both snapd
     # and the store are reachable.
-    result = _client.get('/v2/find', query={'q': 'hello-world'})
+    result = _client.get('/v2/find', query={'q': 'test-snapd-tools'})
     assert isinstance(result, list)
     result = typing.cast('list[dict[str, Any]]', result)
     assert len(result) > 0

--- a/snap/tests/functional/test_alive.py
+++ b/snap/tests/functional/test_alive.py
@@ -16,8 +16,10 @@ from charmlibs.snap import _client
 
 def test_snap_store_reachable():
     # GET /v2/find hits the snap store; a non-empty result confirms both snapd
-    # and the store are reachable.
-    result = _client.get('/v2/find', query={'q': 'test-snapd-tools'})
+    # and the store are reachable. 'name' is an exact-name lookup rather than a search, so the
+    # one result can only be the snap asked for -- a 'q' search could be satisfied by anything
+    # the store thought was relevant, including nothing at all once it stops matching.
+    result = _client.get('/v2/find', query={'name': 'test-snapd-tools'})
     assert isinstance(result, list)
     result = typing.cast('list[dict[str, Any]]', result)
     assert len(result) > 0

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -19,7 +19,22 @@ from typing import Any
 import pytest
 
 from charmlibs.snap import _client, _errors
-from conftest import ensure_installed, ensure_removed, retry_on_rate_limit
+from conftest import (
+    ensure_installed,
+    ensure_installed_local,
+    ensure_removed,
+    retry_on_rate_limit,
+)
+
+# Locally-built snaps (tests/functional/snaps) stand in wherever a test needs some capability
+# of a snap rather than a particular snap: one that accepts configuration, one that runs a
+# service, and one with no apps at all.
+_CONF_SNAP = 'test-configure-snap'
+_SERVICE_SNAP = 'test-service-snap'
+_NO_SERVICES_SNAP = 'test-snap'
+# The smallest classic-confined snap in the store, for the classic-confinement error path.
+# Published by snapd: https://github.com/canonical/snapd/tree/master/tests/lib/snaps
+_CLASSIC_SNAP = 'test-snapd-classic-confinement'
 
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
@@ -124,26 +139,26 @@ def test_get_logs_error_snap_not_found():
 
 
 # ---------------------------------------------------------------------------
-# charmcraft error path
+# classic confinement error path
 # ---------------------------------------------------------------------------
 
 
 def test_post_sync_error_snap_needs_classic():
-    ensure_removed('charmcraft')
+    ensure_removed(_CLASSIC_SNAP)
     with pytest.raises(_errors.NeedsClassicError) as ctx:
-        _client.post('/v2/snaps/charmcraft', body={'action': 'install'})
+        _client.post(f'/v2/snaps/{_CLASSIC_SNAP}', body={'action': 'install'})
     assert ctx.value.kind == 'snap-needs-classic'
 
 
 # ---------------------------------------------------------------------------
-# Tests using other snaps (lxd, kube-proxy, htop — kept installed)
+# Tests using locally-built snaps (kept installed)
 # ---------------------------------------------------------------------------
 
 
 def test_get_returns_list():
     # GET /v2/apps returns a list result.
-    ensure_installed('kube-proxy', classic=True)
-    result = _client.get('/v2/apps', query={'select': 'service', 'names': 'kube-proxy'})
+    ensure_installed_local(_SERVICE_SNAP)
+    result = _client.get('/v2/apps', query={'select': 'service', 'names': _SERVICE_SNAP})
     assert isinstance(result, list)
     result = typing.cast('list[dict[str, Any]]', result)
     assert len(result) > 0
@@ -151,32 +166,34 @@ def test_get_returns_list():
 
 def test_get_with_query_params():
     # Query parameters are passed through and affect the result.
-    ensure_installed('lxd')
+    ensure_installed_local(_CONF_SNAP)
     try:
         # Set two keys so we can retrieve a subset of them.
-        _client.put('/v2/snaps/lxd/conf', body={'test-key-a': 'alpha', 'test-key-b': 'beta'})
-        full = _client.get('/v2/snaps/lxd/conf')
+        _client.put(
+            f'/v2/snaps/{_CONF_SNAP}/conf', body={'test-key-a': 'alpha', 'test-key-b': 'beta'}
+        )
+        full = _client.get(f'/v2/snaps/{_CONF_SNAP}/conf')
         assert isinstance(full, dict)
         assert 'test-key-a' in full and 'test-key-b' in full
         # Request only one key via query params.
-        subset = _client.get('/v2/snaps/lxd/conf', query={'keys': 'test-key-a'})
+        subset = _client.get(f'/v2/snaps/{_CONF_SNAP}/conf', query={'keys': 'test-key-a'})
         assert isinstance(subset, dict)
         assert 'test-key-a' in subset
         assert 'test-key-b' not in subset
     finally:
         # Clean up.
-        _client.put('/v2/snaps/lxd/conf', body={'test-key-a': None, 'test-key-b': None})
+        _client.put(f'/v2/snaps/{_CONF_SNAP}/conf', body={'test-key-a': None, 'test-key-b': None})
 
 
 def test_post_async_change_error_raises_snap_change_error():
     # An async change that fails raises ChangeError.
-    ensure_installed('lxd')
+    ensure_installed_local(_CONF_SNAP)
     with pytest.raises(_errors.ChangeError):
         _client.post(
             '/v2/aliases',
             body={
                 'action': 'alias',
-                'snap': 'lxd',
+                'snap': _CONF_SNAP,
                 'app': 'nonexistent-app',
                 'alias': 'test-alias-func',
             },
@@ -185,38 +202,40 @@ def test_post_async_change_error_raises_snap_change_error():
 
 def test_put_waits_for_async_change():
     # PUT /v2/snaps/{snap}/conf is async and should complete without error.
-    ensure_installed('lxd')
+    ensure_installed_local(_CONF_SNAP)
     try:
-        _client.put('/v2/snaps/lxd/conf', body={'test-key-functional': 'test-value'})
-        result = _client.get('/v2/snaps/lxd/conf', query={'keys': 'test-key-functional'})
+        _client.put(f'/v2/snaps/{_CONF_SNAP}/conf', body={'test-key-functional': 'test-value'})
+        result = _client.get(f'/v2/snaps/{_CONF_SNAP}/conf', query={'keys': 'test-key-functional'})
         assert isinstance(result, dict)
         result = typing.cast('dict[str, Any]', result)
         assert result.get('test-key-functional') == 'test-value'
     finally:
         # Clean up.
-        _client.put('/v2/snaps/lxd/conf', body={'test-key-functional': None})
+        _client.put(f'/v2/snaps/{_CONF_SNAP}/conf', body={'test-key-functional': None})
 
 
 def test_put_no_body_raises():
     # PUT with no body (None) raises a base Error: snapd can't decode EOF as patch values.
-    ensure_installed('lxd')
+    ensure_installed_local(_CONF_SNAP)
     with pytest.raises(_errors.Error) as ctx:
-        _client.put('/v2/snaps/lxd/conf')
+        _client.put(f'/v2/snaps/{_CONF_SNAP}/conf')
     assert 'EOF' in ctx.value.message
     assert not ctx.value.kind
 
 
 def test_put_empty_body_succeeds():
     # PUT with an empty body dict ({}) is accepted by snapd and is a no-op.
-    ensure_installed('lxd')
-    _client.put('/v2/snaps/lxd/conf', body={})  # Should not raise.
+    ensure_installed_local(_CONF_SNAP)
+    _client.put(f'/v2/snaps/{_CONF_SNAP}/conf', body={})  # Should not raise.
 
 
 def test_poll_fails_fast_when_socket_missing():
     # Submit a real async change, then point the client at a missing socket while waiting on it.
     # A missing socket means snapd is absent, so the poll fails fast without retrying.
-    ensure_installed('lxd')
-    response = _client._json_request('PUT', '/v2/snaps/lxd/conf', body={'test-gone-key': 'value'})
+    ensure_installed_local(_CONF_SNAP)
+    response = _client._json_request(
+        'PUT', f'/v2/snaps/{_CONF_SNAP}/conf', body={'test-gone-key': 'value'}
+    )
     change = _client._decode(response)
     assert isinstance(change, _client._Change)
     try:
@@ -228,7 +247,7 @@ def test_poll_fails_fast_when_socket_missing():
     finally:
         # snapd is still processing the original change; wait for it before cleaning up.
         change.wait()
-        _client.put('/v2/snaps/lxd/conf', body={'test-gone-key': None})
+        _client.put(f'/v2/snaps/{_CONF_SNAP}/conf', body={'test-gone-key': None})
 
 
 # ---------------------------------------------------------------------------
@@ -261,12 +280,12 @@ def test_redirect_raises_bad_response_error(path: str, location: str):
 
 def test_percent_encoded_separator_still_reaches_another_endpoint():
     # Why snap names are validated and not merely percent-encoded: snapd's router matches on the
-    # *decoded* path, so '%2F' is still a path separator to it. A name of 'lxd/conf' encodes to a
-    # single segment on the wire, but reaches /v2/snaps/lxd/conf -- the snap's configuration.
-    ensure_installed('lxd')
+    # *decoded* path, so '%2F' is still a path separator to it. A name of '<snap>/conf' encodes
+    # to a single segment on the wire, but reaches /v2/snaps/<snap>/conf -- the configuration.
+    ensure_installed_local(_CONF_SNAP)
     try:
-        _client.put('/v2/snaps/lxd/conf', body={'test-key-encoded': 'alpha'})
-        segment = urllib.parse.quote('lxd/conf', safe='')
+        _client.put(f'/v2/snaps/{_CONF_SNAP}/conf', body={'test-key-encoded': 'alpha'})
+        segment = urllib.parse.quote(f'{_CONF_SNAP}/conf', safe='')
         assert '/' not in segment
         result = _client.get(f'/v2/snaps/{segment}')
         assert isinstance(result, dict)
@@ -274,19 +293,19 @@ def test_percent_encoded_separator_still_reaches_another_endpoint():
         assert result.get('test-key-encoded') == 'alpha'  # The conf, not the snap info.
         assert 'name' not in result
     finally:
-        _client.put('/v2/snaps/lxd/conf', body={'test-key-encoded': None})
+        _client.put(f'/v2/snaps/{_CONF_SNAP}/conf', body={'test-key-encoded': None})
 
 
 def test_get_logs_returns_list():
     # /v2/logs returns a list of dicts.
-    ensure_installed('kube-proxy', classic=True)
-    result = _client.get_logs(query={'names': 'kube-proxy', 'n': 5})
+    ensure_installed_local(_SERVICE_SNAP)
+    result = _client.get_logs(query={'names': _SERVICE_SNAP, 'n': 5})
     assert isinstance(result, list)
 
 
 def test_get_logs_error_app_not_found():
     # A snap with no services returns an app-not-found error via the log stream.
-    ensure_installed('htop')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _client.get_logs(query={'names': 'htop', 'n': 10})
+        _client.get_logs(query={'names': _NO_SERVICES_SNAP, 'n': 10})
     assert ctx.value.kind == 'app-not-found'

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -26,15 +26,18 @@ from conftest import (
     retry_on_rate_limit,
 )
 
+# Snapd's own test snaps from the store, for the paths that need a real store snap: one to
+# install and refresh, and the smallest classic-confined one for the classic error path.
+# Published by snapd: https://github.com/canonical/snapd/tree/master/tests/lib/snaps
+_STORE_SNAP = 'test-snapd-tools'
+_CLASSIC_SNAP = 'test-snapd-classic-confinement'
+
 # Locally-built snaps (tests/functional/snaps) stand in wherever a test needs some capability
 # of a snap rather than a particular snap: one that accepts configuration, one that runs a
 # service, and one with no apps at all.
 _CONF_SNAP = 'test-configure-snap'
 _SERVICE_SNAP = 'test-service-snap'
 _NO_SERVICES_SNAP = 'test-snap'
-# The smallest classic-confined snap in the store, for the classic-confinement error path.
-# Published by snapd: https://github.com/canonical/snapd/tree/master/tests/lib/snaps
-_CLASSIC_SNAP = 'test-snapd-classic-confinement'
 
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
@@ -42,61 +45,61 @@ _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
 
 # ---------------------------------------------------------------------------
-# hello-world INSTALLED — tests that need the snap present
+# store snap INSTALLED — tests that need the snap present
 # ---------------------------------------------------------------------------
 
 
 def test_get_returns_dict():
     # A sync GET for a snap returns a dict result.
-    ensure_installed('hello-world')
-    result = _client.get('/v2/snaps/hello-world')
+    ensure_installed(_STORE_SNAP)
+    result = _client.get(f'/v2/snaps/{_STORE_SNAP}')
     assert isinstance(result, dict)
-    assert result['name'] == 'hello-world'
+    assert result['name'] == _STORE_SNAP
 
 
 def test_post_sync_error_snap_already_installed():
-    ensure_installed('hello-world')
+    ensure_installed(_STORE_SNAP)
     with pytest.raises(_errors._AlreadyInstalledError) as ctx:
-        _client.post('/v2/snaps/hello-world', body={'action': 'install'})
+        _client.post(f'/v2/snaps/{_STORE_SNAP}', body={'action': 'install'})
     assert ctx.value.kind == 'snap-already-installed'
 
 
 def test_post_sync_error_app_not_found():
-    ensure_installed('hello-world')
+    ensure_installed(_STORE_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.post(
-            '/v2/apps', body={'action': 'start', 'names': ['hello-world.nonexistentservice']}
+            '/v2/apps', body={'action': 'start', 'names': [f'{_STORE_SNAP}.nonexistentservice']}
         )
     assert ctx.value.kind == 'app-not-found'
 
 
 def test_post_sync_error_no_kind():
     # An invalid action returns an error with no 'kind'.
-    ensure_installed('hello-world')
+    ensure_installed(_STORE_SNAP)
     with pytest.raises(_errors.Error) as ctx:
-        _client.post('/v2/snaps/hello-world', body={'action': 'invalid-action'})
+        _client.post(f'/v2/snaps/{_STORE_SNAP}', body={'action': 'invalid-action'})
     assert not ctx.value.kind
     assert not isinstance(ctx.value, _errors.BadResponseError)
 
 
 def test_post_snap_no_update_available():
     # snap-no-update-available is raised (not suppressed) at the _client level.
-    ensure_installed('hello-world', channel='latest/stable')
+    ensure_installed(_STORE_SNAP, channel='latest/stable')
     with pytest.raises(_errors._NoUpdatesAvailableError) as ctx:
         retry_on_rate_limit(_client.post)(
-            '/v2/snaps/hello-world', body={'action': 'refresh', 'channel': 'latest/stable'}
+            f'/v2/snaps/{_STORE_SNAP}', body={'action': 'refresh', 'channel': 'latest/stable'}
         )
     assert ctx.value.kind == 'snap-no-update-available'
 
 
 def test_post_waits_for_async_change():
     # POST for an async operation waits until the change completes and does not raise.
-    # Last hello-world test — leaves the snap removed.
-    ensure_installed('hello-world')
-    _client.post('/v2/snaps/hello-world', body={'action': 'remove'})
+    # Last test needing the store snap — leaves it removed.
+    ensure_installed(_STORE_SNAP)
+    _client.post(f'/v2/snaps/{_STORE_SNAP}', body={'action': 'remove'})
     # Verify the snap is actually gone.
     with pytest.raises(_errors.NotFoundError):
-        _client.get('/v2/snaps/hello-world')
+        _client.get(f'/v2/snaps/{_STORE_SNAP}')
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/functional/test_functions.py
+++ b/snap/tests/functional/test_functions.py
@@ -6,7 +6,7 @@
 
 Tests are ordered to minimise snap install/remove churn.  All tests that need
 hello-world *installed* run first, then install-from-removed tests, then error
-paths, with charmcraft tests grouped together.
+paths, with the classic-confinement tests grouped together.
 """
 
 import pytest
@@ -14,6 +14,11 @@ import pytest
 from charmlibs.snap import _errors, _functions
 from charmlibs.snap import _snapd_snaps as _snapd
 from conftest import ensure_installed, ensure_removed, list_channels
+
+# The smallest classic-confined snap in the store, used wherever a test needs classic
+# confinement rather than a particular snap. Published by snapd:
+# https://github.com/canonical/snapd/tree/master/tests/lib/snaps
+_CLASSIC_SNAP = 'test-snapd-classic-confinement'
 
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
@@ -184,31 +189,31 @@ def test_ensure_revision_not_on_channel_raises():
 
 
 # ---------------------------------------------------------------------------
-# charmcraft (classic) — grouped to minimise churn
+# classic confinement — grouped to minimise churn
 # ---------------------------------------------------------------------------
 
 
 def test_ensure_revision_installs_classic():
-    ensure_removed('charmcraft')
-    channels = list_channels('charmcraft')
+    ensure_removed(_CLASSIC_SNAP)
+    channels = list_channels(_CLASSIC_SNAP)
     channel = 'latest/stable' if 'latest/stable' in channels else next(iter(channels))
     revision = channels[channel].revision
-    _functions.ensure('charmcraft', channel=channel, revision=revision, classic=True)
-    info = _snapd.info('charmcraft')
+    _functions.ensure(_CLASSIC_SNAP, channel=channel, revision=revision, classic=True)
+    info = _snapd.info(_CLASSIC_SNAP)
     assert info.classic is True
     assert info.revision == revision
 
 
 def test_ensure_needs_classic_raises():
-    ensure_removed('charmcraft')
+    ensure_removed(_CLASSIC_SNAP)
     with pytest.raises(_errors.NeedsClassicError):
-        _functions.ensure('charmcraft')
+        _functions.ensure(_CLASSIC_SNAP)
 
 
 def test_ensure_installs_classic():
-    ensure_removed('charmcraft')
-    _functions.ensure('charmcraft', classic=True)
-    assert _snapd.info('charmcraft').classic is True
+    ensure_removed(_CLASSIC_SNAP)
+    _functions.ensure(_CLASSIC_SNAP, classic=True)
+    assert _snapd.info(_CLASSIC_SNAP).classic is True
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/functional/test_functions.py
+++ b/snap/tests/functional/test_functions.py
@@ -5,7 +5,7 @@
 """Functional tests for _functions: ensure.
 
 Tests are ordered to minimise snap install/remove churn.  All tests that need
-hello-world *installed* run first, then install-from-removed tests, then error
+the snap *installed* run first, then install-from-removed tests, then error
 paths, with the classic-confinement tests grouped together.
 """
 
@@ -20,172 +20,193 @@ from conftest import ensure_installed, ensure_removed, list_channels
 # https://github.com/canonical/snapd/tree/master/tests/lib/snaps
 _CLASSIC_SNAP = 'test-snapd-classic-confinement'
 
+# Snapd's own test snap: its two open channels on the latest track hold different revisions,
+# so switching channel also switches revision. latest/candidate and latest/beta are closed
+# and absent from the channel map, so the alternate channel here is edge.
+_SNAP = 'test-snapd-tools'
+_CHANNEL = 'latest/stable'
+_ALT_CHANNEL = 'latest/edge'
+
+# hello-world is the one snap whose channels all carry the *same* revision, which is the
+# precondition for test_ensure_same_revision_different_channel_switches_tracking below.
+# It is used for that test alone; everything else here uses _SNAP.
+_SHARED_REVISION_SNAP = 'hello-world'
+
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
 _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
 
 # ---------------------------------------------------------------------------
-# hello-world INSTALLED — no-op / refresh paths (snap stays present)
+# snap INSTALLED — no-op / refresh paths (snap stays present)
 # ---------------------------------------------------------------------------
 
 
 def test_ensure_revision_no_op_if_same_revision():
-    ensure_installed('hello-world')
-    current_revision = _snapd.info('hello-world').revision
-    result = _functions.ensure('hello-world', revision=int(current_revision))
+    ensure_installed(_SNAP)
+    current_revision = _snapd.info(_SNAP).revision
+    result = _functions.ensure(_SNAP, revision=int(current_revision))
     assert result is False
 
 
 def test_ensure_revision_no_op_if_same_revision_and_update_true():
     # update is ignored when a revision is specified: the revision fully determines which
     # revision to be on, so there's nothing to update to.
-    ensure_installed('hello-world')
-    current_revision = _snapd.info('hello-world').revision
-    result = _functions.ensure('hello-world', revision=int(current_revision), update=True)
+    ensure_installed(_SNAP)
+    current_revision = _snapd.info(_SNAP).revision
+    result = _functions.ensure(_SNAP, revision=int(current_revision), update=True)
     assert result is False
 
 
 def test_ensure_revision_refreshes_on_different_revision():
-    ensure_installed('hello-world')
-    original_revision = _snapd.info('hello-world').revision
-    older_revision = int(original_revision) - 1
-    did_something = _functions.ensure('hello-world', revision=older_revision)
+    # The target revision is taken from the alternate channel rather than by subtracting one
+    # from the installed revision: adjacent revision numbers need not exist in the store.
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    other_revision = list_channels(_SNAP)[_ALT_CHANNEL].revision
+    assert _snapd.info(_SNAP).revision != other_revision
+    did_something = _functions.ensure(_SNAP, revision=int(other_revision))
     assert did_something is True
-    assert _snapd.info('hello-world').revision == str(older_revision)
+    assert _snapd.info(_SNAP).revision == other_revision
 
 
 def test_ensure_no_op_update_false():
-    ensure_installed('hello-world', channel='latest/stable')
-    result = _functions.ensure('hello-world', channel='latest/stable', update=False)
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    result = _functions.ensure(_SNAP, channel=_CHANNEL, update=False)
     assert result is False
 
 
 def test_ensure_no_op_normalized_channel():
-    ensure_installed('hello-world', channel='latest/stable')
-    result = _functions.ensure('hello-world', channel='latest', update=False)
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    result = _functions.ensure(_SNAP, channel='latest', update=False)
     assert result is False
 
 
 def test_ensure_no_op_stable_normalized():
-    ensure_installed('hello-world', channel='latest/stable')
-    result = _functions.ensure('hello-world', channel='stable', update=False)
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    result = _functions.ensure(_SNAP, channel='stable', update=False)
     assert result is False
 
 
 def test_ensure_refreshes_on_different_channel():
-    ensure_installed('hello-world', channel='latest/stable')
-    did_something = _functions.ensure('hello-world', channel='latest/candidate')
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    did_something = _functions.ensure(_SNAP, channel=_ALT_CHANNEL)
     assert did_something is True
-    assert _snapd.info('hello-world').tracking == 'latest/candidate'
+    assert _snapd.info(_SNAP).tracking == _ALT_CHANNEL
 
 
 def test_ensure_no_updates_available_returns_false():
-    ensure_installed('hello-world', channel='latest/stable')
+    ensure_installed(_SNAP, channel=_CHANNEL)
     # Already up-to-date — no updates available.
-    result = _functions.ensure('hello-world', channel='latest/stable')
+    result = _functions.ensure(_SNAP, channel=_CHANNEL)
     assert result is False
 
 
 # ---------------------------------------------------------------------------
-# hello-world INSTALL — tests that install from a removed state
+# INSTALL — tests that install from a removed state
 # ---------------------------------------------------------------------------
 
 
 def test_ensure_revision_installs_if_not_present():
-    ensure_removed('hello-world')
-    did_something = _functions.ensure('hello-world', revision=28)
+    ensure_removed(_SNAP)
+    revision = list_channels(_SNAP)[_ALT_CHANNEL].revision
+    did_something = _functions.ensure(_SNAP, revision=int(revision))
     assert did_something is True
-    assert _snapd.info('hello-world').revision == '28'
+    assert _snapd.info(_SNAP).revision == revision
 
 
 def test_ensure_revision_without_channel_tracks_latest_stable():
     # Installing by revision alone always tracks latest/stable, whichever channel the revision
     # was found on. Recorded here because it means the next refresh -- including an automatic
     # one -- moves the snap to latest/stable's revision.
-    ensure_removed('hello-world')
-    _functions.ensure('hello-world', revision=28)
-    info = _snapd.info('hello-world')
-    assert info.revision == '28'
-    assert info.tracking == 'latest/stable'
+    ensure_removed(_SNAP)
+    revision = list_channels(_SNAP)[_ALT_CHANNEL].revision
+    _functions.ensure(_SNAP, revision=int(revision))
+    info = _snapd.info(_SNAP)
+    assert info.revision == revision
+    # Tracks the default channel even though the revision came from the alternate one.
+    assert info.tracking == _CHANNEL
 
 
 def test_ensure_channel_and_revision_installs_and_tracks_channel():
-    ensure_removed('hello-world')
-    edge = list_channels('hello-world')['latest/edge'].revision
-    did_something = _functions.ensure('hello-world', channel='latest/edge', revision=edge)
+    ensure_removed(_SNAP)
+    edge = list_channels(_SNAP)[_ALT_CHANNEL].revision
+    did_something = _functions.ensure(_SNAP, channel=_ALT_CHANNEL, revision=edge)
     assert did_something is True
-    info = _snapd.info('hello-world')
+    info = _snapd.info(_SNAP)
     assert info.revision == edge
-    assert info.tracking == 'latest/edge'
+    assert info.tracking == _ALT_CHANNEL
 
 
 def test_ensure_channel_and_revision_no_op_when_already_matching():
-    ensure_removed('hello-world')
-    edge = list_channels('hello-world')['latest/edge'].revision
-    _functions.ensure('hello-world', channel='latest/edge', revision=edge)
-    result = _functions.ensure('hello-world', channel='latest/edge', revision=edge)
+    ensure_removed(_SNAP)
+    edge = list_channels(_SNAP)[_ALT_CHANNEL].revision
+    _functions.ensure(_SNAP, channel=_ALT_CHANNEL, revision=edge)
+    result = _functions.ensure(_SNAP, channel=_ALT_CHANNEL, revision=edge)
     assert result is False
 
 
 def test_ensure_same_revision_different_channel_switches_tracking():
     # When the revision is already installed but the snap tracks the wrong channel, ensure
     # still refreshes -- snapd moves the tracking channel without changing the revision.
-    channels = list_channels('hello-world')
+    #
+    # This needs one revision that is on two channels at once, so it cannot use _SNAP, whose
+    # channels deliberately hold different revisions. hello-world is kept solely for this.
+    snap_name = _SHARED_REVISION_SNAP
+    channels = list_channels(snap_name)
     revision = channels['latest/edge'].revision
     if channels['latest/stable'].revision != revision:
         pytest.skip('latest/stable and latest/edge are on different revisions')
-    ensure_removed('hello-world')
-    _functions.ensure('hello-world', channel='latest/edge', revision=revision)
-    did_something = _functions.ensure('hello-world', channel='latest/stable', revision=revision)
+    ensure_removed(snap_name)
+    _functions.ensure(snap_name, channel=_ALT_CHANNEL, revision=revision)
+    did_something = _functions.ensure(snap_name, channel=_CHANNEL, revision=revision)
     assert did_something is True
-    info = _snapd.info('hello-world')
+    info = _snapd.info(snap_name)
     assert info.revision == revision
-    assert info.tracking == 'latest/stable'
+    assert info.tracking == _CHANNEL
 
 
 def test_ensure_installs_if_not_present():
-    ensure_removed('hello-world')
-    did_something = _functions.ensure('hello-world')
+    ensure_removed(_SNAP)
+    did_something = _functions.ensure(_SNAP)
     assert did_something is True
-    assert _snapd.info('hello-world').name == 'hello-world'
+    assert _snapd.info(_SNAP).name == _SNAP
 
 
 def test_ensure_installs_at_default_channel():
-    ensure_removed('hello-world')
-    _functions.ensure('hello-world')
-    assert _snapd.info('hello-world').tracking == 'latest/stable'
+    ensure_removed(_SNAP)
+    _functions.ensure(_SNAP)
+    assert _snapd.info(_SNAP).tracking == _CHANNEL
 
 
 def test_ensure_installs_at_specified_channel():
-    ensure_removed('hello-world')
-    _functions.ensure('hello-world', channel='latest/candidate')
-    assert _snapd.info('hello-world').tracking == 'latest/candidate'
+    ensure_removed(_SNAP)
+    _functions.ensure(_SNAP, channel=_ALT_CHANNEL)
+    assert _snapd.info(_SNAP).tracking == _ALT_CHANNEL
 
 
 # ---------------------------------------------------------------------------
-# hello-world error paths (snap removed)
+# error paths (snap removed)
 # ---------------------------------------------------------------------------
 
 
 def test_ensure_bad_channel_raises():
-    ensure_removed('hello-world')
+    ensure_removed(_SNAP)
     with pytest.raises(_errors.APIError):
-        _functions.ensure('hello-world', channel='not/a/real/channel')
+        _functions.ensure(_SNAP, channel='not/a/real/channel')
 
 
 def test_ensure_revision_bad_revision_raises():
-    ensure_removed('hello-world')
+    ensure_removed(_SNAP)
     with pytest.raises(_errors.RevisionNotAvailableError):
-        _functions.ensure('hello-world', revision=99999999)
+        _functions.ensure(_SNAP, revision=99999999)
 
 
 def test_ensure_revision_not_on_channel_raises():
     # The revision exists, but not on the requested channel: reported as a channel error.
-    ensure_removed('hello-world')
-    absent_from_stable = int(list_channels('hello-world')['latest/stable'].revision) - 1
+    ensure_removed(_SNAP)
+    absent_from_channel = int(list_channels(_SNAP)[_ALT_CHANNEL].revision)
     with pytest.raises(_errors.ChannelNotAvailableError):
-        _functions.ensure('hello-world', channel='latest/stable', revision=absent_from_stable)
+        _functions.ensure(_SNAP, channel=_CHANNEL, revision=absent_from_channel)
 
 
 # ---------------------------------------------------------------------------
@@ -232,15 +253,15 @@ def test_ensure_bad_snap_name_raises():
 
 
 def test_ensure_empty_channel_installs_on_default_channel() -> None:
-    ensure_removed('hello-world')
-    did_something = _functions.ensure('hello-world', channel='')
+    ensure_removed(_SNAP)
+    did_something = _functions.ensure(_SNAP, channel='')
     assert did_something is True
-    assert _snapd.info('hello-world').tracking == 'latest/stable'
+    assert _snapd.info(_SNAP).tracking == _CHANNEL
 
 
 def test_ensure_empty_channel_refreshes_when_installed() -> None:
     # channel='' is falsy, so ensure skips the channel-mismatch branch
     # and falls through to the update-check refresh (no-op here).
-    ensure_installed('hello-world', channel='latest/stable')
-    result = _functions.ensure('hello-world', channel='')
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    result = _functions.ensure(_SNAP, channel='')
     assert result is False

--- a/snap/tests/functional/test_snapd_aliases.py
+++ b/snap/tests/functional/test_snapd_aliases.py
@@ -12,7 +12,7 @@ import typing
 import pytest
 
 from charmlibs.snap import _client, _errors, _snapd_aliases
-from conftest import ensure_installed, ensure_removed
+from conftest import ensure_installed, ensure_installed_local, ensure_removed
 
 if typing.TYPE_CHECKING:
     from collections.abc import Mapping
@@ -23,6 +23,12 @@ _SNAP = 'test-snapd-tools'
 _APP = 'echo'
 _APP2 = 'cat'
 _ALIAS = 'test-functional-alias'
+
+# A second snap with a plain command, used only to claim _ALIAS first so that aliasing it to
+# _SNAP conflicts. Locally built (tests/functional/snaps): the test needs two distinct snaps
+# with an aliasable app, and nothing about the conflict depends on which snap the other is.
+_OTHER_SNAP = 'test-alias-snap'
+_OTHER_APP = 'hello'
 
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
@@ -147,18 +153,18 @@ def test_unalias_nonexistent_alias_raises():
 
 
 # ---------------------------------------------------------------------------
-# hello-world installed (test cross-snap alias conflicts)
+# a second snap installed (test cross-snap alias conflicts)
 # ---------------------------------------------------------------------------
 
 
 def test_alias_duplicate_name_different_snap_raises():
     # An alias name already claimed by another snap raises ChangeError.
     ensure_installed(_SNAP)
-    ensure_installed('hello-world')
+    ensure_installed_local(_OTHER_SNAP)
     _cleanup_alias()
     _snapd_aliases.alias(_SNAP, _APP, _ALIAS)
     with pytest.raises(_errors.ChangeError) as ctx:
-        _snapd_aliases.alias('hello-world', 'hello-world', _ALIAS)
+        _snapd_aliases.alias(_OTHER_SNAP, _OTHER_APP, _ALIAS)
     assert 'already enabled for' in ctx.value.message
     _cleanup_alias()
 

--- a/snap/tests/functional/test_snapd_apps.py
+++ b/snap/tests/functional/test_snapd_apps.py
@@ -5,18 +5,22 @@
 
 from __future__ import annotations
 
-import subprocess
 import typing
 from typing import Any
 
 import pytest
 
 from charmlibs.snap import _client, _errors, _snapd_apps
-from conftest import ensure_installed
+from conftest import ensure_installed_local
 
-_SNAP = 'kube-proxy'
+# A locally-built snap whose only app is a long-running daemon (tests/functional/snaps).
+# It stays up once started, so service state is stable enough to assert on directly.
+_SNAP = 'test-service-snap'
 _SERVICE = 'daemon'
 _QUALIFIED_SERVICE = f'{_SNAP}.{_SERVICE}'
+
+# A locally-built snap with no apps at all, for the paths where a snap has no service to act on.
+_NO_SERVICES_SNAP = 'test-snap'
 
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
@@ -48,21 +52,13 @@ def _service_is_enabled() -> bool:
 
 
 def _stop_and_disable() -> None:
-    """Put kube-proxy.daemon into a known clean state: stopped and disabled.
+    """Put test-service-snap.daemon into a known clean state: stopped and disabled.
 
-    Called at the start of tests that need a predictable initial service state.
-    kube-proxy.daemon exits immediately after starting (no running k8s cluster),
-    so `active` state is only reliable right after a `start` from a disabled state.
-    Rapid start/stop cycles hit systemd's StartLimitBurst (default: 5 in 10 s),
-    causing ChangeError on subsequent starts. We call `systemctl reset-failed`
-    after disabling to clear the failure counter so the next start will succeed.
+    Called at the start of tests that need a predictable initial service state. The daemon runs
+    until it is stopped, so it never fails on its own and start/stop cycles don't accumulate
+    against systemd's start rate limit.
     """
     _snapd_apps.stop(_SNAP, _SERVICE, disable=True)
-    subprocess.run(
-        ['systemctl', 'reset-failed', f'snap.{_SNAP}.{_SERVICE}.service'],
-        check=False,
-        capture_output=True,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -71,18 +67,17 @@ def _stop_and_disable() -> None:
 
 
 def test_start():
-    # GIVEN a stopped+disabled service, start should not raise.
-    # kube-proxy.daemon exits immediately (no k8s cluster), so we don't assert active --
-    # the meaningful test is that start() completes without error.
-    ensure_installed(_SNAP, classic=True)
+    # GIVEN a stopped+disabled service, start should leave it running.
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     assert not _service_is_active()
-    _snapd_apps.start(_SNAP, _SERVICE)  # Should not raise.
+    _snapd_apps.start(_SNAP, _SERVICE)
+    assert _service_is_active()
 
 
 def test_start_already_running_no_error():
     # Starting a service should not raise even if already started.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     _snapd_apps.start(_SNAP, _SERVICE)  # First start.
     _snapd_apps.start(_SNAP, _SERVICE)  # Second start should not raise.
@@ -90,18 +85,17 @@ def test_start_already_running_no_error():
 
 def test_start_with_enable():
     # start with enable=True re-enables a disabled service.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     assert not _service_is_enabled()
     _snapd_apps.start(_SNAP, _SERVICE, enable=True)
-    # enabled persists even after kube-proxy exits quickly.
     assert _service_is_enabled()
 
 
 def test_start_nonexistent_service_raises():
-    ensure_installed('hello-world')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.start('hello-world', 'nonexistentservice')
+        _snapd_apps.start(_NO_SERVICES_SNAP, 'nonexistentservice')
     assert ctx.value.kind == 'app-not-found'
 
 
@@ -118,18 +112,17 @@ def test_start_nonexistent_snap_raises():
 
 def test_stop():
     # GIVEN a service that was started from a clean disabled state.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     _snapd_apps.start(_SNAP, _SERVICE)
-    # kube-proxy.daemon exits immediately (no k8s cluster), so we don't assert active here --
-    # that's already verified in test_start. The goal here is to verify stop() works.
+    assert _service_is_active()
     _snapd_apps.stop(_SNAP, _SERVICE)
     assert not _service_is_active()
 
 
 def test_stop_already_stopped_no_error():
     # Stopping an already stopped service should not raise.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     assert not _service_is_active()
     _snapd_apps.stop(_SNAP, _SERVICE)
@@ -138,7 +131,7 @@ def test_stop_already_stopped_no_error():
 
 def test_stop_with_disable():
     # stop with disable=True disables the service so it won't start on boot.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     _snapd_apps.start(_SNAP, _SERVICE, enable=True)
     assert _service_is_enabled()
@@ -147,9 +140,9 @@ def test_stop_with_disable():
 
 
 def test_stop_nonexistent_service_raises():
-    ensure_installed('hello-world')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.stop('hello-world', 'nonexistentservice')
+        _snapd_apps.stop(_NO_SERVICES_SNAP, 'nonexistentservice')
     assert ctx.value.kind == 'app-not-found'
 
 
@@ -165,16 +158,16 @@ def test_stop_nonexistent_snap_raises():
 
 
 def test_restart():
-    # Restarting should complete without error.
-    # kube-proxy.daemon exits quickly after restart, so we don't assert active state.
-    ensure_installed(_SNAP, classic=True)
+    # Restarting should leave the service running.
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     _snapd_apps.restart(_SNAP, _SERVICE)
+    assert _service_is_active()
 
 
 def test_restart_stopped_service():
     # Restarting a stopped service should not raise.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     assert not _service_is_active()
     _snapd_apps.restart(_SNAP, _SERVICE)
@@ -182,20 +175,19 @@ def test_restart_stopped_service():
 
 def test_restart_whole_snap():
     # restart without specifying a service should not raise.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     _snapd_apps.restart(_SNAP)
 
 
 def test_restart_nonexistent_service_raises():
-    ensure_installed('hello-world')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.restart('hello-world', 'nonexistentservice')
+        _snapd_apps.restart(_NO_SERVICES_SNAP, 'nonexistentservice')
     assert ctx.value.kind == 'app-not-found'
 
 
 def test_restart_nonexistent_snap_raises():
-    # kube-proxy has no snap "service" app, so this triggers app-not-found.
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _snapd_apps.restart('nonexistent-snap-xyz', 'service')
     assert ctx.value.kind == 'app-not-found'
@@ -231,13 +223,13 @@ def test_restart_not_installed_snap_raises_app_not_found():
 
 def test_start_all_services_of_snap():
     # Start all services of a snap; should not raise.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     _snapd_apps.start(_SNAP)
 
 
 def test_stop_all_services_of_snap():
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     _stop_and_disable()
     _snapd_apps.start(_SNAP)
     _snapd_apps.stop(_SNAP)
@@ -246,23 +238,23 @@ def test_stop_all_services_of_snap():
 
 def test_start_snap_with_no_services_raises():
     # Starting a snap that has no services raises AppNotFoundError.
-    ensure_installed('hello-world')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.start('hello-world')
+        _snapd_apps.start(_NO_SERVICES_SNAP)
     assert ctx.value.kind == 'app-not-found'
 
 
 def test_stop_snap_with_no_services_raises():
-    ensure_installed('hello-world')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.stop('hello-world')
+        _snapd_apps.stop(_NO_SERVICES_SNAP)
     assert ctx.value.kind == 'app-not-found'
 
 
 def test_restart_snap_with_no_services_raises():
-    ensure_installed('hello-world')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_apps.restart('hello-world')
+        _snapd_apps.restart(_NO_SERVICES_SNAP)
     assert ctx.value.kind == 'app-not-found'
 
 
@@ -283,7 +275,7 @@ def test_restart_snap_with_no_services_raises():
     ids=['start', 'stop', 'restart'],
 )
 def test_empty_and_blank_service_names_raise_value_error(func: Any, service: str):
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     with pytest.raises(ValueError, match='service name must not be'):
         func(_SNAP, service)
 
@@ -292,7 +284,7 @@ def test_empty_and_blank_service_names_raise_value_error(func: Any, service: str
 def test_raw_api_unusable_service_name_is_not_found(service: str):
     # snapd names the service verbatim, without stripping it, so a padded name is not resolved
     # to the service it looks like -- it is simply a service that doesn't exist.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.post('/v2/apps', body={'action': 'restart', 'names': [f'{_SNAP}.{service}']})
     assert ctx.value.kind == 'app-not-found'
@@ -302,7 +294,7 @@ def test_raw_api_unusable_service_name_is_not_found(service: str):
 def test_raw_api_unusable_service_name_aborts_the_whole_request():
     # A valid service named alongside an unusable one is not restarted: the request is rejected
     # as a whole, which is why rejecting the name client-side loses nothing.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     with pytest.raises(_errors.AppNotFoundError):
         _client.post(
             '/v2/apps',

--- a/snap/tests/functional/test_snapd_conf.py
+++ b/snap/tests/functional/test_snapd_conf.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 # Defined in https://github.com/canonical/snapd/tree/master/tests/lib/snaps
 # Only published on latest/edge.
 _SNAP = 'test-snapd-with-configure'
+# A snap with no configure hook, so it can never hold configuration.
+_NO_HOOK_SNAP = 'test-snapd-tools'
 # A key prefix we use to avoid colliding with any other configuration on the snap.
 _KEY = 'test-functional-key'
 _KEY2 = 'test-functional-key2'
@@ -220,10 +222,10 @@ def test_raw_get_all_not_installed_snap_returns_empty_dict():
 
 
 def test_get_all_installed_snap_with_no_config_returns_empty_dict():
-    # hello-world has no configure hook, so it can never have configuration. Unlike the CLI
-    # (`snap get hello-world` errors with 'has no configuration'), get() returns an empty dict.
-    ensure_installed('hello-world')
-    assert _snapd_conf.get('hello-world') == {}
+    # The snap has no configure hook, so it can never have configuration. Unlike the CLI
+    # (`snap get <snap>` errors with 'has no configuration'), get() returns an empty dict.
+    ensure_installed(_NO_HOOK_SNAP)
+    assert _snapd_conf.get(_NO_HOOK_SNAP) == {}
 
 
 # ---------------------------------------------------------------------------
@@ -496,17 +498,17 @@ def test_unset_dotted_path_no_error():
 
 
 def test_set_no_configure_hook_raises_change_error():
-    # set/unset run the snap's configure hook as an async change. hello-world has no
+    # set/unset run the snap's configure hook as an async change. This snap has no
     # configure hook, so snapd fails the change and we surface it as a ChangeError.
-    ensure_installed('hello-world')
+    ensure_installed(_NO_HOOK_SNAP)
     with pytest.raises(_errors.ChangeError):
-        _snapd_conf.set('hello-world', {'any-key': 'value'})
+        _snapd_conf.set(_NO_HOOK_SNAP, {'any-key': 'value'})
 
 
 def test_unset_no_configure_hook_raises_change_error():
-    ensure_installed('hello-world')
+    ensure_installed(_NO_HOOK_SNAP)
     with pytest.raises(_errors.ChangeError):
-        _snapd_conf.unset('hello-world', ['any-key'])
+        _snapd_conf.unset(_NO_HOOK_SNAP, ['any-key'])
 
 
 def test_set_empty_dict_no_configure_hook_is_noop():
@@ -514,8 +516,8 @@ def test_set_empty_dict_no_configure_hook_is_noop():
     # when there is nothing to set (Optional: len(patch) == 0), so a missing hook is not an
     # error and the change completes as a no-op. Contrast test_set_no_configure_hook_*, where a
     # non-empty patch on the same hook-less snap does raise.
-    ensure_installed('hello-world')
-    _snapd_conf.set('hello-world', {})  # Should not raise.
+    ensure_installed(_NO_HOOK_SNAP)
+    _snapd_conf.set(_NO_HOOK_SNAP, {})  # Should not raise.
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/functional/test_snapd_conf.py
+++ b/snap/tests/functional/test_snapd_conf.py
@@ -11,8 +11,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from charmlibs.snap import _client, _errors, _snapd_conf
-from conftest import ensure_installed, ensure_removed
-from test_snapd_local import SNAPS_DIR, install_local
+from conftest import SNAPS_DIR, ensure_installed, ensure_removed, install_local
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -566,12 +565,12 @@ def test_rejected_set_rolls_back_entire_transaction(configure_snap: None):
 # These names are rejected before a request is made. Without that, an empty name builds
 # '/v2/snaps//conf', which snapd answers with an empty-bodied 301 to '/v2/snaps/conf' -- a
 # BadResponseError about invalid JSON, indistinguishable from a transport fault. A name with a
-# path separator is worse: snapd's router decodes '%2F' before matching, so get('lxd/conf') would
-# have read '/v2/snaps/lxd/conf' -- another snap's configuration. See tests/functional/test_client
-# for both behaviours against the raw client.
+# path separator is worse: snapd's router decodes '%2F' before matching, so get('<snap>/conf')
+# would have read '/v2/snaps/<snap>/conf' -- another snap's configuration. See
+# tests/functional/test_client for both behaviours against the raw client.
 
 
-@pytest.mark.parametrize('snap', ['', '.', '..', 'lxd/conf'])
+@pytest.mark.parametrize('snap', ['', '.', '..', 'test-configure-snap/conf'])
 def test_conf_invalid_snap_name_raises_value_error(snap: str):
     with pytest.raises(ValueError):
         _snapd_conf.get(snap)

--- a/snap/tests/functional/test_snapd_conf_system.py
+++ b/snap/tests/functional/test_snapd_conf_system.py
@@ -29,7 +29,7 @@ import pytest
 
 from charmlibs import snap
 from charmlibs.snap import _errors, _snapd_conf
-from conftest import BASE_LESS_SNAPS, ensure_installed, ensure_removed
+from conftest import ensure_installed, remove_core_blockers
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -45,14 +45,12 @@ def core_snap(request: pytest.FixtureRequest) -> Iterator[str]:
     pytest groups tests by this module-scoped parameter, so the core snap's install state is
     flipped at most once per state, not once per test.
 
-    In the 'absent' state we remove the core snap after removing every snap that has it as a
-    base (see BASE_LESS_SNAPS in conftest: any of them, installed by another module, blocks
-    removal). A failed removal is deliberately left to error loudly rather than skip: if a
-    base-less snap we don't manage is installed, that's worth surfacing so we can handle it
-    explicitly.
+    In the 'absent' state we remove the core snap after removing every snap that is held by
+    it (remove_core_blockers asks snapd which those are, so this doesn't need updating when
+    another module starts using a new snap). A failed removal is left to error loudly.
     """
     if request.param == 'absent':
-        ensure_removed(*BASE_LESS_SNAPS)
+        remove_core_blockers()
         snap.remove('core')  # Errors loudly if an unmanaged snap still depends on core.
         yield request.param
         ensure_installed('core')
@@ -128,7 +126,7 @@ def test_removing_core_snap_deletes_stored_system_config():
     ensure_installed('core')  # Ensure installed, so its removal actually deletes stored config.
     _snapd_conf.set('system', {_OPTION: 3})
     assert _snapd_conf.get('system', [_OPTION]) == {_OPTION: 3}
-    ensure_removed(*BASE_LESS_SNAPS)  # Base-less; would otherwise block core removal.
+    remove_core_blockers()  # Base-less snaps would otherwise block core removal.
     snap.remove('core')
     try:
         # Removal deleted the stored option...

--- a/snap/tests/functional/test_snapd_conf_system.py
+++ b/snap/tests/functional/test_snapd_conf_system.py
@@ -29,7 +29,7 @@ import pytest
 
 from charmlibs import snap
 from charmlibs.snap import _errors, _snapd_conf
-from conftest import ensure_installed, ensure_removed
+from conftest import BASE_LESS_SNAPS, ensure_installed, ensure_removed
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -45,14 +45,14 @@ def core_snap(request: pytest.FixtureRequest) -> Iterator[str]:
     pytest groups tests by this module-scoped parameter, so the core snap's install state is
     flipped at most once per state, not once per test.
 
-    In the 'absent' state we remove the core snap after removing any snap that has it as a base
-    (a base-less snap like hello-world or test-snapd-with-configure, installed by other modules,
-    otherwise blocks removal). A failed removal is deliberately left to error loudly rather than
-    skip: if a base-less snap we don't manage is installed, that's worth surfacing so we can
-    handle it explicitly.
+    In the 'absent' state we remove the core snap after removing every snap that has it as a
+    base (see BASE_LESS_SNAPS in conftest: any of them, installed by another module, blocks
+    removal). A failed removal is deliberately left to error loudly rather than skip: if a
+    base-less snap we don't manage is installed, that's worth surfacing so we can handle it
+    explicitly.
     """
     if request.param == 'absent':
-        ensure_removed('hello-world', 'test-snapd-with-configure')
+        ensure_removed(*BASE_LESS_SNAPS)
         snap.remove('core')  # Errors loudly if an unmanaged snap still depends on core.
         yield request.param
         ensure_installed('core')
@@ -128,7 +128,7 @@ def test_removing_core_snap_deletes_stored_system_config():
     ensure_installed('core')  # Ensure installed, so its removal actually deletes stored config.
     _snapd_conf.set('system', {_OPTION: 3})
     assert _snapd_conf.get('system', [_OPTION]) == {_OPTION: 3}
-    ensure_removed('hello-world')  # Base-less; would otherwise block core removal.
+    ensure_removed(*BASE_LESS_SNAPS)  # Base-less; would otherwise block core removal.
     snap.remove('core')
     try:
         # Removal deleted the stored option...

--- a/snap/tests/functional/test_snapd_interfaces.py
+++ b/snap/tests/functional/test_snapd_interfaces.py
@@ -18,8 +18,7 @@ from typing import Any
 import pytest
 
 from charmlibs.snap import _client, _errors, _snapd_interfaces
-from conftest import ensure_removed
-from test_snapd_local import SNAPS_DIR, install_local
+from conftest import SNAPS_DIR, ensure_removed, install_local
 
 # The local test snap and one of the plugs it declares. snapd auto-resolves the
 # mount-observe slot to the system snap.

--- a/snap/tests/functional/test_snapd_interfaces_system.py
+++ b/snap/tests/functional/test_snapd_interfaces_system.py
@@ -30,8 +30,13 @@ import pytest
 
 from charmlibs import snap
 from charmlibs.snap import _client, _errors, _snapd_interfaces
-from conftest import ensure_installed, ensure_removed, remove_core_blockers
-from test_snapd_local import SNAPS_DIR, install_local
+from conftest import (
+    SNAPS_DIR,
+    ensure_installed,
+    ensure_removed,
+    install_local,
+    remove_core_blockers,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/snap/tests/functional/test_snapd_interfaces_system.py
+++ b/snap/tests/functional/test_snapd_interfaces_system.py
@@ -30,7 +30,7 @@ import pytest
 
 from charmlibs import snap
 from charmlibs.snap import _client, _errors, _snapd_interfaces
-from conftest import BASE_LESS_SNAPS, ensure_installed, ensure_removed
+from conftest import ensure_installed, ensure_removed, remove_core_blockers
 from test_snapd_local import SNAPS_DIR, install_local
 
 if TYPE_CHECKING:
@@ -58,12 +58,11 @@ def core_snap(request: pytest.FixtureRequest) -> Iterator[str]:
 
     pytest groups tests by this module-scoped parameter, so the core snap's install state is
     flipped at most once per state, not once per test. In the 'absent' state we first remove
-    every base-less snap other modules may have installed (see BASE_LESS_SNAPS in conftest),
-    which would otherwise block core removal; a failed removal is left to error loudly,
-    matching test_snapd_conf_system.
+    every snap held by core, which would otherwise block its removal; a failed removal is
+    left to error loudly, matching test_snapd_conf_system.
     """
     if request.param == 'absent':
-        ensure_removed(*BASE_LESS_SNAPS)
+        remove_core_blockers()
         snap.remove('core')  # Errors loudly if an unmanaged snap still depends on core.
         yield request.param
         ensure_installed('core')

--- a/snap/tests/functional/test_snapd_interfaces_system.py
+++ b/snap/tests/functional/test_snapd_interfaces_system.py
@@ -30,7 +30,7 @@ import pytest
 
 from charmlibs import snap
 from charmlibs.snap import _client, _errors, _snapd_interfaces
-from conftest import ensure_installed, ensure_removed
+from conftest import BASE_LESS_SNAPS, ensure_installed, ensure_removed
 from test_snapd_local import SNAPS_DIR, install_local
 
 if TYPE_CHECKING:
@@ -57,12 +57,13 @@ def core_snap(request: pytest.FixtureRequest) -> Iterator[str]:
     """Run each test with the core snap installed and again with it absent.
 
     pytest groups tests by this module-scoped parameter, so the core snap's install state is
-    flipped at most once per state, not once per test. In the 'absent' state we first remove any
-    base-less snap that other modules may have installed (which would otherwise block core
-    removal); a failed removal is left to error loudly, matching test_snapd_conf_system.
+    flipped at most once per state, not once per test. In the 'absent' state we first remove
+    every base-less snap other modules may have installed (see BASE_LESS_SNAPS in conftest),
+    which would otherwise block core removal; a failed removal is left to error loudly,
+    matching test_snapd_conf_system.
     """
     if request.param == 'absent':
-        ensure_removed('hello-world', 'test-snapd-with-configure')
+        ensure_removed(*BASE_LESS_SNAPS)
         snap.remove('core')  # Errors loudly if an unmanaged snap still depends on core.
         yield request.param
         ensure_installed('core')

--- a/snap/tests/functional/test_snapd_local.py
+++ b/snap/tests/functional/test_snapd_local.py
@@ -22,6 +22,10 @@ from conftest import SNAPS_DIR, ack, ensure_removed, install_local
 if TYPE_CHECKING:
     from pathlib import Path
 
+# A signed store snap, for the assertion (ack) tests: those need a snap whose assertions the
+# store will hand us, which a locally-built snap by definition has none of.
+_STORE_SNAP = 'test-snapd-tools'
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -55,23 +59,23 @@ def remove_test_classic_snap():
 
 
 @pytest.fixture(scope='session')
-def hello_world_download(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
-    """Download hello-world snap and assertions once for the session."""
-    d = tmp_path_factory.mktemp('hello-world')
+def store_snap_download(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Download a signed store snap and its assertions once for the session."""
+    d = tmp_path_factory.mktemp(_STORE_SNAP)
     subprocess.run(
-        ['snap', 'download', 'hello-world', '--channel=stable', f'--target-directory={d}'],
+        ['snap', 'download', _STORE_SNAP, '--channel=stable', f'--target-directory={d}'],
         check=True,
         capture_output=True,
     )
-    snap_file = next(d.glob('hello-world_*.snap'))
-    assert_file = next(d.glob('hello-world_*.assert'))
+    snap_file = next(d.glob(f'{_STORE_SNAP}_*.snap'))
+    assert_file = next(d.glob(f'{_STORE_SNAP}_*.assert'))
     return snap_file, assert_file
 
 
 @pytest.fixture(autouse=True)
-def remove_hello_world():
+def remove_store_snap():
     yield
-    ensure_removed('hello-world')
+    ensure_removed(_STORE_SNAP)
 
 
 # ---------------------------------------------------------------------------
@@ -135,15 +139,15 @@ def test_install_local_classic(classic_snap_v1: Path):
 # ---------------------------------------------------------------------------
 
 
-def test_ack_and_install(hello_world_download: tuple[Path, Path]):
-    snap_file, assert_file = hello_world_download
-    ensure_removed('hello-world')
+def test_ack_and_install(store_snap_download: tuple[Path, Path]):
+    snap_file, assert_file = store_snap_download
+    ensure_removed(_STORE_SNAP)
     ack(assert_file.read_bytes())
     install_local(snap_file)  # dangerous=False — assertions are in the DB.
-    assert _snapd.info('hello-world').name == 'hello-world'
+    assert _snapd.info(_STORE_SNAP).name == _STORE_SNAP
 
 
-def test_ack_is_idempotent(hello_world_download: tuple[Path, Path]):
-    _, assert_file = hello_world_download
+def test_ack_is_idempotent(store_snap_download: tuple[Path, Path]):
+    _, assert_file = store_snap_download
     ack(assert_file.read_bytes())
     ack(assert_file.read_bytes())  # Second call must not raise.

--- a/snap/tests/functional/test_snapd_local.py
+++ b/snap/tests/functional/test_snapd_local.py
@@ -4,93 +4,23 @@
 
 """Functional tests for local snap installation via the snapd sideload API.
 
-Includes a provisional install_local implementation built directly on _client internals,
-exercising POST /v2/snaps with a multipart body.
+Exercises the provisional ack and install_local helpers in conftest, which are built directly
+on _client internals and POST /v2/snaps with a multipart body.
 """
 
 from __future__ import annotations
 
-import json
 import subprocess
-import uuid
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
-from charmlibs.snap import _client, _errors
+from charmlibs.snap import _errors
 from charmlibs.snap import _snapd_snaps as _snapd
-from conftest import ensure_removed
+from conftest import SNAPS_DIR, ack, ensure_removed, install_local
 
-SNAPS_DIR = Path(__file__).parent / 'snaps'
-
-
-# ---------------------------------------------------------------------------
-# Provisional ack implementation
-# ---------------------------------------------------------------------------
-
-
-def ack(assertions_data: bytes) -> None:
-    """Upload assertion(s) to snapd's local database (POST /v2/assertions)."""
-    response = _client._request('POST', '/v2/assertions', data=assertions_data)
-    response_dict = json.loads(response.read())
-    if response_dict.get('type') == 'error':
-        raise _client._make_error(response_dict)
-
-
-# ---------------------------------------------------------------------------
-# Provisional install_local implementation
-# ---------------------------------------------------------------------------
-
-
-def install_local(path: Path, *, dangerous: bool = False, classic: bool = False) -> None:
-    """Install a local snap file via the snapd sideload API (POST /v2/snaps)."""
-    boundary = uuid.uuid4().hex
-    crlf = b'\r\n'
-
-    def form_field(name: str, value: str) -> bytes:
-        return b''.join([
-            b'--',
-            boundary.encode(),
-            crlf,
-            b'Content-Disposition: form-data; name="',
-            name.encode(),
-            b'"',
-            crlf,
-            crlf,
-            value.encode(),
-            crlf,
-        ])
-
-    body = [
-        b'--',
-        boundary.encode(),
-        crlf,
-        b'Content-Disposition: form-data; name="snap"; filename="',
-        path.name.encode(),
-        b'"',
-        crlf,
-        b'Content-Type: application/octet-stream',
-        crlf,
-        crlf,
-        path.read_bytes(),
-        crlf,
-    ]
-    if dangerous:
-        body.append(form_field('dangerous', 'true'))
-    if classic:
-        body.append(form_field('classic', 'true'))
-    body.extend([b'--', boundary.encode(), b'--', crlf])
-
-    headers = {
-        'Accept': 'application/json',
-        'Content-Type': f'multipart/form-data; boundary={boundary}',
-    }
-    response = _client._request('POST', '/v2/snaps', headers=headers, data=b''.join(body))
-    response_dict = json.loads(response.read())
-    if response_dict.get('type') == 'error':
-        raise _client._make_error(response_dict)
-    _client._Change(response_dict['change']).wait()
-
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/snap/tests/functional/test_snapd_logs.py
+++ b/snap/tests/functional/test_snapd_logs.py
@@ -7,9 +7,15 @@
 import pytest
 
 from charmlibs.snap import _client, _errors, _snapd_logs
-from conftest import ensure_installed
+from conftest import ensure_installed_local
 
-_SNAP = 'kube-proxy'
+# Locally-built snaps (tests/functional/snaps). The service snaps run a daemon that emits a
+# fixed burst of lines on startup, so the number of entries available to read is a property of
+# the fixture rather than of how chatty some real-world snap happens to be.
+_SNAP = 'test-service-snap'
+_OTHER_SNAP = 'test-other-service-snap'
+# A snap with no apps at all, so snapd reports it has no services.
+_NO_SERVICES_SNAP = 'test-snap'
 
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
@@ -19,18 +25,18 @@ _ABSENT_SNAP_2 = 'this-snap-also-does-not-exist-def-456'
 
 
 # ---------------------------------------------------------------------------
-# logs (kube-proxy installed)
+# logs (service snap installed)
 # ---------------------------------------------------------------------------
 
 
 def test_logs_returns_log_entries():
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     entries = _snapd_logs.logs(_SNAP, limit=5)
     assert isinstance(entries, list)
 
 
 def test_logs_entries_have_expected_fields():
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     entries = _snapd_logs.logs(_SNAP, limit=5)
     for entry in entries:
         assert isinstance(entry, _snapd_logs.LogEntry)
@@ -42,7 +48,7 @@ def test_logs_entries_have_expected_fields():
 
 def test_logs_limit():
     # The limit parameter limits the number of results returned.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     entries = _snapd_logs.logs(_SNAP, limit=3)
     assert len(entries) <= 3
 
@@ -50,15 +56,15 @@ def test_logs_limit():
 def test_logs_limit_above_default():
     # The limit parameter is not capped at the snapd default of 10: requesting more
     # returns more (provided enough log entries are available).
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     entries = _snapd_logs.logs(_SNAP, limit=50)
-    # kube-proxy is chatty enough to produce well over 10 entries shortly after install.
+    # The daemon emits a burst of 60 lines on startup, so there are always more than 10.
     assert len(entries) > 10
 
 
 def test_logs_ordered_oldest_first():
     # Log entries are returned in chronological order: oldest first, newest last.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     entries = _snapd_logs.logs(_SNAP, limit=50)
     timestamps = [entry.timestamp for entry in entries]
     assert timestamps == sorted(timestamps)
@@ -66,9 +72,9 @@ def test_logs_ordered_oldest_first():
 
 def test_logs_multiple_snaps():
     # Requesting logs for multiple snaps should not raise.
-    ensure_installed(_SNAP, classic=True)
-    ensure_installed('lxd')
-    entries = _snapd_logs.logs(_SNAP, 'lxd', limit=10)
+    ensure_installed_local(_SNAP)
+    ensure_installed_local(_OTHER_SNAP)
+    entries = _snapd_logs.logs(_SNAP, _OTHER_SNAP, limit=10)
     assert isinstance(entries, list)
 
 
@@ -80,7 +86,7 @@ def test_logs_limit_zero_raises():
 
 def test_logs_limit_none_returns_all():
     # limit=None retrieves all available log entries (no limit).
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     all_entries = _snapd_logs.logs(_SNAP, limit=None)
     limited = _snapd_logs.logs(_SNAP, limit=5)
     assert isinstance(all_entries, list)
@@ -94,15 +100,15 @@ def test_logs_no_snap_args():
 
 
 # ---------------------------------------------------------------------------
-# snap with no services (htop)
+# snap with no services
 # ---------------------------------------------------------------------------
 
 
 def test_logs_snap_with_no_services_raises():
     # A snap with no services raises AppNotFoundError.
-    ensure_installed('htop')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
-        _snapd_logs.logs('htop')
+        _snapd_logs.logs(_NO_SERVICES_SNAP)
     assert ctx.value.kind == 'app-not-found'
 
 
@@ -129,7 +135,18 @@ def test_logs_not_installed_snap_raises():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize('name', ['', ' ', '\t', '\xa0', 'htop,lxd', ' htop', 'htop\n'])
+@pytest.mark.parametrize(
+    'name',
+    [
+        '',
+        ' ',
+        '\t',
+        '\xa0',
+        f'{_NO_SERVICES_SNAP},{_SNAP}',
+        f' {_NO_SERVICES_SNAP}',
+        f'{_NO_SERVICES_SNAP}\n',
+    ],
+)
 def test_unusable_names_raise_value_error(name: str):
     # The public contract: anything snapd's parsing would alter is a ValueError, not a request.
     with pytest.raises(ValueError):
@@ -146,7 +163,7 @@ def test_empty_names_leave_no_filter(names: str):
     # Entries are compared by their syslog identifiers, since new ones are logged all the time.
     # The unfiltered query runs first so that entries logged in between can only add identifiers
     # to the second result, which is why this is a superset rather than an equality.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     unfiltered = {entry['sid'] for entry in _client.get_logs(query={'n': -1})}
     assert unfiltered, 'no system-wide logs to compare against'
     result = {entry['sid'] for entry in _client.get_logs(query={'n': -1, 'names': names})}
@@ -160,24 +177,34 @@ def test_blank_names_leave_no_filter(names: str):
     # str.strip and the Go unicode.IsSpace snapd strips with agree on which characters these are,
     # including U+00A0, which the two define separately -- so the client-side check can mirror
     # snapd's rule rather than approximate it.
-    ensure_installed(_SNAP, classic=True)
+    ensure_installed_local(_SNAP)
     unfiltered = {entry['sid'] for entry in _client.get_logs(query={'n': -1})}
     assert unfiltered, 'no system-wide logs to compare against'
     result = {entry['sid'] for entry in _client.get_logs(query={'n': -1, 'names': names})}
     assert result.issuperset(unfiltered)
 
 
-@pytest.mark.parametrize('names', [',htop', 'htop,', ',htop,', ' htop ', '\thtop\n', ' ,htop'])
+@pytest.mark.parametrize(
+    'names',
+    [
+        f',{_NO_SERVICES_SNAP}',
+        f'{_NO_SERVICES_SNAP},',
+        f',{_NO_SERVICES_SNAP},',
+        f' {_NO_SERVICES_SNAP} ',
+        f'\t{_NO_SERVICES_SNAP}\n',
+        f' ,{_NO_SERVICES_SNAP}',
+    ],
+)
 def test_discarded_and_stripped_entries_leave_the_named_snap(names: str):
     # The named snap is all that is left once the empty entries are dropped and the surviving
     # ones are stripped, so these queries mean what naming it on its own means: snapd resolves
     # the name and reports that it has no services. An empty entry taken as a name of its own,
     # or a padded name taken literally, would report something else.
-    ensure_installed('htop')
+    ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.get_logs(query={'n': -1, 'names': names})
     assert ctx.value.kind == 'app-not-found'
-    assert ctx.value.message == 'snap "htop" has no services'
+    assert ctx.value.message == f'snap "{_NO_SERVICES_SNAP}" has no services'
 
 
 def test_comma_in_a_name_queries_two_snaps():

--- a/snap/tests/functional/test_snapd_snaps.py
+++ b/snap/tests/functional/test_snapd_snaps.py
@@ -20,6 +20,11 @@ from charmlibs.snap import _client, _errors
 from charmlibs.snap import _snapd_snaps as _snapd
 from conftest import ensure_installed, ensure_removed, list_channels, retry_on_rate_limit
 
+# The smallest classic-confined snap in the store, used wherever a test needs classic
+# confinement rather than a particular snap. Published by snapd:
+# https://github.com/canonical/snapd/tree/master/tests/lib/snaps
+_CLASSIC_SNAP = 'test-snapd-classic-confinement'
+
 # A snap name that is never installed — used for error paths where any absent
 # snap produces the same error response, avoiding unnecessary remove operations.
 _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
@@ -247,21 +252,21 @@ def test_install_revision():
 
 
 # ---------------------------------------------------------------------------
-# charmcraft (classic) — grouped to minimise churn
+# classic confinement — grouped to minimise churn
 # ---------------------------------------------------------------------------
 
 
 def test_install_needs_classic_raises():
-    ensure_removed('charmcraft')
+    ensure_removed(_CLASSIC_SNAP)
     with pytest.raises(_errors.NeedsClassicError) as ctx:
-        retry_on_rate_limit(_snapd.install)('charmcraft')
+        retry_on_rate_limit(_snapd.install)(_CLASSIC_SNAP)
     assert ctx.value.kind == 'snap-needs-classic'
 
 
 def test_install_classic():
-    ensure_removed('charmcraft')
-    retry_on_rate_limit(_snapd.install)('charmcraft', classic=True)
-    info = _snapd.info('charmcraft')
+    ensure_removed(_CLASSIC_SNAP)
+    retry_on_rate_limit(_snapd.install)(_CLASSIC_SNAP, classic=True)
+    info = _snapd.info(_CLASSIC_SNAP)
     assert info.classic is True
 
 

--- a/snap/tests/functional/test_snapd_snaps.py
+++ b/snap/tests/functional/test_snapd_snaps.py
@@ -5,7 +5,7 @@
 """Functional tests for _snapd_snaps: info, install, remove, refresh, hold, unhold.
 
 Tests are ordered to minimise snap install/remove churn.  All tests that need
-hello-world *installed* run first, then all tests that need it *removed*, then
+the snap *installed* run first, then all tests that need it *removed*, then
 tests that inherently install/remove as part of the test logic.
 """
 
@@ -19,6 +19,15 @@ import pytest
 from charmlibs.snap import _client, _errors
 from charmlibs.snap import _snapd_snaps as _snapd
 from conftest import ensure_installed, ensure_removed, list_channels, retry_on_rate_limit
+
+# Snapd's own test snap, used for everything that needs real store semantics. Its two open
+# channels on the latest track carry *different* revisions (stable is newer than edge), so a
+# channel change is also a revision change -- which is what lets these tests tell 'tracking
+# was updated' apart from 'the installed revision was updated'. latest/candidate and
+# latest/beta are closed, so they are absent from the channel map and are not used here.
+_SNAP = 'test-snapd-tools'
+_CHANNEL = 'latest/stable'
+_ALT_CHANNEL = 'latest/edge'
 
 # The smallest classic-confined snap in the store, used wherever a test needs classic
 # confinement rather than a particular snap. Published by snapd:
@@ -42,146 +51,151 @@ def _list_snaps() -> list[_snapd.Info]:
 
 
 # ---------------------------------------------------------------------------
-# hello-world INSTALLED — tests that need the snap present
+# snap INSTALLED — tests that need the snap present
 # ---------------------------------------------------------------------------
 
 
 def test_info_installed():
-    ensure_installed('hello-world')
-    info = _snapd.info('hello-world')
-    assert info.name == 'hello-world'
+    ensure_installed(_SNAP)
+    info = _snapd.info(_SNAP)
+    assert info.name == _SNAP
     assert info.tracking
     assert info.revision
     assert info.version
     # Independent oracle: /v2/snaps (list) should agree with /v2/snaps/{snap} (info).
-    assert 'hello-world' in {s.name for s in _list_snaps()}
+    assert _SNAP in {s.name for s in _list_snaps()}
 
 
 def test_info_fields():
-    ensure_installed('hello-world')
-    info = _snapd.info('hello-world')
+    ensure_installed(_SNAP)
+    info = _snapd.info(_SNAP)
     assert info.classic is False
     assert info.hold is None
 
 
 def test_install_already_installed_returns_false():
-    ensure_installed('hello-world')
-    result = _snapd.install('hello-world')
+    ensure_installed(_SNAP)
+    result = _snapd.install(_SNAP)
     assert result is False
 
 
 def test_refresh_no_updates_returns_false():
-    ensure_installed('hello-world', channel='latest/stable')
-    result = retry_on_rate_limit(_snapd.refresh)('hello-world', channel='latest/stable')
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    result = retry_on_rate_limit(_snapd.refresh)(_SNAP, channel=_CHANNEL)
     assert result is False
-    assert _snapd.info('hello-world').tracking == 'latest/stable'
+    assert _snapd.info(_SNAP).tracking == _CHANNEL
 
 
 def test_refresh_channel():
-    ensure_installed('hello-world', channel='latest/stable')
-    # Pre-flight: confirm the target channel exists before refreshing to it.
-    assert 'latest/candidate' in list_channels('hello-world')
-    retry_on_rate_limit(_snapd.refresh)('hello-world', channel='latest/candidate')
-    info = _snapd.info('hello-world')
-    assert info.tracking == 'latest/candidate'
+    # Refreshing to another channel moves both the tracking channel and the installed
+    # revision, since the two channels hold different revisions. Asserting the revision as
+    # well as the tracking is the point: a refresh that updated only the tracking would be
+    # indistinguishable from a correct one if both channels held the same revision.
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    channels = list_channels(_SNAP)
+    assert channels[_CHANNEL].revision != channels[_ALT_CHANNEL].revision
+    retry_on_rate_limit(_snapd.refresh)(_SNAP, channel=_ALT_CHANNEL)
+    info = _snapd.info(_SNAP)
+    assert info.tracking == _ALT_CHANNEL
+    assert info.revision == channels[_ALT_CHANNEL].revision
 
 
 def test_refresh_invalid_channel_raises():
-    ensure_installed('hello-world')
+    ensure_installed(_SNAP)
     with pytest.raises(_errors.ChannelNotAvailableError) as ctx:
-        retry_on_rate_limit(_snapd.refresh)('hello-world', channel='garbage')
+        retry_on_rate_limit(_snapd.refresh)(_SNAP, channel='garbage')
     assert ctx.value.kind == 'snap-channel-not-available'
 
 
 def test_refresh_revision_not_available_raises():
-    ensure_installed('hello-world')
+    ensure_installed(_SNAP)
     with pytest.raises(_errors.RevisionNotAvailableError) as ctx:
-        retry_on_rate_limit(_snapd.refresh)('hello-world', revision=99999999)
+        retry_on_rate_limit(_snapd.refresh)(_SNAP, revision=99999999)
     assert ctx.value.kind == 'snap-revision-not-available'
 
 
 def test_hold_with_duration():
-    ensure_installed('hello-world')
+    ensure_installed(_SNAP)
     try:
-        _snapd.hold('hello-world', duration=datetime.timedelta(days=2))
-        info = _snapd.info('hello-world')
+        _snapd.hold(_SNAP, duration=datetime.timedelta(days=2))
+        info = _snapd.info(_SNAP)
         assert info.hold is not None
         assert info.hold - datetime.datetime.now().astimezone() > datetime.timedelta(days=1)
     finally:
-        _snapd.unhold('hello-world')
+        _snapd.unhold(_SNAP)
 
 
 def test_hold_forever():
-    ensure_installed('hello-world')
+    ensure_installed(_SNAP)
     try:
-        _snapd.hold('hello-world')
-        info = _snapd.info('hello-world')
+        _snapd.hold(_SNAP)
+        info = _snapd.info(_SNAP)
         # When held forever, snapd returns a far-future timestamp.
         assert info.hold is not None
     finally:
-        _snapd.unhold('hello-world')
+        _snapd.unhold(_SNAP)
 
 
 def test_hold_already_held_no_error():
     # Holding an already-held snap is idempotent — no error is raised.
-    ensure_installed('hello-world')
+    ensure_installed(_SNAP)
     try:
-        _snapd.hold('hello-world')
-        _snapd.hold('hello-world')  # Second hold should not raise.
+        _snapd.hold(_SNAP)
+        _snapd.hold(_SNAP)  # Second hold should not raise.
     finally:
-        _snapd.unhold('hello-world')
+        _snapd.unhold(_SNAP)
 
 
 def test_unhold():
-    ensure_installed('hello-world')
-    _snapd.hold('hello-world')
-    assert _snapd.info('hello-world').hold is not None
-    _snapd.unhold('hello-world')
-    assert _snapd.info('hello-world').hold is None
+    ensure_installed(_SNAP)
+    _snapd.hold(_SNAP)
+    assert _snapd.info(_SNAP).hold is not None
+    _snapd.unhold(_SNAP)
+    assert _snapd.info(_SNAP).hold is None
 
 
 def test_remove():
-    # Last test in the "installed" block — leaves hello-world removed for the next block.
-    ensure_installed('hello-world')
-    _snapd.remove('hello-world')
+    # Last test in the "installed" block — leaves the snap removed for the next block.
+    ensure_installed(_SNAP)
+    _snapd.remove(_SNAP)
     with pytest.raises(_errors.NotFoundError):
-        _snapd.info('hello-world')
+        _snapd.info(_SNAP)
 
 
 # ---------------------------------------------------------------------------
-# hello-world REMOVED — tests that need the snap absent
-# (after test_remove above, hello-world is already gone)
+# snap REMOVED — tests that need the snap absent
+# (after test_remove above, it is already gone)
 # ---------------------------------------------------------------------------
 
 
 def test_info_missing_raises():
-    ensure_removed('hello-world')
+    ensure_removed(_SNAP)
     # Independent oracle: the snap really is absent from /v2/snaps.
-    assert 'hello-world' not in {s.name for s in _list_snaps()}
+    assert _SNAP not in {s.name for s in _list_snaps()}
     with pytest.raises(_errors.NotFoundError) as ctx:
-        _snapd.info('hello-world')
+        _snapd.info(_SNAP)
     assert ctx.value.kind == 'snap-not-found'
 
 
 def test_remove_not_installed_returns_false():
-    ensure_removed('hello-world')
-    result = _snapd.remove('hello-world')
+    ensure_removed(_SNAP)
+    result = _snapd.remove(_SNAP)
     assert result is False
 
 
 def test_remove_purge_not_installed_returns_false():
     # purge=True on a non-installed snap behaves the same as purge=False: returns False.
-    ensure_removed('hello-world')
-    result = _snapd.remove('hello-world', purge=True)
+    ensure_removed(_SNAP)
+    result = _snapd.remove(_SNAP, purge=True)
     assert result is False
 
 
 def test_refresh_not_installed_raises_base_snap_error():
     # The API returns an error with no 'kind' when refreshing a non-installed snap.
     # This is distinct from NotFoundError; it's a base Error.
-    ensure_removed('hello-world')
+    ensure_removed(_SNAP)
     with pytest.raises(_errors.Error) as ctx:
-        retry_on_rate_limit(_snapd.refresh)('hello-world')
+        retry_on_rate_limit(_snapd.refresh)(_SNAP)
     # No kind is set -- the message contains "is not installed" but snapd omits the kind field.
     assert not ctx.value.kind
     assert 'not installed' in ctx.value.message
@@ -189,66 +203,71 @@ def test_refresh_not_installed_raises_base_snap_error():
 
 def test_hold_not_installed_raises_snap_not_found_error():
     # hold() calls info() first, which raises NotFoundError with a proper kind.
-    ensure_removed('hello-world')
+    ensure_removed(_SNAP)
     with pytest.raises(_errors.NotFoundError) as ctx:
-        _snapd.hold('hello-world')
+        _snapd.hold(_SNAP)
     assert ctx.value.kind == 'snap-not-found'
 
 
 def test_unhold_not_installed_no_error():
     # unhold on a non-installed snap succeeds silently (async Done).
-    ensure_removed('hello-world')
-    _snapd.unhold('hello-world')  # Should not raise.
+    ensure_removed(_SNAP)
+    _snapd.unhold(_SNAP)  # Should not raise.
 
 
 def test_install_invalid_channel_raises():
-    ensure_removed('hello-world')
+    ensure_removed(_SNAP)
     with pytest.raises(_errors.ChannelNotAvailableError) as ctx:
-        retry_on_rate_limit(_snapd.install)('hello-world', channel='garbage')
+        retry_on_rate_limit(_snapd.install)(_SNAP, channel='garbage')
     assert ctx.value.kind == 'snap-channel-not-available'
     assert 'channel' in ctx.value.message or 'no snap revision' in ctx.value.message
 
 
 def test_install_revision_not_available_raises():
-    ensure_removed('hello-world')
+    ensure_removed(_SNAP)
     with pytest.raises(_errors.RevisionNotAvailableError) as ctx:
-        retry_on_rate_limit(_snapd.install)('hello-world', revision=99999999)
+        retry_on_rate_limit(_snapd.install)(_SNAP, revision=99999999)
     assert ctx.value.kind == 'snap-revision-not-available'
 
 
 # ---------------------------------------------------------------------------
-# hello-world INSTALL operations — tests that install as part of the test
+# INSTALL operations — tests that install as part of the test
 # ---------------------------------------------------------------------------
 
 
 def test_install():
-    ensure_removed('hello-world')
-    retry_on_rate_limit(_snapd.install)('hello-world')
-    info = _snapd.info('hello-world')
-    assert info.name == 'hello-world'
-    assert info.tracking == 'latest/stable'
+    ensure_removed(_SNAP)
+    retry_on_rate_limit(_snapd.install)(_SNAP)
+    info = _snapd.info(_SNAP)
+    assert info.name == _SNAP
+    assert info.tracking == _CHANNEL
     # The installed revision should match the store's current latest/stable revision.
-    assert info.revision == list_channels('hello-world')['latest/stable'].revision
+    assert info.revision == list_channels(_SNAP)[_CHANNEL].revision
 
 
 def test_install_channel():
-    ensure_removed('hello-world')
+    ensure_removed(_SNAP)
     # Pre-flight: confirm the target channel actually exists in the store.
-    assert 'latest/candidate' in list_channels('hello-world')
-    retry_on_rate_limit(_snapd.install)('hello-world', channel='latest/candidate')
-    info = _snapd.info('hello-world')
-    assert info.tracking == 'latest/candidate'
+    channels = list_channels(_SNAP)
+    assert _ALT_CHANNEL in channels
+    retry_on_rate_limit(_snapd.install)(_SNAP, channel=_ALT_CHANNEL)
+    info = _snapd.info(_SNAP)
+    assert info.tracking == _ALT_CHANNEL
+    # Installing a channel gets that channel's revision, not the default channel's.
+    assert info.revision == channels[_ALT_CHANNEL].revision
 
 
 def test_install_revision():
-    ensure_removed('hello-world')
-    # hello-world revision 28 is one behind the current latest/stable revision (sourced
-    # from the store rather than hard-coded, to document the relationship and catch drift).
-    current = int(list_channels('hello-world')['latest/stable'].revision)
-    previous = current - 1
-    retry_on_rate_limit(_snapd.install)('hello-world', revision=previous)
-    info = _snapd.info('hello-world')
-    assert info.revision == str(previous)
+    # A revision on its own installs that exact revision, regardless of which channel it is
+    # on. The revision is taken from the alternate channel rather than by subtracting one
+    # from the default channel's: adjacent revision numbers need not exist in the store.
+    ensure_removed(_SNAP)
+    channels = list_channels(_SNAP)
+    revision = channels[_ALT_CHANNEL].revision
+    assert revision != channels[_CHANNEL].revision
+    retry_on_rate_limit(_snapd.install)(_SNAP, revision=int(revision))
+    info = _snapd.info(_SNAP)
+    assert info.revision == revision
 
 
 # ---------------------------------------------------------------------------
@@ -284,40 +303,40 @@ def test_install_nonexistent_snap_raises():
 
 def test_install_channel_and_revision():
     # Not mutually exclusive: snapd installs the revision and tracks the channel.
-    ensure_removed('hello-world')
-    edge = list_channels('hello-world')['latest/edge'].revision
-    retry_on_rate_limit(_snapd.install)('hello-world', channel='latest/edge', revision=edge)
-    info = _snapd.info('hello-world')
+    ensure_removed(_SNAP)
+    edge = list_channels(_SNAP)[_ALT_CHANNEL].revision
+    retry_on_rate_limit(_snapd.install)(_SNAP, channel=_ALT_CHANNEL, revision=edge)
+    info = _snapd.info(_SNAP)
     assert info.revision == edge
-    assert info.tracking == 'latest/edge'
+    assert info.tracking == _ALT_CHANNEL
 
 
 def test_install_revision_not_on_channel_raises():
     # The store checks the revision against the channel, so asking for a revision that isn't
     # on the requested channel is an error -- reported against the channel, not the revision.
-    ensure_removed('hello-world')
-    channels = list_channels('hello-world')
-    absent_from_stable = int(channels['latest/stable'].revision) - 1
+    ensure_removed(_SNAP)
+    channels = list_channels(_SNAP)
+    # A revision that really is in the store, on the alternate channel but not this one, so
+    # the error is genuinely about the pairing rather than about an unknown revision.
+    absent_from_channel = int(channels[_ALT_CHANNEL].revision)
     with pytest.raises(_errors.ChannelNotAvailableError) as ctx:
-        retry_on_rate_limit(_snapd.install)(
-            'hello-world', channel='latest/stable', revision=absent_from_stable
-        )
+        retry_on_rate_limit(_snapd.install)(_SNAP, channel=_CHANNEL, revision=absent_from_channel)
     assert ctx.value.kind == 'snap-channel-not-available'
 
 
 def test_refresh_channel_and_revision():
-    ensure_installed('hello-world', channel='latest/stable')
-    edge = list_channels('hello-world')['latest/edge'].revision
-    retry_on_rate_limit(_snapd.refresh)('hello-world', channel='latest/edge', revision=edge)
-    info = _snapd.info('hello-world')
+    ensure_installed(_SNAP, channel=_CHANNEL)
+    edge = list_channels(_SNAP)[_ALT_CHANNEL].revision
+    retry_on_rate_limit(_snapd.refresh)(_SNAP, channel=_ALT_CHANNEL, revision=edge)
+    info = _snapd.info(_SNAP)
     assert info.revision == edge
-    assert info.tracking == 'latest/edge'
+    assert info.tracking == _ALT_CHANNEL
 
 
 def test_refresh_revision_already_installed_still_refreshes():
     # Snapd runs a full refresh when a revision is specified, even if that revision is already
     # installed, so refresh reports that it did something. ensure() relies on knowing this.
-    ensure_installed('hello-world')
-    current = _snapd.info('hello-world').revision
-    result = retry_on_rate_limit(_snapd.refresh)('hello-world', revision=current)
+    ensure_installed(_SNAP)
+    current = _snapd.info(_SNAP).revision
+    result = retry_on_rate_limit(_snapd.refresh)(_SNAP, revision=current)
     assert result is True


### PR DESCRIPTION
This PR reworks the snap functional tests to use lightweight testing snaps instead of heavy snaps like LXD. The test snaps are either:
- defined locally and fake packed with `mksquashfs`
- snapd's own test snaps, which are published to the store
- in one case, the hello-world snap