### PR TITLE
feat(snap): rename `ensure` -> `ensure_installed`

### DIFF
--- a/snap/src/charmlibs/snap/__init__.py
+++ b/snap/src/charmlibs/snap/__init__.py
@@ -14,8 +14,8 @@
 
 """Opinionated library for performing snap operations, targeted at use in charm code.
 
-Use :func:`ensure` to ensure that a snap is installed, optionally on a specific channel
-or revision.
+Use :func:`ensure_installed` to ensure that a snap is installed, optionally on a specific
+channel or revision.
 
 Manually manage snap installation with :func:`install`, :func:`refresh`, and :func:`remove`.
 Use :func:`list_one` to query the current state of an installed snap.

--- a/snap/src/charmlibs/snap/__init__.py
+++ b/snap/src/charmlibs/snap/__init__.py
@@ -61,7 +61,7 @@ from ._errors import (
     TimeoutError,  # noqa: A004 (shadowing a Python builtin)
 )
 from ._functions import (
-    ensure,
+    ensure_installed,
 )
 from ._snapd_aliases import (
     alias,
@@ -116,7 +116,7 @@ __all__ = [
     'alias',
     'connect',
     'disconnect',
-    'ensure',
+    'ensure_installed',
     'get',
     'get_one',
     'hold',

--- a/snap/src/charmlibs/snap/_functions.py
+++ b/snap/src/charmlibs/snap/_functions.py
@@ -17,7 +17,7 @@
 from . import _errors, _snapd_snaps, _utils
 
 
-def ensure(
+def ensure_installed(
     snap: str,
     channel: str | None = None,
     *,

--- a/snap/tests/functional/conftest.py
+++ b/snap/tests/functional/conftest.py
@@ -83,7 +83,7 @@ def ensure_removed(*snaps: str) -> None:
             snap.remove(snap_name)
 
 
-def ensure_installed(*snaps: str, channel: str | None = None, classic: bool = False) -> None:
+def ensure_installed_store(*snaps: str, channel: str | None = None, classic: bool = False) -> None:
     for snap_name in snaps:
         retry_on_rate_limit(snap.ensure_installed)(
             snap_name, channel=channel, classic=classic, update=False

--- a/snap/tests/functional/conftest.py
+++ b/snap/tests/functional/conftest.py
@@ -85,7 +85,9 @@ def ensure_removed(*snaps: str) -> None:
 
 def ensure_installed(*snaps: str, channel: str | None = None, classic: bool = False) -> None:
     for snap_name in snaps:
-        retry_on_rate_limit(snap.ensure)(snap_name, channel=channel, classic=classic, update=False)
+        retry_on_rate_limit(snap.ensure_installed)(
+            snap_name, channel=channel, classic=classic, update=False
+        )
 
 
 # Test helper for the parts of `snap list` the library deliberately doesn't implement: listing

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -20,8 +20,8 @@ import pytest
 
 from charmlibs.snap import _client, _errors
 from conftest import (
-    ensure_installed,
     ensure_installed_local,
+    ensure_installed_store,
     ensure_removed,
     retry_on_rate_limit,
 )
@@ -51,21 +51,21 @@ _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
 def test_get_returns_dict():
     # A sync GET for a snap returns a dict result.
-    ensure_installed(_STORE_SNAP)
+    ensure_installed_store(_STORE_SNAP)
     result = _client.get(f'/v2/snaps/{_STORE_SNAP}')
     assert isinstance(result, dict)
     assert result['name'] == _STORE_SNAP
 
 
 def test_post_sync_error_snap_already_installed():
-    ensure_installed(_STORE_SNAP)
+    ensure_installed_store(_STORE_SNAP)
     with pytest.raises(_errors._AlreadyInstalledError) as ctx:
         _client.post(f'/v2/snaps/{_STORE_SNAP}', body={'action': 'install'})
     assert ctx.value.kind == 'snap-already-installed'
 
 
 def test_post_sync_error_app_not_found():
-    ensure_installed(_STORE_SNAP)
+    ensure_installed_store(_STORE_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.post(
             '/v2/apps', body={'action': 'start', 'names': [f'{_STORE_SNAP}.nonexistentservice']}
@@ -75,7 +75,7 @@ def test_post_sync_error_app_not_found():
 
 def test_post_sync_error_no_kind():
     # An invalid action returns an error with no 'kind'.
-    ensure_installed(_STORE_SNAP)
+    ensure_installed_store(_STORE_SNAP)
     with pytest.raises(_errors.Error) as ctx:
         _client.post(f'/v2/snaps/{_STORE_SNAP}', body={'action': 'invalid-action'})
     assert not ctx.value.kind
@@ -84,7 +84,7 @@ def test_post_sync_error_no_kind():
 
 def test_post_snap_no_update_available():
     # snap-no-update-available is raised (not suppressed) at the _client level.
-    ensure_installed(_STORE_SNAP, channel='latest/stable')
+    ensure_installed_store(_STORE_SNAP, channel='latest/stable')
     with pytest.raises(_errors._NoUpdatesAvailableError) as ctx:
         retry_on_rate_limit(_client.post)(
             f'/v2/snaps/{_STORE_SNAP}', body={'action': 'refresh', 'channel': 'latest/stable'}
@@ -95,7 +95,7 @@ def test_post_snap_no_update_available():
 def test_post_waits_for_async_change():
     # POST for an async operation waits until the change completes and does not raise.
     # Last test needing the store snap — leaves it removed.
-    ensure_installed(_STORE_SNAP)
+    ensure_installed_store(_STORE_SNAP)
     _client.post(f'/v2/snaps/{_STORE_SNAP}', body={'action': 'remove'})
     # Verify the snap is actually gone.
     with pytest.raises(_errors._NotFoundError):

--- a/snap/tests/functional/test_confinement.py
+++ b/snap/tests/functional/test_confinement.py
@@ -10,7 +10,8 @@ that requires it (``ensureInstallPreconditions`` in snapd's ``overlord/snapstate
 an installed classic snap keeps classic confinement on refresh without the flag, and the flag is
 dropped for a revision that doesn't require it. So confinement follows the revision both ways,
 and no value of ``classic`` changes the confinement of a revision already installed -- which is
-why :func:`charmlibs.snap.ensure` doesn't compare it against a snap's current confinement.
+why :func:`charmlibs.snap.ensure_installed` doesn't compare it against a snap's current
+confinement.
 
 These need one snap name whose revisions differ in confinement, so they use locally-built snaps:
 ``test-conf-snap`` 1.0 is strict, 2.0 and 3.0 are classic. Sideloading reaches the same flag
@@ -91,12 +92,12 @@ def test_flag_is_silently_dropped_for_a_strict_revision():
     assert snap.list_one(_SNAP).classic is False
 
 
-def test_ensure_does_not_refresh_an_installed_snap_to_change_confinement():
+def test_ensure_installed_does_not_refresh_an_installed_snap_to_change_confinement():
     # The library-level consequence: a strict snap that is already on the requested revision is
     # left alone even when classic=True is passed, because a refresh could not make it classic.
     install_local(_STRICT, dangerous=True)
     revision = snap.list_one(_SNAP).revision
-    assert snap.ensure(_SNAP, revision=revision, classic=True) is False
+    assert snap.ensure_installed(_SNAP, revision=revision, classic=True) is False
     info = snap.list_one(_SNAP)
     assert info.revision == revision
     assert info.classic is False

--- a/snap/tests/functional/test_functions.py
+++ b/snap/tests/functional/test_functions.py
@@ -13,7 +13,7 @@ import pytest
 
 from charmlibs.snap import _errors, _functions
 from charmlibs.snap import _snapd_snaps as _snapd
-from conftest import ensure_installed, ensure_removed, list_channels
+from conftest import ensure_installed_store, ensure_removed, list_channels
 
 # The smallest classic-confined snap in the store, used wherever a test needs classic
 # confinement rather than a particular snap. Published by snapd:
@@ -43,7 +43,7 @@ _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
 
 def test_ensure_installed_revision_no_op_if_same_revision():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     current_revision = _snapd.list_one(_SNAP).revision
     result = _functions.ensure_installed(_SNAP, revision=int(current_revision))
     assert result is False
@@ -52,7 +52,7 @@ def test_ensure_installed_revision_no_op_if_same_revision():
 def test_ensure_installed_revision_no_op_if_same_revision_and_update_true():
     # update is ignored when a revision is specified: the revision fully determines which
     # revision to be on, so there's nothing to update to.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     current_revision = _snapd.list_one(_SNAP).revision
     result = _functions.ensure_installed(_SNAP, revision=int(current_revision), update=True)
     assert result is False
@@ -61,7 +61,7 @@ def test_ensure_installed_revision_no_op_if_same_revision_and_update_true():
 def test_ensure_installed_revision_refreshes_on_different_revision():
     # The target revision is taken from the alternate channel rather than by subtracting one
     # from the installed revision: adjacent revision numbers need not exist in the store.
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     other_revision = list_channels(_SNAP)[_ALT_CHANNEL].revision
     assert _snapd.list_one(_SNAP).revision != other_revision
     did_something = _functions.ensure_installed(_SNAP, revision=int(other_revision))
@@ -70,32 +70,32 @@ def test_ensure_installed_revision_refreshes_on_different_revision():
 
 
 def test_ensure_installed_no_op_update_false():
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     result = _functions.ensure_installed(_SNAP, channel=_CHANNEL, update=False)
     assert result is False
 
 
 def test_ensure_installed_no_op_normalized_channel():
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     result = _functions.ensure_installed(_SNAP, channel='latest', update=False)
     assert result is False
 
 
 def test_ensure_installed_no_op_stable_normalized():
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     result = _functions.ensure_installed(_SNAP, channel='stable', update=False)
     assert result is False
 
 
 def test_ensure_installed_refreshes_on_different_channel():
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     did_something = _functions.ensure_installed(_SNAP, channel=_ALT_CHANNEL)
     assert did_something is True
     assert _snapd.list_one(_SNAP).tracking == _ALT_CHANNEL
 
 
 def test_ensure_installed_no_updates_available_returns_false():
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     # Already up-to-date — no updates available.
     result = _functions.ensure_installed(_SNAP, channel=_CHANNEL)
     assert result is False
@@ -266,6 +266,6 @@ def test_ensure_installed_empty_channel_installs_on_default_channel() -> None:
 def test_ensure_installed_empty_channel_refreshes_when_installed() -> None:
     # channel='' is falsy, so ensure_installed skips the channel-mismatch branch
     # and falls through to the update-check refresh (no-op here).
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     result = _functions.ensure_installed(_SNAP, channel='')
     assert result is False

--- a/snap/tests/functional/test_functions.py
+++ b/snap/tests/functional/test_functions.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Functional tests for _functions: ensure.
+"""Functional tests for _functions: ensure_installed.
 
 Tests are ordered to minimise snap install/remove churn.  All tests that need
 the snap *installed* run first, then install-from-removed tests, then error
@@ -28,7 +28,7 @@ _CHANNEL = 'latest/stable'
 _ALT_CHANNEL = 'latest/edge'
 
 # hello-world is the one snap whose channels all carry the *same* revision, which is the
-# precondition for test_ensure_same_revision_different_channel_switches_tracking below.
+# precondition for test_ensure_installed_same_revision_different_channel_switches_tracking below.
 # It is used for that test alone; everything else here uses _SNAP.
 _SHARED_REVISION_SNAP = 'hello-world'
 
@@ -42,62 +42,62 @@ _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_revision_no_op_if_same_revision():
+def test_ensure_installed_revision_no_op_if_same_revision():
     ensure_installed(_SNAP)
     current_revision = _snapd.list_one(_SNAP).revision
-    result = _functions.ensure(_SNAP, revision=int(current_revision))
+    result = _functions.ensure_installed(_SNAP, revision=int(current_revision))
     assert result is False
 
 
-def test_ensure_revision_no_op_if_same_revision_and_update_true():
+def test_ensure_installed_revision_no_op_if_same_revision_and_update_true():
     # update is ignored when a revision is specified: the revision fully determines which
     # revision to be on, so there's nothing to update to.
     ensure_installed(_SNAP)
     current_revision = _snapd.list_one(_SNAP).revision
-    result = _functions.ensure(_SNAP, revision=int(current_revision), update=True)
+    result = _functions.ensure_installed(_SNAP, revision=int(current_revision), update=True)
     assert result is False
 
 
-def test_ensure_revision_refreshes_on_different_revision():
+def test_ensure_installed_revision_refreshes_on_different_revision():
     # The target revision is taken from the alternate channel rather than by subtracting one
     # from the installed revision: adjacent revision numbers need not exist in the store.
     ensure_installed(_SNAP, channel=_CHANNEL)
     other_revision = list_channels(_SNAP)[_ALT_CHANNEL].revision
     assert _snapd.list_one(_SNAP).revision != other_revision
-    did_something = _functions.ensure(_SNAP, revision=int(other_revision))
+    did_something = _functions.ensure_installed(_SNAP, revision=int(other_revision))
     assert did_something is True
     assert _snapd.list_one(_SNAP).revision == other_revision
 
 
-def test_ensure_no_op_update_false():
+def test_ensure_installed_no_op_update_false():
     ensure_installed(_SNAP, channel=_CHANNEL)
-    result = _functions.ensure(_SNAP, channel=_CHANNEL, update=False)
+    result = _functions.ensure_installed(_SNAP, channel=_CHANNEL, update=False)
     assert result is False
 
 
-def test_ensure_no_op_normalized_channel():
+def test_ensure_installed_no_op_normalized_channel():
     ensure_installed(_SNAP, channel=_CHANNEL)
-    result = _functions.ensure(_SNAP, channel='latest', update=False)
+    result = _functions.ensure_installed(_SNAP, channel='latest', update=False)
     assert result is False
 
 
-def test_ensure_no_op_stable_normalized():
+def test_ensure_installed_no_op_stable_normalized():
     ensure_installed(_SNAP, channel=_CHANNEL)
-    result = _functions.ensure(_SNAP, channel='stable', update=False)
+    result = _functions.ensure_installed(_SNAP, channel='stable', update=False)
     assert result is False
 
 
-def test_ensure_refreshes_on_different_channel():
+def test_ensure_installed_refreshes_on_different_channel():
     ensure_installed(_SNAP, channel=_CHANNEL)
-    did_something = _functions.ensure(_SNAP, channel=_ALT_CHANNEL)
+    did_something = _functions.ensure_installed(_SNAP, channel=_ALT_CHANNEL)
     assert did_something is True
     assert _snapd.list_one(_SNAP).tracking == _ALT_CHANNEL
 
 
-def test_ensure_no_updates_available_returns_false():
+def test_ensure_installed_no_updates_available_returns_false():
     ensure_installed(_SNAP, channel=_CHANNEL)
     # Already up-to-date — no updates available.
-    result = _functions.ensure(_SNAP, channel=_CHANNEL)
+    result = _functions.ensure_installed(_SNAP, channel=_CHANNEL)
     assert result is False
 
 
@@ -106,48 +106,49 @@ def test_ensure_no_updates_available_returns_false():
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_revision_installs_if_not_present():
+def test_ensure_installed_revision_installs_if_not_present():
     ensure_removed(_SNAP)
     revision = list_channels(_SNAP)[_ALT_CHANNEL].revision
-    did_something = _functions.ensure(_SNAP, revision=int(revision))
+    did_something = _functions.ensure_installed(_SNAP, revision=int(revision))
     assert did_something is True
     assert _snapd.list_one(_SNAP).revision == revision
 
 
-def test_ensure_revision_without_channel_tracks_latest_stable():
+def test_ensure_installed_revision_without_channel_tracks_latest_stable():
     # Installing by revision alone always tracks latest/stable, whichever channel the revision
     # was found on. Recorded here because it means the next refresh -- including an automatic
     # one -- moves the snap to latest/stable's revision.
     ensure_removed(_SNAP)
     revision = list_channels(_SNAP)[_ALT_CHANNEL].revision
-    _functions.ensure(_SNAP, revision=int(revision))
+    _functions.ensure_installed(_SNAP, revision=int(revision))
     info = _snapd.list_one(_SNAP)
     assert info.revision == revision
     # Tracks the default channel even though the revision came from the alternate one.
     assert info.tracking == _CHANNEL
 
 
-def test_ensure_channel_and_revision_installs_and_tracks_channel():
+def test_ensure_installed_channel_and_revision_installs_and_tracks_channel():
     ensure_removed(_SNAP)
     edge = list_channels(_SNAP)[_ALT_CHANNEL].revision
-    did_something = _functions.ensure(_SNAP, channel=_ALT_CHANNEL, revision=edge)
+    did_something = _functions.ensure_installed(_SNAP, channel=_ALT_CHANNEL, revision=edge)
     assert did_something is True
     info = _snapd.list_one(_SNAP)
     assert info.revision == edge
     assert info.tracking == _ALT_CHANNEL
 
 
-def test_ensure_channel_and_revision_no_op_when_already_matching():
+def test_ensure_installed_channel_and_revision_no_op_when_already_matching():
     ensure_removed(_SNAP)
     edge = list_channels(_SNAP)[_ALT_CHANNEL].revision
-    _functions.ensure(_SNAP, channel=_ALT_CHANNEL, revision=edge)
-    result = _functions.ensure(_SNAP, channel=_ALT_CHANNEL, revision=edge)
+    _functions.ensure_installed(_SNAP, channel=_ALT_CHANNEL, revision=edge)
+    result = _functions.ensure_installed(_SNAP, channel=_ALT_CHANNEL, revision=edge)
     assert result is False
 
 
-def test_ensure_same_revision_different_channel_switches_tracking():
-    # When the revision is already installed but the snap tracks the wrong channel, ensure
-    # still refreshes -- snapd moves the tracking channel without changing the revision.
+def test_ensure_installed_same_revision_different_channel_switches_tracking():
+    # When the revision is already installed but the snap tracks the wrong channel,
+    # ensure_installed still refreshes -- snapd moves the tracking channel without changing
+    # the revision.
     #
     # This needs one revision that is on two channels at once, so it cannot use _SNAP, whose
     # channels deliberately hold different revisions. hello-world is kept solely for this.
@@ -157,30 +158,30 @@ def test_ensure_same_revision_different_channel_switches_tracking():
     if channels['latest/stable'].revision != revision:
         pytest.skip('latest/stable and latest/edge are on different revisions')
     ensure_removed(snap_name)
-    _functions.ensure(snap_name, channel=_ALT_CHANNEL, revision=revision)
-    did_something = _functions.ensure(snap_name, channel=_CHANNEL, revision=revision)
+    _functions.ensure_installed(snap_name, channel=_ALT_CHANNEL, revision=revision)
+    did_something = _functions.ensure_installed(snap_name, channel=_CHANNEL, revision=revision)
     assert did_something is True
     info = _snapd.list_one(snap_name)
     assert info.revision == revision
     assert info.tracking == _CHANNEL
 
 
-def test_ensure_installs_if_not_present():
+def test_ensure_installed_installs_if_not_present():
     ensure_removed(_SNAP)
-    did_something = _functions.ensure(_SNAP)
+    did_something = _functions.ensure_installed(_SNAP)
     assert did_something is True
     assert _snapd.list_one(_SNAP).name == _SNAP
 
 
-def test_ensure_installs_at_default_channel():
+def test_ensure_installed_installs_at_default_channel():
     ensure_removed(_SNAP)
-    _functions.ensure(_SNAP)
+    _functions.ensure_installed(_SNAP)
     assert _snapd.list_one(_SNAP).tracking == _CHANNEL
 
 
-def test_ensure_installs_at_specified_channel():
+def test_ensure_installed_installs_at_specified_channel():
     ensure_removed(_SNAP)
-    _functions.ensure(_SNAP, channel=_ALT_CHANNEL)
+    _functions.ensure_installed(_SNAP, channel=_ALT_CHANNEL)
     assert _snapd.list_one(_SNAP).tracking == _ALT_CHANNEL
 
 
@@ -189,24 +190,24 @@ def test_ensure_installs_at_specified_channel():
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_bad_channel_raises():
+def test_ensure_installed_bad_channel_raises():
     ensure_removed(_SNAP)
     with pytest.raises(_errors.APIError):
-        _functions.ensure(_SNAP, channel='not/a/real/channel')
+        _functions.ensure_installed(_SNAP, channel='not/a/real/channel')
 
 
-def test_ensure_revision_bad_revision_raises():
+def test_ensure_installed_revision_bad_revision_raises():
     ensure_removed(_SNAP)
     with pytest.raises(_errors.RevisionNotAvailableError):
-        _functions.ensure(_SNAP, revision=99999999)
+        _functions.ensure_installed(_SNAP, revision=99999999)
 
 
-def test_ensure_revision_not_on_channel_raises():
+def test_ensure_installed_revision_not_on_channel_raises():
     # The revision exists, but not on the requested channel: reported as a channel error.
     ensure_removed(_SNAP)
     absent_from_channel = int(list_channels(_SNAP)[_ALT_CHANNEL].revision)
     with pytest.raises(_errors.ChannelNotAvailableError):
-        _functions.ensure(_SNAP, channel=_CHANNEL, revision=absent_from_channel)
+        _functions.ensure_installed(_SNAP, channel=_CHANNEL, revision=absent_from_channel)
 
 
 # ---------------------------------------------------------------------------
@@ -214,26 +215,26 @@ def test_ensure_revision_not_on_channel_raises():
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_revision_installs_classic():
+def test_ensure_installed_revision_installs_classic():
     ensure_removed(_CLASSIC_SNAP)
     channels = list_channels(_CLASSIC_SNAP)
     channel = 'latest/stable' if 'latest/stable' in channels else next(iter(channels))
     revision = channels[channel].revision
-    _functions.ensure(_CLASSIC_SNAP, channel=channel, revision=revision, classic=True)
+    _functions.ensure_installed(_CLASSIC_SNAP, channel=channel, revision=revision, classic=True)
     info = _snapd.list_one(_CLASSIC_SNAP)
     assert info.classic is True
     assert info.revision == revision
 
 
-def test_ensure_needs_classic_raises():
+def test_ensure_installed_needs_classic_raises():
     ensure_removed(_CLASSIC_SNAP)
     with pytest.raises(_errors.NeedsClassicError):
-        _functions.ensure(_CLASSIC_SNAP)
+        _functions.ensure_installed(_CLASSIC_SNAP)
 
 
-def test_ensure_installs_classic():
+def test_ensure_installed_installs_classic():
     ensure_removed(_CLASSIC_SNAP)
-    _functions.ensure(_CLASSIC_SNAP, classic=True)
+    _functions.ensure_installed(_CLASSIC_SNAP, classic=True)
     assert _snapd.list_one(_CLASSIC_SNAP).classic is True
 
 
@@ -242,29 +243,29 @@ def test_ensure_installs_classic():
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_bad_snap_name_raises():
-    # ensure() finds the snap isn't installed and goes on to install it, so the store is what
-    # reports the name as missing -- not the local check that got there first.
+def test_ensure_installed_bad_snap_name_raises():
+    # ensure_installed() finds the snap isn't installed and goes on to install it, so the
+    # store is what reports the name as missing -- not the local check that got there first.
     with pytest.raises(_errors.NotInStoreError) as ctx:
-        _functions.ensure(_ABSENT_SNAP)
+        _functions.ensure_installed(_ABSENT_SNAP)
     assert type(ctx.value) is _errors.NotInStoreError
 
 
 # ---------------------------------------------------------------------------
-# ensure with channel='' — treated as no channel (empty string is falsy)
+# ensure_installed with channel='' — treated as no channel (empty string is falsy)
 # ---------------------------------------------------------------------------
 
 
-def test_ensure_empty_channel_installs_on_default_channel() -> None:
+def test_ensure_installed_empty_channel_installs_on_default_channel() -> None:
     ensure_removed(_SNAP)
-    did_something = _functions.ensure(_SNAP, channel='')
+    did_something = _functions.ensure_installed(_SNAP, channel='')
     assert did_something is True
     assert _snapd.list_one(_SNAP).tracking == _CHANNEL
 
 
-def test_ensure_empty_channel_refreshes_when_installed() -> None:
-    # channel='' is falsy, so ensure skips the channel-mismatch branch
+def test_ensure_installed_empty_channel_refreshes_when_installed() -> None:
+    # channel='' is falsy, so ensure_installed skips the channel-mismatch branch
     # and falls through to the update-check refresh (no-op here).
     ensure_installed(_SNAP, channel=_CHANNEL)
-    result = _functions.ensure(_SNAP, channel='')
+    result = _functions.ensure_installed(_SNAP, channel='')
     assert result is False

--- a/snap/tests/functional/test_snapd_aliases.py
+++ b/snap/tests/functional/test_snapd_aliases.py
@@ -12,7 +12,7 @@ import typing
 import pytest
 
 from charmlibs.snap import _client, _errors, _snapd_aliases
-from conftest import ensure_installed, ensure_installed_local, ensure_removed
+from conftest import ensure_installed_local, ensure_installed_store, ensure_removed
 
 if typing.TYPE_CHECKING:
     from collections.abc import Mapping
@@ -79,7 +79,7 @@ def _assert_alias_exists(app: str = _APP) -> None:
 
 
 def test_alias_creates_alias():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _cleanup_alias()
     _snapd_aliases.alias(_SNAP, _APP, _ALIAS)
     _assert_alias_exists()
@@ -88,7 +88,7 @@ def test_alias_creates_alias():
 
 def test_alias_nonexistent_app_raises_snap_change_error():
     # Aliasing to an app that doesn't exist fails as an async change error.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _cleanup_alias()
     with pytest.raises(_errors.ChangeError):
         _snapd_aliases.alias(_SNAP, 'nonexistent-app', _ALIAS)
@@ -97,7 +97,7 @@ def test_alias_nonexistent_app_raises_snap_change_error():
 
 def test_alias_is_idempotent():
     # Calling alias() again with the same snap, app, and alias name succeeds silently.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _cleanup_alias()
     _snapd_aliases.alias(_SNAP, _APP, _ALIAS)
     _assert_alias_exists()
@@ -109,7 +109,7 @@ def test_alias_is_idempotent():
 def test_alias_reassigns_within_same_snap():
     # Calling alias() with the same alias name but a different app of the same snap
     # silently reassigns the alias — no error raised.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _cleanup_alias()
     _snapd_aliases.alias(_SNAP, _APP, _ALIAS)
     _assert_alias_exists()
@@ -120,7 +120,7 @@ def test_alias_reassigns_within_same_snap():
 
 def test_alias_name_conflicts_with_snap_command_namespace():
     # Using a snap's own name as the alias name conflicts with its command namespace.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _cleanup_alias()
     with pytest.raises(_errors.ChangeError) as ctx:
         _snapd_aliases.alias(_SNAP, _APP, _SNAP)  # Alias name = snap name.
@@ -133,7 +133,7 @@ def test_alias_name_conflicts_with_snap_command_namespace():
 
 
 def test_unalias_removes_alias():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _snapd_aliases.alias(_SNAP, _APP, _ALIAS)
     _assert_alias_exists()
     _snapd_aliases.unalias(_ALIAS)
@@ -144,7 +144,7 @@ def test_unalias_removes_alias():
 
 def test_unalias_nonexistent_alias_raises():
     # Unaliasing an alias that doesn't exist raises a base Error (no kind).
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _cleanup_alias()
     with pytest.raises(_errors.Error) as ctx:
         _snapd_aliases.unalias(_ALIAS)
@@ -159,7 +159,7 @@ def test_unalias_nonexistent_alias_raises():
 
 def test_alias_duplicate_name_different_snap_raises():
     # An alias name already claimed by another snap raises ChangeError.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     ensure_installed_local(_OTHER_SNAP)
     _cleanup_alias()
     _snapd_aliases.alias(_SNAP, _APP, _ALIAS)
@@ -198,7 +198,7 @@ def test_alias_not_installed_snap_raises():
 
 @pytest.mark.parametrize('value', ['', ' ', '\t'])
 def test_alias_rejects_empty_and_blank_fields(value: str):
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     for args in ((value, _APP, _ALIAS), (_SNAP, value, _ALIAS), (_SNAP, _APP, value)):
         with pytest.raises(ValueError):
             _snapd_aliases.alias(*args)
@@ -222,7 +222,7 @@ def test_raw_alias_empty_or_blank_snap_is_not_installed(snap_name: str):
 def test_raw_alias_empty_or_blank_app_fails_the_change(app: str):
     # The app name is not validated up front by snapd: the change is created and only fails once
     # the alias is set up, which is a round trip and a change for a value that can never work.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _cleanup_alias()
     with pytest.raises(_errors.ChangeError) as ctx:
         _client.post(
@@ -233,7 +233,7 @@ def test_raw_alias_empty_or_blank_app_fails_the_change(app: str):
 
 @pytest.mark.parametrize('alias_name', ['', ' '])
 def test_raw_alias_empty_or_blank_alias_is_invalid(alias_name: str):
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     with pytest.raises(_errors.APIError) as ctx:
         _client.post(
             '/v2/aliases',
@@ -257,7 +257,7 @@ def test_raw_unalias_empty_or_blank_alias_is_not_found(alias_name: str):
 def test_unalias_after_snap_removed_raises():
     # Aliases don't survive snap removal; unaliasing after removal raises the same error
     # as attempting to remove an alias that was never created.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _cleanup_alias()
     _snapd_aliases.alias(_SNAP, _APP, _ALIAS)
     ensure_removed(_SNAP)

--- a/snap/tests/functional/test_snapd_conf.py
+++ b/snap/tests/functional/test_snapd_conf.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from charmlibs.snap import _client, _errors, _snapd_conf
-from conftest import SNAPS_DIR, ensure_installed, ensure_removed, install_local
+from conftest import SNAPS_DIR, ensure_installed_store, ensure_removed, install_local
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -42,49 +42,49 @@ def _cleanup(*keys: str) -> None:
 
 
 def test_set_and_get_bool_true():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: True})
     assert _snapd_conf.get_one(_SNAP, _KEY) is True
     _cleanup()
 
 
 def test_set_and_get_bool_false():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: False})
     assert _snapd_conf.get_one(_SNAP, _KEY) is False
     _cleanup()
 
 
 def test_set_and_get_integer():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 42})
     assert _snapd_conf.get_one(_SNAP, _KEY) == 42
     _cleanup()
 
 
 def test_set_and_get_float():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 3.14})
     assert _snapd_conf.get_one(_SNAP, _KEY) == 3.14
     _cleanup()
 
 
 def test_set_and_get_string():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'hello'})
     assert _snapd_conf.get_one(_SNAP, _KEY) == 'hello'
     _cleanup()
 
 
 def test_set_and_get_list():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: [1, 2, 3]})
     assert _snapd_conf.get_one(_SNAP, _KEY) == [1, 2, 3]
     _cleanup()
 
 
 def test_set_and_get_dict():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: {'a': 1, 'b': 'two'}})
     assert _snapd_conf.get_one(_SNAP, _KEY) == {'a': 1, 'b': 'two'}
     # Dotted notation reads back a single nested value.
@@ -94,7 +94,7 @@ def test_set_and_get_dict():
 
 def test_set_null_unsets_key():
     # Setting a key to None (JSON null) unsets it at the top level.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'hello'})
     assert _snapd_conf.get(_SNAP, [_KEY]).get(_KEY) == 'hello'
     _snapd_conf.set(_SNAP, {_KEY: None})
@@ -110,7 +110,7 @@ def test_set_null_unsets_key():
 def test_get_all_keys():
     # get() with no keys returns all config as a dict. Nested values are returned in full:
     # the returned dict is keyed by top-level option, and each value keeps its full structure.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value', _KEY2: {'nested': {'deep': 1}}})
     config = _snapd_conf.get(_SNAP)
     assert isinstance(config, dict)
@@ -123,7 +123,7 @@ def test_get_mixed_dotted_and_non_dotted_keys():
     # Requesting an option and a dotted sub-key of it returns both as separate entries:
     # the plain key yields the full subtree, the dotted key yields the leaf, keyed by the
     # literal dotted string. The two do not merge or collide.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: {'nested': 'value'}})
     result = _snapd_conf.get(_SNAP, [_KEY, f'{_KEY}.nested'])
     assert result == {_KEY: {'nested': 'value'}, f'{_KEY}.nested': 'value'}
@@ -131,7 +131,7 @@ def test_get_mixed_dotted_and_non_dotted_keys():
 
 
 def test_get_specific_keys_returns_subset():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'alpha', _KEY2: 'beta'})
     subset = _snapd_conf.get(_SNAP, [_KEY])
     assert _KEY in subset
@@ -140,7 +140,7 @@ def test_get_specific_keys_returns_subset():
 
 
 def test_get_multiple_specific_keys():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'alpha', _KEY2: 'beta'})
     result = _snapd_conf.get(_SNAP, [_KEY, _KEY2])
     assert result[_KEY] == 'alpha'
@@ -149,7 +149,7 @@ def test_get_multiple_specific_keys():
 
 
 def test_get_option_not_found_raises():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get(_SNAP, ['key-that-should-not-exist'])
     assert ctx.value.kind == 'option-not-found'
@@ -157,7 +157,7 @@ def test_get_option_not_found_raises():
 
 
 def test_get_option_not_found_value_contains_snap_and_key():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get(_SNAP, ['key-that-should-not-exist'])
     value = str(ctx.value.value)
@@ -217,7 +217,7 @@ def test_raw_get_all_not_installed_snap_returns_empty_dict():
 def test_get_all_installed_snap_with_no_config_returns_empty_dict():
     # The snap has no configure hook, so it can never have configuration. Unlike the CLI
     # (`snap get <snap>` errors with 'has no configuration'), get() returns an empty dict.
-    ensure_installed(_NO_HOOK_SNAP)
+    ensure_installed_store(_NO_HOOK_SNAP)
     assert _snapd_conf.get(_NO_HOOK_SNAP) == {}
 
 
@@ -231,7 +231,7 @@ def test_get_all_installed_snap_with_no_config_returns_empty_dict():
 
 
 def test_get_one_returns_the_value_not_a_dict():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value'})
     assert _snapd_conf.get_one(_SNAP, _KEY) == 'value'
     assert _snapd_conf.get(_SNAP, [_KEY]) == {_KEY: 'value'}
@@ -241,14 +241,14 @@ def test_get_one_returns_the_value_not_a_dict():
 def test_get_one_returns_a_subtree_for_a_key_that_names_one():
     # A key naming a subtree yields the whole nested dict -- get_one unwraps get's result by
     # one level, it doesn't flatten the value.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: {'nested': {'deep': 1}}})
     assert _snapd_conf.get_one(_SNAP, _KEY) == {'nested': {'deep': 1}}
     _cleanup()
 
 
 def test_get_one_dotted_key_returns_the_leaf():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: {'nested': 'value'}})
     assert _snapd_conf.get_one(_SNAP, f'{_KEY}.nested') == 'value'
     _cleanup()
@@ -256,7 +256,7 @@ def test_get_one_dotted_key_returns_the_leaf():
 
 def test_get_one_missing_key_raises_option_not_found():
     # Never a KeyError: get raises before there is a dict to subscript.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get_one(_SNAP, 'key-that-should-not-exist')
     assert ctx.value.kind == 'option-not-found'
@@ -294,7 +294,7 @@ def test_get_one_invalid_snap_name_raises_value_error(snap: str):
 
 
 def test_get_bare_string_is_one_key():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value'})
     assert _snapd_conf.get(_SNAP, _KEY) == {_KEY: 'value'}
     assert _snapd_conf.get(_SNAP, _KEY) == _snapd_conf.get(_SNAP, [_KEY])
@@ -302,7 +302,7 @@ def test_get_bare_string_is_one_key():
 
 
 def test_get_bare_string_dotted_key():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: {'nested': 'value'}})
     assert _snapd_conf.get(_SNAP, f'{_KEY}.nested') == {f'{_KEY}.nested': 'value'}
     _cleanup()
@@ -315,7 +315,7 @@ def test_get_bare_string_is_validated_like_a_key_in_a_list():
 
 
 def test_unset_bare_string_is_one_key():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value'})
     _snapd_conf.unset(_SNAP, _KEY)
     with pytest.raises(_errors.OptionNotFoundError):
@@ -331,7 +331,7 @@ def test_get_empty_keys_returns_empty_dict():
     # keys=[] is a deliberate "no keys requested" query, distinct from the CLI-following
     # default of keys=None ("give me everything"). It never reaches the conf endpoint, but
     # still confirms the snap is installed before returning {}.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value'})
     assert _snapd_conf.get(_SNAP, []) == {}
     _cleanup()
@@ -361,7 +361,7 @@ def test_raw_get_keys_that_parse_away_returns_the_full_config(keys: str):
     # list whose keys all parse away doesn't match that check, so it used to fall through to
     # being joined into the 'keys' query parameter. snapd's parsing of that treats it the same
     # as no 'keys' param at all, so the full config comes back -- keys=None, not keys=[].
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value'})
     full_config = _snapd_conf.get(_SNAP)
     assert full_config != {}
@@ -384,7 +384,7 @@ def test_raw_get_padded_key_returns_the_stripped_key():
     # Whitespace is stripped from each key, so a padded key addresses the key it names once
     # stripped, and the result is keyed by the stripped name -- meaning result[' key '] would
     # raise KeyError on a request that appeared to succeed.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value'})
     assert _client.get(f'/v2/snaps/{_SNAP}/conf', query={'keys': f' {_KEY} '}) == {_KEY: 'value'}
     _cleanup()
@@ -393,7 +393,7 @@ def test_raw_get_padded_key_returns_the_stripped_key():
 def test_raw_get_comma_in_a_key_queries_two_keys():
     # A comma inside one key is not escaped by url-encoding it: snapd decodes the parameter
     # before splitting, so one key becomes two. This is why a comma is rejected.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value', _KEY2: 'value2'})
     result = _client.get(f'/v2/snaps/{_SNAP}/conf', query={'keys': f'{_KEY},{_KEY2}'})
     assert result == {_KEY: 'value', _KEY2: 'value2'}
@@ -406,7 +406,7 @@ def test_raw_get_comma_in_a_key_queries_two_keys():
 
 
 def test_unset_key():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'hello'})
     assert _snapd_conf.get(_SNAP, [_KEY]).get(_KEY) == 'hello'
     _snapd_conf.unset(_SNAP, [_KEY])
@@ -416,18 +416,18 @@ def test_unset_key():
 
 def test_unset_nonexistent_key_no_error():
     # Unsetting a key that doesn't exist should not raise.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.unset(_SNAP, ['key-that-does-not-exist'])
 
 
 def test_unset_nonexistent_key_deeply_dotted_no_error():
     # Unsetting a dotted-path key that doesn't exist should not raise.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.unset(_SNAP, ['key-that-does-not-exist.nested.deep'])
 
 
 def test_unset_multiple_keys():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'val1', _KEY2: 'val2'})
     _snapd_conf.unset(_SNAP, [_KEY, _KEY2])
     with pytest.raises(_errors.OptionNotFoundError):
@@ -437,7 +437,7 @@ def test_unset_multiple_keys():
 
 
 def test_unset_empty_keys_is_noop():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'value'})
     _snapd_conf.unset(_SNAP, [])  # Should not raise, and should not touch existing config.
     assert _snapd_conf.get_one(_SNAP, _KEY) == 'value'
@@ -475,7 +475,7 @@ def test_unset_not_installed_snap_raises_snap_not_found():
 
 
 def test_set_multiple_keys_at_once():
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     values: dict[str, Any] = {_KEY: 'v1', _KEY2: 'v2'}
     _snapd_conf.set(_SNAP, values)
     result = _snapd_conf.get(_SNAP, [_KEY, _KEY2])
@@ -487,7 +487,7 @@ def test_set_multiple_keys_at_once():
 def test_set_empty_dict_is_noop():
     # set(snap, {}) is a no-op — the API accepts an empty body without error, and existing
     # configuration is left untouched (an empty body does NOT unset all keys).
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'before-empty-set'})
     _snapd_conf.set(_SNAP, {})
     assert _snapd_conf.get_one(_SNAP, _KEY) == 'before-empty-set'
@@ -507,7 +507,7 @@ def test_set_empty_dict_is_noop():
 @pytest.mark.parametrize('key', ['', ' ', '\t'])
 @pytest.mark.parametrize('func', [_snapd_conf.set, _snapd_conf.unset], ids=['set', 'unset'])
 def test_set_and_unset_reject_empty_and_blank_keys(func: Any, key: str):
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(ValueError):
         func(_SNAP, {key: 'value'} if func is _snapd_conf.set else [key])
 
@@ -526,7 +526,7 @@ def test_raw_put_unusable_key_fails_the_change(key: str, expected: str):
     # snapd names the offending key verbatim, without stripping it, and fails the whole change.
     # The empty key is the odd one out: it's reported as an internal error rather than as an
     # invalid option name, which is the message a caller would otherwise have had to read.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.ChangeError) as ctx:
         _client.put(f'/v2/snaps/{_SNAP}/conf', body={key: 'value'})
     assert expected in ctx.value.message
@@ -541,7 +541,7 @@ def test_raw_put_unusable_key_fails_the_change(key: str, expected: str):
 @pytest.mark.parametrize('key', ['a.', '.a', 'a..b', '.'])
 def test_get_key_with_an_empty_dotted_segment_raises(key: str):
     # On the read side this is at least immediate: a synchronous APIError, no change, no hook.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_conf.get(_SNAP, [key])
     assert not ctx.value.kind
@@ -551,7 +551,7 @@ def test_get_key_with_an_empty_dotted_segment_raises(key: str):
 @pytest.mark.parametrize('key', ['a.', '.a', 'a..b', '.'])
 def test_set_key_with_an_empty_dotted_segment_fails_the_change(key: str):
     # On the write side it costs a round trip and a configure hook run before failing.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.ChangeError) as ctx:
         _snapd_conf.set(_SNAP, {key: 'value'})
     assert 'invalid option name: ""' in ctx.value.message
@@ -559,7 +559,7 @@ def test_set_key_with_an_empty_dotted_segment_fails_the_change(key: str):
 
 def test_raw_put_unusable_key_rolls_back_the_valid_keys():
     # The change is all-or-nothing, so a valid key sent alongside an unusable one is not applied.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'before'})
     with pytest.raises(_errors.ChangeError):
         _client.put(f'/v2/snaps/{_SNAP}/conf', body={'': 'value', _KEY: 'after'})
@@ -570,7 +570,7 @@ def test_raw_put_unusable_key_rolls_back_the_valid_keys():
 def test_get_mixed_keys_raises_option_not_found():
     # When some requested keys exist and some don't, the API raises option-not-found
     # for the first missing key rather than returning partial results.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: 'exists'})
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get(_SNAP, [_KEY, 'key-that-does-not-exist-xyz'])
@@ -580,7 +580,7 @@ def test_get_mixed_keys_raises_option_not_found():
 
 def test_unset_dotted_path_no_error():
     # unset() accepts dotted-path keys and the API handles them without error.
-    ensure_installed(_SNAP, channel='latest/edge')
+    ensure_installed_store(_SNAP, channel='latest/edge')
     _snapd_conf.set(_SNAP, {_KEY: {'nested': 'value'}})
     _snapd_conf.unset(_SNAP, [f'{_KEY}.nested'])  # Should not raise.
     _cleanup()
@@ -594,13 +594,13 @@ def test_unset_dotted_path_no_error():
 def test_set_no_configure_hook_raises_change_error():
     # set/unset run the snap's configure hook as an async change. This snap has no
     # configure hook, so snapd fails the change and we surface it as a ChangeError.
-    ensure_installed(_NO_HOOK_SNAP)
+    ensure_installed_store(_NO_HOOK_SNAP)
     with pytest.raises(_errors.ChangeError):
         _snapd_conf.set(_NO_HOOK_SNAP, {'any-key': 'value'})
 
 
 def test_unset_no_configure_hook_raises_change_error():
-    ensure_installed(_NO_HOOK_SNAP)
+    ensure_installed_store(_NO_HOOK_SNAP)
     with pytest.raises(_errors.ChangeError):
         _snapd_conf.unset(_NO_HOOK_SNAP, ['any-key'])
 
@@ -610,7 +610,7 @@ def test_set_empty_dict_no_configure_hook_is_noop():
     # when there is nothing to set (Optional: len(patch) == 0), so a missing hook is not an
     # error and the change completes as a no-op. Contrast test_set_no_configure_hook_*, where a
     # non-empty patch on the same hook-less snap does raise.
-    ensure_installed(_NO_HOOK_SNAP)
+    ensure_installed_store(_NO_HOOK_SNAP)
     _snapd_conf.set(_NO_HOOK_SNAP, {})  # Should not raise.
 
 

--- a/snap/tests/functional/test_snapd_conf_system.py
+++ b/snap/tests/functional/test_snapd_conf_system.py
@@ -18,7 +18,7 @@ CI containers.
 
 Ordering: the module needs no special ordering relative to other modules. It removes and
 restores the core snap within its own fixture, no other module depends on system configuration,
-and any snap a module needs is (re)installed via ensure_installed.
+and any snap a module needs is (re)installed via ensure_installed_store.
 """
 
 from __future__ import annotations
@@ -29,7 +29,7 @@ import pytest
 
 from charmlibs import snap
 from charmlibs.snap import _errors, _snapd_conf
-from conftest import ensure_installed, remove_core_blockers
+from conftest import ensure_installed_store, remove_core_blockers
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -53,9 +53,9 @@ def core_snap(request: pytest.FixtureRequest) -> Iterator[str]:
         remove_core_blockers()
         snap.remove('core')  # Errors loudly if an unmanaged snap still depends on core.
         yield request.param
-        ensure_installed('core')
+        ensure_installed_store('core')
     else:
-        ensure_installed('core')  # A no-op if already installed.
+        ensure_installed_store('core')  # A no-op if already installed.
         yield request.param
 
 
@@ -123,7 +123,9 @@ def test_removing_core_snap_deletes_stored_system_config():
     # snap deletes them like any other snap's config, while options computed live by snapd
     # (system.hostname and so on) survive. This test manages the core snap itself, so it does
     # not use the core_snap fixture.
-    ensure_installed('core')  # Ensure installed, so its removal actually deletes stored config.
+    ensure_installed_store(
+        'core'
+    )  # Ensure installed, so its removal actually deletes stored config.
     _snapd_conf.set('system', {_OPTION: 3})
     assert _snapd_conf.get('system', [_OPTION]) == {_OPTION: 3}
     remove_core_blockers()  # Base-less snaps would otherwise block core removal.
@@ -135,5 +137,5 @@ def test_removing_core_snap_deletes_stored_system_config():
         # ...while computed configuration remains, so bare get is not empty.
         assert 'system' in _snapd_conf.get('system')
     finally:
-        ensure_installed('core')  # Restore the core snap for other tests.
+        ensure_installed_store('core')  # Restore the core snap for other tests.
         _snapd_conf.unset('system', [_OPTION])  # A no-op if the removal already wiped it.

--- a/snap/tests/functional/test_snapd_interfaces_system.py
+++ b/snap/tests/functional/test_snapd_interfaces_system.py
@@ -32,7 +32,7 @@ from charmlibs import snap
 from charmlibs.snap import _client, _errors, _snapd_interfaces
 from conftest import (
     SNAPS_DIR,
-    ensure_installed,
+    ensure_installed_store,
     ensure_removed,
     install_local,
     remove_core_blockers,
@@ -70,9 +70,9 @@ def core_snap(request: pytest.FixtureRequest) -> Iterator[str]:
         remove_core_blockers()
         snap.remove('core')  # Errors loudly if an unmanaged snap still depends on core.
         yield request.param
-        ensure_installed('core')
+        ensure_installed_store('core')
     else:
-        ensure_installed('core')  # A no-op if already installed.
+        ensure_installed_store('core')  # A no-op if already installed.
         yield request.param
 
 

--- a/snap/tests/functional/test_snapd_snaps.py
+++ b/snap/tests/functional/test_snapd_snaps.py
@@ -18,7 +18,13 @@ import pytest
 
 from charmlibs.snap import _client, _errors
 from charmlibs.snap import _snapd_snaps as _snapd
-from conftest import _list, ensure_installed, ensure_removed, list_channels, retry_on_rate_limit
+from conftest import (
+    _list,
+    ensure_installed_store,
+    ensure_removed,
+    list_channels,
+    retry_on_rate_limit,
+)
 
 # Snapd's own test snap, used for everything that needs real store semantics. Its two open
 # channels on the latest track carry *different* revisions (stable is newer than edge), so a
@@ -50,7 +56,7 @@ _ABSENT_SNAP = 'this-snap-does-not-exist-xyz-abc-123'
 
 
 def test_list_one_installed():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     info = _snapd.list_one(_SNAP)
     assert info.name == _SNAP
     assert info.tracking
@@ -62,20 +68,20 @@ def test_list_one_installed():
 
 
 def test_list_one_fields():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     info = _snapd.list_one(_SNAP)
     assert info.classic is False
     assert info.hold is None
 
 
 def test_install_already_installed_returns_false():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     result = _snapd.install(_SNAP)
     assert result is False
 
 
 def test_refresh_no_updates_returns_false():
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     result = retry_on_rate_limit(_snapd.refresh)(_SNAP, channel=_CHANNEL)
     assert result is False
     assert _snapd.list_one(_SNAP).tracking == _CHANNEL
@@ -86,7 +92,7 @@ def test_refresh_channel():
     # revision, since the two channels hold different revisions. Asserting the revision as
     # well as the tracking is the point: a refresh that updated only the tracking would be
     # indistinguishable from a correct one if both channels held the same revision.
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     channels = list_channels(_SNAP)
     assert channels[_CHANNEL].revision != channels[_ALT_CHANNEL].revision
     retry_on_rate_limit(_snapd.refresh)(_SNAP, channel=_ALT_CHANNEL)
@@ -96,21 +102,21 @@ def test_refresh_channel():
 
 
 def test_refresh_invalid_channel_raises():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     with pytest.raises(_errors.ChannelNotAvailableError) as ctx:
         retry_on_rate_limit(_snapd.refresh)(_SNAP, channel='garbage')
     assert ctx.value.kind == 'snap-channel-not-available'
 
 
 def test_refresh_revision_not_available_raises():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     with pytest.raises(_errors.RevisionNotAvailableError) as ctx:
         retry_on_rate_limit(_snapd.refresh)(_SNAP, revision=99999999)
     assert ctx.value.kind == 'snap-revision-not-available'
 
 
 def test_hold_with_duration():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     try:
         _snapd.hold(_SNAP, duration=datetime.timedelta(days=2))
         info = _snapd.list_one(_SNAP)
@@ -121,7 +127,7 @@ def test_hold_with_duration():
 
 
 def test_hold_forever():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     try:
         _snapd.hold(_SNAP)
         info = _snapd.list_one(_SNAP)
@@ -133,7 +139,7 @@ def test_hold_forever():
 
 def test_hold_already_held_no_error():
     # Holding an already-held snap is idempotent — no error is raised.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     try:
         _snapd.hold(_SNAP)
         _snapd.hold(_SNAP)  # Second hold should not raise.
@@ -142,7 +148,7 @@ def test_hold_already_held_no_error():
 
 
 def test_unhold():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _snapd.hold(_SNAP)
     assert _snapd.list_one(_SNAP).hold is not None
     _snapd.unhold(_SNAP)
@@ -151,7 +157,7 @@ def test_unhold():
 
 def test_remove():
     # Last test in the "installed" block — leaves the snap removed for the next block.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _snapd.remove(_SNAP)
     with pytest.raises(_errors.NotInstalledError):
         _snapd.list_one(_SNAP)
@@ -236,11 +242,11 @@ def test_unhold_not_installed_no_error():
 def test_hold_does_not_survive_removal():
     # Why unhold treats an absent snap as nothing to do rather than an error: removing a snap
     # takes its hold with it, so an absent snap cannot be holding back a refresh.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     _snapd.hold(_SNAP)
     assert _snapd.list_one(_SNAP).hold is not None
     _snapd.remove(_SNAP)
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     assert _snapd.list_one(_SNAP).hold is None
     ensure_removed(_SNAP)
 
@@ -361,7 +367,7 @@ def test_install_revision_not_on_channel_raises():
 
 
 def test_refresh_channel_and_revision():
-    ensure_installed(_SNAP, channel=_CHANNEL)
+    ensure_installed_store(_SNAP, channel=_CHANNEL)
     edge = list_channels(_SNAP)[_ALT_CHANNEL].revision
     retry_on_rate_limit(_snapd.refresh)(_SNAP, channel=_ALT_CHANNEL, revision=edge)
     info = _snapd.list_one(_SNAP)
@@ -373,7 +379,7 @@ def test_refresh_revision_already_installed_still_refreshes():
     # Snapd runs a full refresh when a revision is specified, even if that revision is already
     # installed, so refresh reports that it did something. ensure_installed() relies on knowing
     # this.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     current = _snapd.list_one(_SNAP).revision
     result = retry_on_rate_limit(_snapd.refresh)(_SNAP, revision=current)
     assert result is True
@@ -410,8 +416,8 @@ def test_refresh_retains_the_previous_revision():
 
 
 def test_list_several_snaps_in_one_request():
-    ensure_installed(_SNAP)
-    ensure_installed(_CLASSIC_SNAP, classic=True)
+    ensure_installed_store(_SNAP)
+    ensure_installed_store(_CLASSIC_SNAP, classic=True)
     listed = {i.name: i for i in _list([_SNAP, _CLASSIC_SNAP])}
     assert set(listed) == {_SNAP, _CLASSIC_SNAP}
     # The collection agrees with the per-snap endpoint list_one reads.
@@ -420,7 +426,7 @@ def test_list_several_snaps_in_one_request():
 
 
 def test_list_bare_name_and_single_element_list_agree():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     assert [i.name for i in _list(_SNAP)] == [i.name for i in _list([_SNAP])]
 
 
@@ -428,7 +434,7 @@ def test_list_absent_snap_is_filtered_rather_than_an_error():
     # snapd filters instead of failing, so an absent name is simply missing from the result with
     # nothing to distinguish it from one that was never asked for. A plural API would have to
     # reconstruct the error client-side; list_one gets snapd's own, which is the shape we keep.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     assert [i.name for i in _list([_SNAP, _ABSENT_SNAP])] == [_SNAP]
     assert _list(_ABSENT_SNAP) == []
     with pytest.raises(_errors.NotInstalledError):
@@ -436,7 +442,7 @@ def test_list_absent_snap_is_filtered_rather_than_an_error():
 
 
 def test_list_no_names_lists_nothing_but_none_lists_everything():
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     assert _list([]) == []
     assert _list(None) != []
 
@@ -448,7 +454,7 @@ def test_raw_api_empty_snaps_value_lists_everything():
     # all of them -- the same quirk the conf 'keys' and logs 'names' parameters have.
     #
     # Compared by name: snapd does not return these in a stable order.
-    ensure_installed(_SNAP)
+    ensure_installed_store(_SNAP)
     everything = {i.name for i in _list(None)}
     assert everything
     result = _client.get('/v2/snaps', query={'snaps': ''})

--- a/snap/tests/functional/test_snapd_snaps.py
+++ b/snap/tests/functional/test_snapd_snaps.py
@@ -371,7 +371,8 @@ def test_refresh_channel_and_revision():
 
 def test_refresh_revision_already_installed_still_refreshes():
     # Snapd runs a full refresh when a revision is specified, even if that revision is already
-    # installed, so refresh reports that it did something. ensure() relies on knowing this.
+    # installed, so refresh reports that it did something. ensure_installed() relies on knowing
+    # this.
     ensure_installed(_SNAP)
     current = _snapd.list_one(_SNAP).revision
     result = retry_on_rate_limit(_snapd.refresh)(_SNAP, revision=current)

--- a/snap/tests/unit/test_empty_or_blank.py
+++ b/snap/tests/unit/test_empty_or_blank.py
@@ -29,7 +29,7 @@ _CALLS: dict[str, Callable[[str], object]] = {
     'alias': lambda v: snap.alias(v, 'lxc', 'testlxc'),
     'alias (app)': lambda v: snap.alias('lxd', v, 'testlxc'),
     'alias (alias)': lambda v: snap.alias('lxd', 'lxc', v),
-    'ensure': lambda v: snap.ensure(v),
+    'ensure_installed': lambda v: snap.ensure_installed(v),
     'get': lambda v: snap.get(v),
     'get (key)': lambda v: snap.get('lxd', [v]),
     'get_one': lambda v: snap.get_one(v, 'mykey'),
@@ -162,10 +162,10 @@ _MAX_FRAMES = 3
 # reach first does it. That puts the check one or more frames deeper than the rule above
 # allows, which is the price of not duplicating the check in a layer that doesn't own it.
 #
-# ensure leaves the deepest traceback in the library -- ensure, its _installed_info probe,
-# list_one, snap_path_segment and the check. get_one delegates to get, which validates both
-# the snap name and the key before making a request.
-_COMPOSITE_FUNCTIONS = {'ensure', 'get_one'}
+# ensure_installed leaves the deepest traceback in the library -- ensure_installed, its
+# _installed_info probe, list_one, snap_path_segment and the check. get_one delegates to get,
+# which validates both the snap name and the key before making a request.
+_COMPOSITE_FUNCTIONS = {'ensure_installed', 'get_one'}
 
 
 @pytest.mark.parametrize('name', sorted(_CALLS) + sorted(_BLANK_ONLY_CALLS))

--- a/snap/tests/unit/test_functions.py
+++ b/snap/tests/unit/test_functions.py
@@ -65,10 +65,10 @@ class TestGetInfo:
         assert result is None
 
 
-class TestEnsureInstalls:
+class TestEnsureInstalledInstalls:
     def test_not_installed(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = None
-        result = _functions.ensure('hello-world')
+        result = _functions.ensure_installed('hello-world')
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel=None, revision=None, classic=False
         )
@@ -76,14 +76,14 @@ class TestEnsureInstalls:
 
     def test_not_installed_channel(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = None
-        _functions.ensure('hello-world', channel='edge')
+        _functions.ensure_installed('hello-world', channel='edge')
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel='edge', revision=None, classic=False
         )
 
     def test_not_installed_revision(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = None
-        result = _functions.ensure('hello-world', revision=5)
+        result = _functions.ensure_installed('hello-world', revision=5)
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel=None, revision=5, classic=False
         )
@@ -91,23 +91,23 @@ class TestEnsureInstalls:
 
     def test_not_installed_channel_and_revision(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = None
-        _functions.ensure('hello-world', channel='edge', revision=5)
+        _functions.ensure_installed('hello-world', channel='edge', revision=5)
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel='edge', revision=5, classic=False
         )
 
     def test_not_installed_classic(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = None
-        _functions.ensure('hello-world', classic=True)
+        _functions.ensure_installed('hello-world', classic=True)
         mock_snapd.install.assert_called_once_with(
             'hello-world', channel=None, revision=None, classic=True
         )
 
 
-class TestEnsureChannel:
+class TestEnsureInstalledChannel:
     def test_installed_different_channel(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
-        result = _functions.ensure('hello-world', channel='edge')
+        result = _functions.ensure_installed('hello-world', channel='edge')
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel='edge', revision=None, classic=False
         )
@@ -116,7 +116,7 @@ class TestEnsureChannel:
     def test_installed_same_channel_update_true(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         mock_snapd.refresh.return_value = True
-        result = _functions.ensure('hello-world', channel='latest/stable')
+        result = _functions.ensure_installed('hello-world', channel='latest/stable')
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel='latest/stable', classic=False
         )
@@ -124,19 +124,19 @@ class TestEnsureChannel:
 
     def test_installed_same_channel_update_false(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
-        result = _functions.ensure('hello-world', channel='latest/stable', update=False)
+        result = _functions.ensure_installed('hello-world', channel='latest/stable', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     def test_installed_no_channel_update_false(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info()
-        result = _functions.ensure('hello-world', update=False)
+        result = _functions.ensure_installed('hello-world', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     def test_installed_normalized_channel(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
-        result = _functions.ensure('hello-world', channel='stable', update=False)
+        result = _functions.ensure_installed('hello-world', channel='stable', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
@@ -144,13 +144,13 @@ class TestEnsureChannel:
         # 'edge' resolves to '3.6/edge' for a snap on the 3.6 track, not to 'latest/edge',
         # so a snap already on '3.6/edge' is left alone rather than refreshed every call.
         mock_snapd.list_one.return_value = make_info(tracking='3.6/edge')
-        result = _functions.ensure('hello-world', channel='edge', update=False)
+        result = _functions.ensure_installed('hello-world', channel='edge', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     def test_risk_only_channel_inherits_track_when_different(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(tracking='3.6/stable')
-        result = _functions.ensure('hello-world', channel='edge')
+        result = _functions.ensure_installed('hello-world', channel='edge')
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel='edge', revision=None, classic=False
         )
@@ -159,35 +159,35 @@ class TestEnsureChannel:
     def test_no_updates_available_returns_false(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
         mock_snapd.refresh.return_value = False
-        result = _functions.ensure('hello-world', channel='latest/stable')
+        result = _functions.ensure_installed('hello-world', channel='latest/stable')
         assert result is False
 
     def test_empty_channel_treated_as_none(self, mock_snapd: MockSnapd):
         # channel='' is falsy, so it's treated the same as channel=None:
         # no channel-mismatch refresh, and with update=False no refresh at all.
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
-        result = _functions.ensure('hello-world', channel='', update=False)
+        result = _functions.ensure_installed('hello-world', channel='', update=False)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
 
-class TestEnsureRevision:
+class TestEnsureInstalledRevision:
     def test_installed_same_revision(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(revision=5)
-        result = _functions.ensure('hello-world', revision=5)
+        result = _functions.ensure_installed('hello-world', revision=5)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     @pytest.mark.parametrize('revision', [5, '5'])
     def test_revision_may_be_int_or_str(self, mock_snapd: MockSnapd, revision: int | str):
         mock_snapd.list_one.return_value = make_info(revision=5)
-        result = _functions.ensure('hello-world', revision=revision)
+        result = _functions.ensure_installed('hello-world', revision=revision)
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
     def test_installed_different_revision(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(revision=5)
-        result = _functions.ensure('hello-world', revision=6)
+        result = _functions.ensure_installed('hello-world', revision=6)
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel=None, revision=6, classic=False
         )
@@ -197,7 +197,7 @@ class TestEnsureRevision:
         # The revision is already installed, but the snap tracks the wrong channel, so it
         # still needs a refresh -- snapd moves the tracking channel without changing revision.
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable', revision=5)
-        result = _functions.ensure('hello-world', channel='edge', revision=5)
+        result = _functions.ensure_installed('hello-world', channel='edge', revision=5)
         mock_snapd.refresh.assert_called_once_with(
             'hello-world', channel='edge', revision=5, classic=False
         )
@@ -207,18 +207,20 @@ class TestEnsureRevision:
     def test_update_ignored_when_revision_matches(self, mock_snapd: MockSnapd, update: bool):
         # A revision fully specifies what to install, so there's nothing to update to.
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable', revision=5)
-        result = _functions.ensure('hello-world', channel='stable', revision=5, update=update)
+        result = _functions.ensure_installed(
+            'hello-world', channel='stable', revision=5, update=update
+        )
         mock_snapd.refresh.assert_not_called()
         assert result is False
 
 
-class TestEnsureClassic:
+class TestEnsureInstalledClassic:
     def test_classic_passed_to_refresh(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
-        _functions.ensure('hello-world', channel='edge', classic=True)
+        _functions.ensure_installed('hello-world', channel='edge', classic=True)
         assert mock_snapd.refresh.call_args.kwargs['classic'] is True
 
     def test_classic_passed_to_update_refresh(self, mock_snapd: MockSnapd):
         mock_snapd.list_one.return_value = make_info(tracking='latest/stable')
-        _functions.ensure('hello-world', channel='latest/stable', classic=True)
+        _functions.ensure_installed('hello-world', channel='latest/stable', classic=True)
         assert mock_snapd.refresh.call_args.kwargs['classic'] is True

--- a/snap/tests/unit/test_not_found.py
+++ b/snap/tests/unit/test_not_found.py
@@ -103,7 +103,7 @@ def test_does_not_raise(name: str, mock_client: MockClient):
     CALLS[name]()  # Does not raise.
 
 
-def test_ensure_also_raises_not_in_store_error(
+def test_refresh_also_raises_not_in_store_error(
     monkeypatch: pytest.MonkeyPatch, mock_client: MockClient
 ):
     """Ensure raises NotInstalledError if both the refresh and the check_installed probe fail.

--- a/snap/tests/unit/test_not_found.py
+++ b/snap/tests/unit/test_not_found.py
@@ -106,7 +106,7 @@ def test_does_not_raise(name: str, mock_client: MockClient):
 def test_refresh_also_raises_not_in_store_error(
     monkeypatch: pytest.MonkeyPatch, mock_client: MockClient
 ):
-    """Ensure raises NotInstalledError if both the refresh and the check_installed probe fail.
+    """Refresh raises NotInstalledError if both the refresh and the check_installed probe fail.
 
     If the refresh fails with _NotFoundError but check_installed succeeds,
     then we raise NotInStoreError instead.

--- a/snap/tests/unit/test_not_found.py
+++ b/snap/tests/unit/test_not_found.py
@@ -36,7 +36,7 @@ EXCLUDE = {'alias', 'unalias', 'unhold'}
 CALLS: dict[str, Callable[[], object]] = {
     'connect': lambda: snap.connect(('lxd', 'home')),
     'disconnect': lambda: snap.disconnect(('lxd', 'home')),
-    'ensure': lambda: snap.ensure('lxd'),
+    'ensure_installed': lambda: snap.ensure_installed('lxd'),
     'get': lambda: snap.get('lxd'),
     'get_one': lambda: snap.get_one('lxd', 'mykey'),
     'hold': lambda: snap.hold('lxd'),
@@ -52,7 +52,7 @@ CALLS: dict[str, Callable[[], object]] = {
     'unset': lambda: snap.unset('lxd', ['mykey']),
 }
 DOES_NOT_RAISE = {'remove'}  # catches _NotFoundError but doesn't raise
-RAISES_NOT_IN_STORE = {'ensure', 'install'}
+RAISES_NOT_IN_STORE = {'ensure_installed', 'install'}
 
 
 def _mock_error(mock_client: MockClient) -> _NotFoundError:

--- a/snap/tests/unit/test_utils.py
+++ b/snap/tests/unit/test_utils.py
@@ -375,7 +375,7 @@ class TestResolveChannel:
 
     @pytest.mark.parametrize('channel', ['stable', 'candidate', 'beta', 'edge'])
     def test_resolving_the_tracked_channel_is_a_no_op(self, channel: str):
-        # ensure() relies on this to tell whether a requested channel is the one already
+        # ensure_installed() relies on this to tell whether a requested channel is the one
         # tracked, so resolving a snap's own channel must give that channel back unchanged.
         for track in ('latest', '3.6'):
             tracking = f'{track}/{channel}'


### PR DESCRIPTION
This PR renames `ensure` to `ensure_installed` because it's a better name, matches the convention of `pathops.ensure_contents`, and the 1.0 library has an `ensure` function with subtly different semantics, so it would be nice to avoid accidental collisions with that.