### PR TITLE
fix(snap): correct timestamp timezone parsing, document InstalledInfo

### DIFF
--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -46,7 +46,7 @@ class InstalledInfo:
     ):
         self._name = name
         self._classic = classic
-        self._tracking = _utils.normalize_channel(tracking)
+        self._tracking = tracking
         self._revision = str(revision)
         self._version = version
         self._hold = _utils.parse_timestamp(hold) if isinstance(hold, str) else hold

--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -108,13 +108,22 @@ class InstalledInfo:
 
         A held snap is not automatically refreshed, but can be manually refreshed.
 
-        A snap that is held forever is reported by snapd as held for 200+ years,
-        which is hopefully sufficient.
+        Snapd has no distinct value for an indefinite hold, such as the one :func:`hold` places
+        by default: it records the hold as ending after Go's maximum duration, so this is a
+        timestamp roughly 292 years after the hold was placed.
         """
         return self._hold
 
     def __repr__(self) -> str:
-        hold = self.hold if self.hold is None else f"'{self.hold}'"
+        # The hold is rendered as a timestamp string rather than as a datetime repr, which keeps
+        # the repr readable and still lets it be evaluated to reconstruct an equal object: this
+        # is the format __init__ accepts, in the UTC form _utils.parse_timestamp reads on every
+        # supported Python (its fallback for 3.10 doesn't handle an offset).
+        if self.hold is None:
+            hold = None
+        else:
+            utc = self.hold.astimezone(datetime.timezone.utc)
+            hold = f'{utc.isoformat(timespec="microseconds").removesuffix("+00:00")}Z'
         return (
             f'{type(self).__name__}('
             f'{self.name!r}'
@@ -122,7 +131,7 @@ class InstalledInfo:
             f', tracking={self.tracking!r}'
             f', revision={self.revision!r}'
             f', version={self.version!r}'
-            f', hold={hold}'
+            f', hold={hold!r}'
             ')'
         )
 

--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 
 
 class InstalledInfo:
+    """Information about an installed snap."""
+
     def __init__(
         self,
         name: str,
@@ -67,10 +69,12 @@ class InstalledInfo:
 
     @property
     def name(self) -> str:
+        """The snap's name."""
         return self._name
 
     @property
     def classic(self) -> bool:
+        """Whether the snap is installed with classic confinement."""
         return self._classic
 
     @property
@@ -87,15 +91,40 @@ class InstalledInfo:
 
     @property
     def revision(self) -> str:
+        """The snap's revision, as a string.
+
+        Note that locally installed snaps have revisions in the form 'x<N>'.
+        """
         return self._revision
 
     @property
     def version(self) -> str:
+        """The version of the installed software as reported by snapd."""
         return self._version
 
     @property
     def hold(self) -> datetime.datetime | None:
+        """The date the snap is held until, or None if it is not held.
+
+        A held snap is not automatically refreshed, but can be manually refreshed.
+
+        A snap that is held forever is reported by snapd as held for 200+ years,
+        which is hopefully sufficient.
+        """
         return self._hold
+
+    def __repr__(self) -> str:
+        hold = self.hold if self.hold is None else f"'{self.hold}'"
+        return (
+            f'{type(self).__name__}('
+            f'{self.name!r}'
+            f', classic={self.classic!r}'
+            f', tracking={self.tracking!r}'
+            f', revision={self.revision!r}'
+            f', version={self.version!r}'
+            f', hold={hold}'
+            ')'
+        )
 
 
 def list_one(snap: str) -> InstalledInfo:

--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -108,16 +108,12 @@ class InstalledInfo:
 
         A held snap is not automatically refreshed, but can be manually refreshed.
 
-        Snapd has no distinct value for an indefinite hold, such as the one :func:`hold` places
-        by default: it records the hold as ending after Go's maximum duration, so this is a
-        timestamp roughly 292 years after the hold was placed.
+        For an indefinite hold, snapd reports a timestamp roughly 292 years after the hold was
+        placed (Go's maximum duration), which is hopefully sufficient.
         """
         return self._hold
 
     def __repr__(self) -> str:
-        # The hold is rendered as a timestamp string rather than as a datetime repr, which keeps
-        # the repr readable and still lets it be evaluated to reconstruct an equal object: it's
-        # the form snapd sends, which is the form __init__ takes.
         hold = None if self.hold is None else self.hold.isoformat()
         return (
             f'{type(self).__name__}('

--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -116,14 +116,9 @@ class InstalledInfo:
 
     def __repr__(self) -> str:
         # The hold is rendered as a timestamp string rather than as a datetime repr, which keeps
-        # the repr readable and still lets it be evaluated to reconstruct an equal object: this
-        # is the format __init__ accepts, in the UTC form _utils.parse_timestamp reads on every
-        # supported Python (its fallback for 3.10 doesn't handle an offset).
-        if self.hold is None:
-            hold = None
-        else:
-            utc = self.hold.astimezone(datetime.timezone.utc)
-            hold = f'{utc.isoformat(timespec="microseconds").removesuffix("+00:00")}Z'
+        # the repr readable and still lets it be evaluated to reconstruct an equal object: it's
+        # the form snapd sends, which is the form __init__ takes.
+        hold = None if self.hold is None else self.hold.isoformat()
         return (
             f'{type(self).__name__}('
             f'{self.name!r}'

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -169,6 +169,23 @@ def _parse_timestamp_310(timestamp: str) -> datetime.datetime:
     ValueError here and a datetime there. Snapd sends none of those, and the unit tests assert
     that both paths agree on every form it does send.
     """
+    return datetime.datetime.fromisoformat(_normalize_timestamp_310(timestamp))
+
+
+def _normalize_timestamp_310(timestamp: str) -> str:
+    """Rewrite a snapd timestamp in the narrow form every supported Python reads the same way.
+
+    The result always spells the fractional seconds with exactly 6 digits (or omits them) and
+    the timezone as an offset (or omits it), which is the overlap between what Python 3.10's
+    ``fromisoformat`` accepts and what later versions accept -- so what this returns parses to
+    the same datetime on every version, and a test of it on 3.14 is a test of 3.10's behaviour.
+
+    Kept separate from :func:`_parse_timestamp_310` because this is the part that is ours: the
+    rest is one stdlib call, on a string this has already put in the subset the versions agree
+    on. Delete both with the branch in :func:`parse_timestamp`.
+
+    Raises ValueError if the timestamp isn't a format snapd sends.
+    """
     match = _TIMESTAMP_310.fullmatch(timestamp)
     if match is None:
         raise ValueError(f'Invalid isoformat string: {timestamp!r}')
@@ -181,7 +198,7 @@ def _parse_timestamp_310(timestamp: str) -> datetime.datetime:
     # A timestamp with no timezone at all stays naive, as fromisoformat would leave it.
     timezone = match['timezone']
     offset = '' if timezone is None else '+00:00' if timezone == 'Z' else timezone
-    return datetime.datetime.fromisoformat(f'{match["datetime"]}{subsecond}{offset}')
+    return f'{match["datetime"]}{subsecond}{offset}'
 
 
 ########################################################

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import datetime
 import re
+import sys
 import typing
 import urllib.parse
 
@@ -127,30 +128,48 @@ def resolve_channel(channel: str, tracking: str) -> str:
     return normalize_channel(channel)
 
 
-# Snapd marshals timestamps with Go's RFC3339Nano layout, which drops trailing zeros from the
-# fractional seconds -- so the fraction is 0 to 9 digits long -- and writes the timezone as 'Z'
-# when snapd's clock is UTC and as an offset such as '+13:00' when it isn't. Which of those two
-# forms a charm sees is decided by the machine's timezone, not by the Ubuntu base or the snapd
-# version (pinned by tests/functional/test_timestamps.py).
-_TIMESTAMP = re.compile(
-    r'(?P<datetime>\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2})'
-    r'(?:\.(?P<fraction>\d+))?'
-    r'(?P<timezone>[Zz]|[+-]\d{2}:\d{2})?'
-)
-
-
 def parse_timestamp(timestamp: str) -> datetime.datetime:
     """Parse a snapd timestamp string to a datetime object.
 
-    The timestamp is normalized before being handed to ``datetime.fromisoformat``, rather than
-    passed to it as-is, so that every supported Python parses snapd's timestamps identically.
-    On Python 3.10, ``fromisoformat`` rejects both the ``Z`` suffix and any fractional part that
-    isn't exactly 3 or 6 digits long, and snapd emits both.
-
-    Raises ValueError if the timestamp isn't in the format snapd sends, matching what
-    ``fromisoformat`` raises for a string it can't parse.
+    Raises ValueError for a string that can't be parsed, as ``datetime.fromisoformat`` does.
     """
-    match = _TIMESTAMP.fullmatch(timestamp)
+    if sys.version_info >= (3, 11):
+        return datetime.datetime.fromisoformat(timestamp)
+    return _parse_timestamp_310(timestamp)
+
+
+# Snapd marshals timestamps with Go's RFC3339Nano layout, which drops trailing zeros from the
+# fractional seconds -- so the fraction is 0 to 9 digits long, down to no fraction at all -- and
+# writes the timezone as 'Z' when snapd's clock is UTC and as an offset such as '+13:00' when it
+# isn't. Which of those two forms a charm sees is decided by the timezone of the machine snapd
+# runs on, not by the Ubuntu base or the snapd version (pinned by
+# tests/functional/test_timestamps.py).
+#
+# The date and time separator and the timezone are matched as fromisoformat matches them, which
+# is to say case sensitively: it rejects a lowercase 't' or 'z' on every version we support.
+_TIMESTAMP_310 = re.compile(
+    r'(?P<datetime>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})'
+    r'(?:\.(?P<fraction>\d+))?'
+    r'(?P<timezone>Z|[+-]\d{2}:\d{2})?'
+)
+
+
+def _parse_timestamp_310(timestamp: str) -> datetime.datetime:
+    """Parse the timestamps snapd sends on Python 3.10, where fromisoformat can't read them.
+
+    Python 3.10's ``fromisoformat`` rejects the ``Z`` suffix outright, and accepts a fractional
+    part only when it's exactly 3 or 6 digits long. Snapd sends ``Z``, and sends fractions of
+    every length from 0 to 9 digits, so the timestamp is normalized to a form 3.10 does read
+    rather than parsed by hand -- leaving the arithmetic, and the timezone, to the stdlib.
+
+    Delete this, and the branch in :func:`parse_timestamp`, once we require Python 3.11+.
+
+    This accepts what snapd sends, which is narrower than what ``fromisoformat`` accepts on
+    3.11+: a bare date, an offset without minutes, or the basic format with no separators is a
+    ValueError here and a datetime there. Snapd sends none of those, and the unit tests assert
+    that both paths agree on every form it does send.
+    """
+    match = _TIMESTAMP_310.fullmatch(timestamp)
     if match is None:
         raise ValueError(f'Invalid isoformat string: {timestamp!r}')
     # datetime supports microseconds only, so a longer fraction is truncated and a shorter one
@@ -158,10 +177,10 @@ def parse_timestamp(timestamp: str) -> datetime.datetime:
     # a fraction it accepts on 3.11+, so the two agree on the timestamps snapd sends.
     fraction = match['fraction']
     subsecond = '' if fraction is None else f'.{fraction[:6].ljust(6, "0")}'
-    # fromisoformat only learned to read 'Z' in 3.11, but has always read the offset it stands
-    # for. A timestamp with no timezone at all stays naive, as fromisoformat would leave it.
+    # 3.10's fromisoformat has always read the offset that 'Z' stands for, just not 'Z' itself.
+    # A timestamp with no timezone at all stays naive, as fromisoformat would leave it.
     timezone = match['timezone']
-    offset = '' if timezone is None else '+00:00' if timezone.upper() == 'Z' else timezone
+    offset = '' if timezone is None else '+00:00' if timezone == 'Z' else timezone
     return datetime.datetime.fromisoformat(f'{match["datetime"]}{subsecond}{offset}')
 
 

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -133,20 +133,21 @@ def parse_timestamp(timestamp: str) -> datetime.datetime:
 
     Raises ValueError for a string that can't be parsed, as ``datetime.fromisoformat`` does.
     """
-    if sys.version_info >= (3, 11):
-        return datetime.datetime.fromisoformat(timestamp)
-    return _parse_timestamp_310(timestamp)
+    if sys.version_info < (3, 11):
+        return _parse_timestamp_310(timestamp)
+    return datetime.datetime.fromisoformat(timestamp)
+
+
+def _parse_timestamp_310(timestamp: str) -> datetime.datetime:
+    """Parse the timestamps snapd sends on Python 3.10, where fromisoformat can't read them."""
+    return datetime.datetime.fromisoformat(_normalize_timestamp_310(timestamp))
 
 
 # Snapd marshals timestamps with Go's RFC3339Nano layout, which drops trailing zeros from the
 # fractional seconds -- so the fraction is 0 to 9 digits long, down to no fraction at all -- and
 # writes the timezone as 'Z' when snapd's clock is UTC and as an offset such as '+13:00' when it
 # isn't. Which of those two forms a charm sees is decided by the timezone of the machine snapd
-# runs on, not by the Ubuntu base or the snapd version (pinned by
-# tests/functional/test_timestamps.py).
-#
-# The date and time separator and the timezone are matched as fromisoformat matches them, which
-# is to say case sensitively: it rejects a lowercase 't' or 'z' on every version we support.
+# runs on, not by the Ubuntu base or the snapd version.
 _TIMESTAMP_310 = re.compile(
     r'(?P<datetime>\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2})'
     r'(?:\.(?P<fraction>\d+))?'
@@ -154,37 +155,22 @@ _TIMESTAMP_310 = re.compile(
 )
 
 
-def _parse_timestamp_310(timestamp: str) -> datetime.datetime:
-    """Parse the timestamps snapd sends on Python 3.10, where fromisoformat can't read them.
+def _normalize_timestamp_310(timestamp: str) -> str:
+    """Rewrite a snapd timestamp in the narrow form every supported Python reads the same way.
+
+    This accepts what snapd sends, which is narrower than what ``fromisoformat`` accepts on
+    3.11+: a bare date, an offset without minutes, or the basic format with no separators is a
+    ValueError here and a datetime there.
 
     Python 3.10's ``fromisoformat`` rejects the ``Z`` suffix outright, and accepts a fractional
     part only when it's exactly 3 or 6 digits long. Snapd sends ``Z``, and sends fractions of
     every length from 0 to 9 digits, so the timestamp is normalized to a form 3.10 does read
     rather than parsed by hand -- leaving the arithmetic, and the timezone, to the stdlib.
 
-    Delete this, and the branch in :func:`parse_timestamp`, once we require Python 3.11+.
-
-    This accepts what snapd sends, which is narrower than what ``fromisoformat`` accepts on
-    3.11+: a bare date, an offset without minutes, or the basic format with no separators is a
-    ValueError here and a datetime there. Snapd sends none of those, and the unit tests assert
-    that both paths agree on every form it does send.
-    """
-    return datetime.datetime.fromisoformat(_normalize_timestamp_310(timestamp))
-
-
-def _normalize_timestamp_310(timestamp: str) -> str:
-    """Rewrite a snapd timestamp in the narrow form every supported Python reads the same way.
-
     The result always spells the fractional seconds with exactly 6 digits (or omits them) and
     the timezone as an offset (or omits it), which is the overlap between what Python 3.10's
     ``fromisoformat`` accepts and what later versions accept -- so what this returns parses to
-    the same datetime on every version, and a test of it on 3.14 is a test of 3.10's behaviour.
-
-    Kept separate from :func:`_parse_timestamp_310` because this is the part that is ours: the
-    rest is one stdlib call, on a string this has already put in the subset the versions agree
-    on. Delete both with the branch in :func:`parse_timestamp`.
-
-    Raises ValueError if the timestamp isn't a format snapd sends.
+    the same datetime on every version.
     """
     match = _TIMESTAMP_310.fullmatch(timestamp)
     if match is None:

--- a/snap/src/charmlibs/snap/_utils.py
+++ b/snap/src/charmlibs/snap/_utils.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import datetime
-import sys
+import re
 import typing
 import urllib.parse
 
@@ -127,28 +127,42 @@ def resolve_channel(channel: str, tracking: str) -> str:
     return normalize_channel(channel)
 
 
+# Snapd marshals timestamps with Go's RFC3339Nano layout, which drops trailing zeros from the
+# fractional seconds -- so the fraction is 0 to 9 digits long -- and writes the timezone as 'Z'
+# when snapd's clock is UTC and as an offset such as '+13:00' when it isn't. Which of those two
+# forms a charm sees is decided by the machine's timezone, not by the Ubuntu base or the snapd
+# version (pinned by tests/functional/test_timestamps.py).
+_TIMESTAMP = re.compile(
+    r'(?P<datetime>\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2})'
+    r'(?:\.(?P<fraction>\d+))?'
+    r'(?P<timezone>[Zz]|[+-]\d{2}:\d{2})?'
+)
+
+
 def parse_timestamp(timestamp: str) -> datetime.datetime:
     """Parse a snapd timestamp string to a datetime object.
 
-    This can be dropped in favour of datetime.fromisoformat when we require Python 3.11+.
+    The timestamp is normalized before being handed to ``datetime.fromisoformat``, rather than
+    passed to it as-is, so that every supported Python parses snapd's timestamps identically.
+    On Python 3.10, ``fromisoformat`` rejects both the ``Z`` suffix and any fractional part that
+    isn't exactly 3 or 6 digits long, and snapd emits both.
+
+    Raises ValueError if the timestamp isn't in the format snapd sends, matching what
+    ``fromisoformat`` raises for a string it can't parse.
     """
-    if sys.version_info >= (3, 11):
-        return datetime.datetime.fromisoformat(timestamp)
-    # Python 3.10 can't parse the fractional seconds with fromisoformat.
-    # We parse the format manually here for Ubuntu 22.04 based charms.
-    #
-    # The snapd version that comes with Ubuntu 22.04 emits Z-suffixed timestamps, e.g.
-    # 2026-02-27T03:01:19.488008Z
-    #
-    # Note: Newer snapd versions emit RFC3339 timestamps with timezone offsets, but we don't
-    # need to handle them here since they're covered by fromisoformat in Python 3.11+.
-    dt, ms = timestamp.removesuffix('Z').split('.')
-    base = datetime.datetime.fromisoformat(dt).replace(tzinfo=datetime.timezone.utc)
-    # datetime.timedelta only supports microsecond precision (first 6 digits of fractional secs).
-    # Snapd timestamps may have higher precision (truncated) or fewer than 6 digits (right-padded
-    # with zeros). E.g. '.13454' is 134540 μs, not 13454 μs. This matches fromisoformat in 3.11+.
-    microseconds = datetime.timedelta(microseconds=int(ms[:6].ljust(6, '0')))
-    return base + microseconds
+    match = _TIMESTAMP.fullmatch(timestamp)
+    if match is None:
+        raise ValueError(f'Invalid isoformat string: {timestamp!r}')
+    # datetime supports microseconds only, so a longer fraction is truncated and a shorter one
+    # is right padded: '.13454' is 134540 μs, not 13454 μs. This is what fromisoformat does with
+    # a fraction it accepts on 3.11+, so the two agree on the timestamps snapd sends.
+    fraction = match['fraction']
+    subsecond = '' if fraction is None else f'.{fraction[:6].ljust(6, "0")}'
+    # fromisoformat only learned to read 'Z' in 3.11, but has always read the offset it stands
+    # for. A timestamp with no timezone at all stays naive, as fromisoformat would leave it.
+    timezone = match['timezone']
+    offset = '' if timezone is None else '+00:00' if timezone.upper() == 'Z' else timezone
+    return datetime.datetime.fromisoformat(f'{match["datetime"]}{subsecond}{offset}')
 
 
 ########################################################

--- a/snap/tests/functional/test_timestamps.py
+++ b/snap/tests/functional/test_timestamps.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Functional tests for the timestamp format snapd actually sends.
+
+_utils.parse_timestamp normalizes a timestamp before handing it to datetime.fromisoformat,
+rather than passing it as-is, because fromisoformat on Python 3.10 -- the version charms on
+Ubuntu 22.04 run -- rejects the 'Z' suffix and any fractional part that isn't exactly 3 or 6
+digits long. These tests pin what the live snapd on each Ubuntu base really emits, so that the
+3.10 parser is matched against reality rather than against what the format is assumed to be.
+
+The formats seen here are copied into the unit tests, which assert the exact datetime each one
+parses to on every supported Python. Those run everywhere; these run against one snapd and one
+Python per base.
+"""
+
+from __future__ import annotations
+
+import datetime
+import re
+import typing
+from typing import Any
+
+import pytest
+
+from charmlibs.snap import _client, _snapd_logs, _utils
+from charmlibs.snap import _snapd_snaps as _snapd
+from conftest import ensure_installed_local
+
+# Locally-built snaps (tests/functional/snaps), so that nothing here depends on the store.
+_SNAP = 'test-snap'
+# The service snap emits a burst of log lines on startup, giving /v2/logs something to report.
+_SERVICE_SNAP = 'test-service-snap'
+
+# Snapd marshals a Go time.Time, which encoding/json writes with the RFC3339Nano layout
+# "2006-01-02T15:04:05.999999999Z07:00". The 9s mean trailing zeros are trimmed from the
+# fractional seconds, all the way to no fraction at all for a whole second; the Z07:00 means
+# 'Z' when the time is UTC and an offset such as '+13:00' when it isn't.
+_RFC3339_NANO = re.compile(
+    r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'  # Date and time, always written in full.
+    r'(?:\.\d{1,9})?'  # Fractional seconds, if any survived the trimming.
+    r'(?:Z|[+-]\d{2}:\d{2})'  # Timezone: 'Z' for UTC, otherwise an offset.
+)
+
+
+def _raw_snap_info(name: str) -> dict[str, Any]:
+    """The unparsed /v2/snaps/{name} result, which InstalledInfo is built from."""
+    result = _client.get(f'/v2/snaps/{name}')
+    assert isinstance(result, dict)
+    return typing.cast('dict[str, Any]', result)
+
+
+def _assert_parses(timestamp: str) -> datetime.datetime:
+    """Assert the timestamp is a format we support, and return what we parse it as."""
+    assert _RFC3339_NANO.fullmatch(timestamp), f'unexpected timestamp format: {timestamp!r}'
+    parsed = _utils.parse_timestamp(timestamp)
+    # Snapd always sends a timezone, in either of its two forms, so nothing here is naive.
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() is not None
+    # The 3.10 parser is checked against the live timestamp on every base, not only on the base
+    # whose Python uses it. On 3.11+ parse_timestamp is fromisoformat, so this compares the
+    # parser with the stdlib on a timestamp snapd really sent.
+    fallback = _utils._parse_timestamp_310(timestamp)
+    assert fallback == parsed
+    assert fallback.utcoffset() == parsed.utcoffset()
+    return parsed
+
+
+def test_install_date_format():
+    # install-date is the field most likely to land on a whole second, and so to arrive with no
+    # fractional part at all -- the case the previous hand-rolled 3.10 parser raised ValueError
+    # on. The library doesn't expose it, but it comes from the same endpoint as hold.
+    ensure_installed_local(_SNAP)
+    install_date = _raw_snap_info(_SNAP)['install-date']
+    parsed = _assert_parses(install_date)
+    assert parsed < datetime.datetime.now(tz=datetime.timezone.utc)
+
+
+def test_hold_format():
+    ensure_installed_local(_SNAP)
+    try:
+        _snapd.hold(_SNAP)
+        raw_hold = _raw_snap_info(_SNAP)['hold']
+        parsed = _assert_parses(raw_hold)
+        # What InstalledInfo reports has been through the same parsing.
+        info = _snapd.list_one(_SNAP)
+        assert info.hold == parsed
+    finally:
+        _snapd.unhold(_SNAP)
+
+
+def test_hold_forever_is_a_far_future_timestamp():
+    # An indefinite hold has no distinct representation in snapd: it holds for Go's maximum
+    # duration, 2**63-1 nanoseconds, which is a little over 292 years. InstalledInfo.hold
+    # documents that, and a charm can only tell an indefinite hold from a definite one by the
+    # date being absurd, so pin the arithmetic rather than just 'is not None'.
+    ensure_installed_local(_SNAP)
+    try:
+        _snapd.hold(_SNAP)
+        hold = _snapd.list_one(_SNAP).hold
+        assert hold is not None
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        assert datetime.timedelta(days=290 * 365) < hold - now < datetime.timedelta(days=293 * 365)
+    finally:
+        _snapd.unhold(_SNAP)
+
+
+def test_hold_with_duration_format():
+    # A hold snapd computes from a duration we sent, rather than one it made up itself.
+    ensure_installed_local(_SNAP)
+    try:
+        _snapd.hold(_SNAP, duration=datetime.timedelta(days=2))
+        parsed = _assert_parses(_raw_snap_info(_SNAP)['hold'])
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        assert datetime.timedelta(days=1) < parsed - now < datetime.timedelta(days=3)
+    finally:
+        _snapd.unhold(_SNAP)
+
+
+def test_log_timestamp_format():
+    # /v2/logs timestamps come from journald rather than from snapd's own clock, so they're a
+    # separate format risk: snapd converts them with .UTC(), and journald records microseconds.
+    ensure_installed_local(_SERVICE_SNAP)
+    result = _client.get_logs(query={'n': 5})
+    entries = typing.cast('list[dict[str, Any]]', result)
+    if not entries:
+        pytest.skip('snapd reported no log entries to check the timestamp format of')
+    for entry in entries:
+        parsed = _assert_parses(entry['timestamp'])
+        assert parsed < datetime.datetime.now(tz=datetime.timezone.utc)
+    # What LogEntry reports has been through the same parsing.
+    log_entries = _snapd_logs.logs(_SERVICE_SNAP, limit=5)
+    for log_entry in log_entries:
+        assert log_entry.timestamp.tzinfo is not None
+
+
+def test_timezone_is_read_from_the_timestamp():
+    # Which of the two timezone forms a charm sees is decided by the timezone of the machine
+    # snapd runs on, not by the Ubuntu base or the snapd version: a UTC machine (a CI runner, a
+    # container) reports 'Z', and a machine on a local timezone reports an offset. Whichever
+    # this machine produced, the offset we parse has to be the one the string carries -- the
+    # 3.10 parser this replaced silently read every offset as UTC, putting hold and log
+    # timestamps out by the machine's offset.
+    ensure_installed_local(_SNAP)
+    install_date = _raw_snap_info(_SNAP)['install-date']
+    offset = _utils.parse_timestamp(install_date).utcoffset()
+    if install_date.endswith('Z'):
+        assert offset == datetime.timedelta(0)
+    else:
+        sign, hours, minutes = install_date[-6], install_date[-5:-3], install_date[-2:]
+        assert sign in '+-'
+        expected = datetime.timedelta(hours=int(hours), minutes=int(minutes))
+        assert offset == (-expected if sign == '-' else expected)

--- a/snap/tests/functional/test_timestamps.py
+++ b/snap/tests/functional/test_timestamps.py
@@ -22,8 +22,6 @@ import re
 import typing
 from typing import Any
 
-import pytest
-
 from charmlibs.snap import _client, _snapd_logs, _utils
 from charmlibs.snap import _snapd_snaps as _snapd
 from conftest import ensure_installed_local
@@ -124,8 +122,7 @@ def test_log_timestamp_format():
     ensure_installed_local(_SERVICE_SNAP)
     result = _client.get_logs(query={'n': 5})
     entries = typing.cast('list[dict[str, Any]]', result)
-    if not entries:
-        pytest.skip('snapd reported no log entries to check the timestamp format of')
+    assert entries
     for entry in entries:
         parsed = _assert_parses(entry['timestamp'])
         assert parsed < datetime.datetime.now(tz=datetime.timezone.utc)

--- a/snap/tests/unit/test_snapd_logs.py
+++ b/snap/tests/unit/test_snapd_logs.py
@@ -7,13 +7,11 @@ from __future__ import annotations
 
 import datetime
 import logging
-import sys
 from typing import TYPE_CHECKING
 
 import pytest
 
 from charmlibs.snap import LogEntry, _snapd_logs
-from charmlibs.snap._utils import parse_timestamp
 from conftest import result_of
 
 if TYPE_CHECKING:
@@ -127,49 +125,6 @@ class TestLogs:
         assert repr(entry.sid) in r
         assert repr(entry.pid) in r
         assert repr(entry.message) in r
-
-
-class TestParseTimestamp:
-    def test_z_suffix(self):
-        ts = parse_timestamp('2026-02-27T03:01:19.488008Z')
-        assert ts.year == 2026
-        assert ts.month == 2
-        assert ts.day == 27
-        assert ts.hour == 3
-
-    def test_z_suffix_microseconds(self):
-        ts = parse_timestamp('2026-02-27T03:01:19.488008Z')
-        assert ts.microsecond == 488008
-
-    def test_z_suffix_utc(self):
-        ts = parse_timestamp('2026-02-27T03:01:19.488008Z')
-        assert ts.tzinfo is not None
-        assert ts.utcoffset() == datetime.timedelta(0)
-
-    def test_z_suffix_high_precision(self):
-        # 7-digit fraction should be truncated to 6 without error.
-        ts = parse_timestamp('2026-02-27T03:01:19.4880089Z')
-        assert ts.microsecond == 488008
-
-    def test_z_suffix_short_fraction(self):
-        # 5-digit fraction should be left-padded to 6 digits (0.13454 s = 134540 μs).
-        ts = parse_timestamp('2026-02-27T03:01:19.13454Z')
-        assert ts.microsecond == 134540
-
-    def test_z_suffix_four_digit_fraction(self):
-        # 4-digit fraction: 0.0033 s = 3300 μs.
-        ts = parse_timestamp('2026-02-27T03:01:19.0033Z')
-        assert ts.microsecond == 3300
-
-    @pytest.mark.skipif(
-        sys.version_info < (3, 11),
-        reason='fromisoformat does not support offset suffixes on Python 3.10',
-    )
-    def test_offset_suffix(self):
-        ts = parse_timestamp('2026-02-27T16:01:19.488008+13:00')
-        assert ts.tzinfo is not None
-        assert ts.utcoffset() == datetime.timedelta(hours=13)
-        assert ts.hour == 16
 
 
 class TestSnapsArgument:

--- a/snap/tests/unit/test_snapd_snaps.py
+++ b/snap/tests/unit/test_snapd_snaps.py
@@ -147,8 +147,20 @@ def _repr_fields(info: object) -> list[tuple[str | None, str]]:
         {k: v for k, v in _MINIMAL_INFO_DICT.items() if k != 'tracking-channel'},
         # A held snap: the hold is a timezone aware datetime rather than None.
         result_of('snap_info_hello_world_held.json'),
+        # The hold as snapd sends it from a machine that isn't on UTC, and one that landed on a
+        # whole second. Both are timestamps the repr has to write in a form __init__ reads back
+        # unchanged, on Python 3.10 as much as on 3.11+ (see TestParseTimestamp).
+        {**_MINIMAL_INFO_DICT, 'hold': '2318-08-04T16:25:39.803472+13:00'},
+        {**_MINIMAL_INFO_DICT, 'hold': '2318-08-04T16:25:39Z'},
     ],
-    ids=['minimal', 'classic-local-revision', 'no-tracking-channel', 'held'],
+    ids=[
+        'minimal',
+        'classic-local-revision',
+        'no-tracking-channel',
+        'held',
+        'held-with-offset',
+        'held-on-a-whole-second',
+    ],
 )
 class TestInstalledInfoRepr:
     def test_repr_has_every_public_field_in_order(self, info_dict: dict[str, Any]):

--- a/snap/tests/unit/test_snapd_snaps.py
+++ b/snap/tests/unit/test_snapd_snaps.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import datetime
+import re
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -103,6 +104,73 @@ class TestInstalledInfoFromDict:
         }
         info = _snapd.InstalledInfo._from_dict(info_dict)
         assert info.name == 'hello-world'
+
+
+def _public_fields(cls: type) -> list[str]:
+    """The public properties of a class, in the order the class defines them.
+
+    Read from the class rather than dir(), which sorts alphabetically and would lose that order.
+    """
+    return [
+        name
+        for name, attr in vars(cls).items()
+        if not name.startswith('_') and isinstance(attr, property)
+    ]
+
+
+def _field_values(info: _snapd.InstalledInfo) -> dict[str, Any]:
+    return {name: getattr(info, name) for name in _public_fields(type(info))}
+
+
+def _repr_fields(info: object) -> list[tuple[str | None, str]]:
+    """The fields of a repr as (name, value) pairs, with a None name for a positional field."""
+    r = repr(info)
+    prefix = f'{type(info).__name__}('
+    assert r.startswith(prefix), r
+    assert r.endswith(')'), r
+    fields: list[tuple[str | None, str]] = []
+    for field in r[len(prefix) : -1].split(', '):
+        # A value that happens to contain '=' isn't mistaken for a name: a name has to be a
+        # bare identifier at the start of the field, and every value here is quoted or a literal.
+        match = re.fullmatch(r'(?:([a-z_]+)=)?(.+)', field)
+        assert match is not None, field
+        fields.append((match.group(1), match.group(2)))
+    return fields
+
+
+@pytest.mark.parametrize(
+    'info_dict',
+    [
+        _MINIMAL_INFO_DICT,
+        {**_MINIMAL_INFO_DICT, 'confinement': 'classic', 'revision': 'x1'},
+        # A snap installed from a local file: no tracked channel.
+        {k: v for k, v in _MINIMAL_INFO_DICT.items() if k != 'tracking-channel'},
+        # A held snap: the hold is a timezone aware datetime rather than None.
+        result_of('snap_info_hello_world_held.json'),
+    ],
+    ids=['minimal', 'classic-local-revision', 'no-tracking-channel', 'held'],
+)
+class TestInstalledInfoRepr:
+    def test_repr_has_every_public_field_in_order(self, info_dict: dict[str, Any]):
+        # Read from the class rather than hardcoded, so a new public field is covered here as
+        # soon as it's added, in the position the class declares it in.
+        expected = _public_fields(_snapd.InstalledInfo)
+        info = _snapd.InstalledInfo._from_dict(info_dict)
+        names = [name for name, _ in _repr_fields(info)]
+        # The first field may be positional, matching the constructor's first argument.
+        assert names[0] in (expected[0], None)
+        assert names[1:] == expected[1:]
+
+    def test_repr_round_trips_through_eval(self, info_dict: dict[str, Any]):
+        # The repr is valid Python that reconstructs an equal object, which pins the timestamp
+        # format the repr writes the hold in: __init__ has to be able to parse it back on every
+        # supported Python (see TestParseTimestamp).
+        info = _snapd.InstalledInfo._from_dict(info_dict)
+        namespace = {'InstalledInfo': _snapd.InstalledInfo, 'datetime': datetime}
+        clone = eval(repr(info), namespace)  # noqa: S307
+        assert isinstance(clone, _snapd.InstalledInfo)
+        assert _field_values(clone) == _field_values(info)
+        assert repr(clone) == repr(info)
 
 
 class TestListOne:

--- a/snap/tests/unit/test_utils.py
+++ b/snap/tests/unit/test_utils.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import datetime
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -372,6 +374,126 @@ class TestResolveChannel:
     )
     def test_resolve(self, channel: str, tracking: str, expected: str):
         assert _utils.resolve_channel(channel, tracking) == expected
+
+
+UTC = datetime.timezone.utc
+NZDT = datetime.timezone(datetime.timedelta(hours=13))
+NZST = datetime.timezone(datetime.timedelta(hours=12))
+CHATHAM = datetime.timezone(datetime.timedelta(hours=12, minutes=45))
+
+# Snapd writes timestamps with Go's RFC3339Nano layout, so the same field varies in two ways:
+# the timezone is 'Z' or an offset depending on the timezone of the machine snapd runs on, and
+# the fractional seconds have their trailing zeros trimmed, down to no fraction at all.
+#
+# These are timestamps snapd 2.76 really sent, copied from the endpoints the library reads.
+# tests/functional/test_timestamps.py checks the format against a live snapd on each base, so
+# that this list stays a record of the real thing rather than of what we assume it to be.
+OBSERVED_TIMESTAMPS = [
+    # /v2/logs, whose timestamps journald records to microsecond precision.
+    ('2026-02-27T03:01:19.488008Z', datetime.datetime(2026, 2, 27, 3, 1, 19, 488008, UTC)),
+    # A snap's 'hold', from Go's nanosecond clock: 9 digits, truncated to 6 rather than rounded.
+    ('2318-11-10T01:13:31.475559159Z', datetime.datetime(2318, 11, 10, 1, 13, 31, 475559, UTC)),
+    # A snap's 'install-date', which regularly lands on a whole second and so arrives with no
+    # fraction at all. fromisoformat reads this on 3.10, but the old parser raised ValueError.
+    ('2026-07-22T11:27:35Z', datetime.datetime(2026, 7, 22, 11, 27, 35, 0, UTC)),
+    # The same fields from a snapd whose machine isn't on UTC. 3.10's fromisoformat reads the
+    # offset but not the fraction, so these need normalizing too -- and the old parser read
+    # every one of them as UTC, putting the result out by the machine's offset.
+    (
+        '2026-02-26T12:20:32.316341429+13:00',
+        datetime.datetime(2026, 2, 26, 12, 20, 32, 316341, NZDT),
+    ),
+    (
+        '2026-06-29T15:23:53.793426507+12:00',
+        datetime.datetime(2026, 6, 29, 15, 23, 53, 793426, NZST),
+    ),
+    (
+        '2026-07-31T13:32:35.365168077+12:00',
+        datetime.datetime(2026, 7, 31, 13, 32, 35, 365168, NZST),
+    ),
+]
+
+# Forms Go's layout can produce that we haven't happened to catch snapd emitting.
+CONSTRUCTED_TIMESTAMPS = [
+    # A negative offset, and one that isn't a whole number of hours.
+    (
+        '2026-02-26T12:20:32.316341429-05:00',
+        datetime.datetime(
+            2026, 2, 26, 12, 20, 32, 316341, datetime.timezone(datetime.timedelta(hours=-5))
+        ),
+    ),
+    ('2026-02-26T12:20:32.3+12:45', datetime.datetime(2026, 2, 26, 12, 20, 32, 300000, CHATHAM)),
+    # Fractions shorter than 6 digits are right padded, not left padded: '.13454' is 134540 μs.
+    ('2026-02-27T03:01:19.13454Z', datetime.datetime(2026, 2, 27, 3, 1, 19, 134540, UTC)),
+    ('2026-02-27T03:01:19.0033Z', datetime.datetime(2026, 2, 27, 3, 1, 19, 3300, UTC)),
+    ('2026-02-27T03:01:19.1Z', datetime.datetime(2026, 2, 27, 3, 1, 19, 100000, UTC)),
+    # Go's zero time, which is what a time field snapd has no value for would marshal to.
+    ('0001-01-01T00:00:00Z', datetime.datetime(1, 1, 1, 0, 0, 0, 0, UTC)),
+]
+
+TIMESTAMPS = [*OBSERVED_TIMESTAMPS, *CONSTRUCTED_TIMESTAMPS]
+
+
+class TestParseTimestamp:
+    # The formats below are pinned to exact values rather than to properties of the result, so
+    # that every supported Python is asserted to parse them identically -- the point of
+    # normalizing the timestamp instead of handing it to fromisoformat as-is, which silently
+    # dropped the timezone (or raised) on 3.10.
+    @pytest.mark.parametrize(('timestamp', 'expected'), TIMESTAMPS)
+    def test_parse(self, timestamp: str, expected: datetime.datetime):
+        parsed = _utils.parse_timestamp(timestamp)
+        assert parsed == expected
+        # Aware datetimes compare equal across timezones, so the offset is checked separately:
+        # without this, a timestamp parsed as UTC would match one that isn't.
+        assert parsed.utcoffset() == expected.utcoffset()
+
+    @pytest.mark.parametrize(('timestamp', 'expected'), TIMESTAMPS)
+    @pytest.mark.skipif(
+        sys.version_info < (3, 11),
+        reason='fromisoformat only reads these formats on 3.11+, which is why we normalize',
+    )
+    def test_parse_matches_fromisoformat(self, timestamp: str, expected: datetime.datetime):
+        # Where the stdlib can parse the timestamp itself, normalizing must not change the
+        # result: the expected values above are the stdlib's, not ours.
+        del expected  # only in the signature to share the parametrization
+        parsed = datetime.datetime.fromisoformat(timestamp)
+        assert _utils.parse_timestamp(timestamp) == parsed
+        assert _utils.parse_timestamp(timestamp).utcoffset() == parsed.utcoffset()
+
+    @pytest.mark.parametrize('separator', ['T', 't', ' '])
+    def test_date_and_time_separator(self, separator: str):
+        # Snapd always writes 'T'. The other two are accepted because fromisoformat accepts them
+        # and str(datetime) produces the space form, which is what a caller passing a timestamp
+        # to InstalledInfo is most likely to have to hand.
+        parsed = _utils.parse_timestamp(f'2026-02-27{separator}03:01:19.488008Z')
+        assert parsed == datetime.datetime(2026, 2, 27, 3, 1, 19, 488008, UTC)
+
+    def test_no_timezone_is_naive(self):
+        # Snapd always sends a timezone, but fromisoformat accepts a timestamp without one and
+        # returns a naive datetime rather than assuming UTC, so we do the same.
+        parsed = _utils.parse_timestamp('2026-02-27T03:01:19.488008')
+        assert parsed == datetime.datetime(2026, 2, 27, 3, 1, 19, 488008)
+        assert parsed.tzinfo is None
+
+    @pytest.mark.parametrize(
+        'timestamp',
+        [
+            '',
+            'not a timestamp',
+            '2026-02-27',  # A date with no time: snapd never sends one, so we don't accept it.
+            '03:01:19.488008Z',  # A time with no date.
+            '2026-02-27T03:01:19.488008+13',  # An offset must have minutes.
+            '2026-02-27T03:01:19.488008 Z',
+            '2026-02-27T03:01:19.Z',  # A fraction, if present, must have digits.
+            '2026-02-27T03:01:19.488008Z trailing',
+            'leading 2026-02-27T03:01:19.488008Z',
+        ],
+    )
+    def test_unparseable_raises_value_error(self, timestamp: str):
+        # ValueError is what fromisoformat raises, and what logs() catches to skip an entry it
+        # can't read rather than failing the whole call.
+        with pytest.raises(ValueError, match='Invalid isoformat string'):
+            _utils.parse_timestamp(timestamp)
 
     @pytest.mark.parametrize('channel', ['stable', 'candidate', 'beta', 'edge'])
     def test_resolving_the_tracked_channel_is_a_no_op(self, channel: str):

--- a/snap/tests/unit/test_utils.py
+++ b/snap/tests/unit/test_utils.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import datetime
+import re
 import sys
 from typing import TYPE_CHECKING
 
@@ -434,6 +435,15 @@ CONSTRUCTED_TIMESTAMPS = [
 TIMESTAMPS = [*OBSERVED_TIMESTAMPS, *CONSTRUCTED_TIMESTAMPS]
 
 
+# What _normalize_timestamp_310 is allowed to emit: fractional seconds spelled with exactly 6
+# digits or left out, and the timezone as an offset or left out. Python 3.10's fromisoformat
+# reads this subset, and every later version reads it to the same datetime -- checked against
+# 3.10, 3.12 and 3.14, including that a '+00:00' offset gives datetime.timezone.utc on all of
+# them. Nothing outside the subset can be assumed to survive the version difference.
+AGREED_SUBSET = re.compile(
+    r'\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d{6})?(?:[+-]\d{2}:\d{2})?'
+)
+
 # Neither fromisoformat nor the 3.10 parser reads any of these, on any version we support.
 MALFORMED = [
     '',
@@ -477,6 +487,19 @@ class TestParseTimestamp:
         parsed = _utils._parse_timestamp_310(timestamp)
         assert parsed == expected
         assert parsed.utcoffset() == expected.utcoffset()
+
+    # ...but that test ends in a call to the *running* version's fromisoformat, so on 3.14 it
+    # only stands in for 3.10 as far as the two agree. What makes it stand in is the shape of
+    # the normalized string: a 6 digit fraction or none, and an offset or none, which is the
+    # subset every supported fromisoformat reads identically. That property is version
+    # independent, so asserting it here is what carries the test across versions.
+    @pytest.mark.parametrize(('timestamp', 'expected'), TIMESTAMPS)
+    def test_normalize_310_output_is_read_the_same_by_every_version(
+        self, timestamp: str, expected: datetime.datetime
+    ):
+        del expected  # only in the signature to share the parametrization
+        normalized = _utils._normalize_timestamp_310(timestamp)
+        assert AGREED_SUBSET.fullmatch(normalized), normalized
 
     @pytest.mark.parametrize(('timestamp', 'expected'), TIMESTAMPS)
     @pytest.mark.skipif(

--- a/snap/tests/unit/test_utils.py
+++ b/snap/tests/unit/test_utils.py
@@ -434,11 +434,34 @@ CONSTRUCTED_TIMESTAMPS = [
 TIMESTAMPS = [*OBSERVED_TIMESTAMPS, *CONSTRUCTED_TIMESTAMPS]
 
 
+# Neither fromisoformat nor the 3.10 parser reads any of these, on any version we support.
+MALFORMED = [
+    '',
+    'not a timestamp',
+    '03:01:19.488008Z',  # A time with no date.
+    '2026-02-27t03:01:19.488008z',  # fromisoformat is case sensitive, so we are too.
+    '2026-02-27T03:01:19.488008Z trailing',
+    'leading 2026-02-27T03:01:19.488008Z',
+]
+
+# Valid ISO 8601 that snapd never sends. fromisoformat on 3.11+ reads all of these, and the 3.10
+# parser reads none of them: it accepts snapd's format rather than every format, so that an
+# unexpected timestamp is an error rather than a datetime nothing meant.
+NOT_SNAPD_FORMAT = [
+    '2026-02-27',  # A date with no time.
+    '2026-02-27T03:01:19.488008+13',  # An offset with no minutes.
+    '2026-02-27T03:01:19+13:00:30',  # An offset with seconds.
+    '2026-02-27T03:01:19.Z',  # A fraction with no digits.
+    '2026-02-27x03:01:19.488008Z',  # An arbitrary separator.
+    '20260227T030119Z',  # The basic format, with the separators left out.
+    '2026-W09-5T03:01:19Z',  # A week date.
+]
+
+
 class TestParseTimestamp:
-    # The formats below are pinned to exact values rather than to properties of the result, so
-    # that every supported Python is asserted to parse them identically -- the point of
-    # normalizing the timestamp instead of handing it to fromisoformat as-is, which silently
-    # dropped the timezone (or raised) on 3.10.
+    # Every timestamp is pinned to an exact value rather than to properties of the result, so
+    # that both parsing paths are asserted to agree -- the 3.10 one silently dropped the
+    # timezone, which no assertion about the shape of the result would have caught.
     @pytest.mark.parametrize(('timestamp', 'expected'), TIMESTAMPS)
     def test_parse(self, timestamp: str, expected: datetime.datetime):
         parsed = _utils.parse_timestamp(timestamp)
@@ -447,53 +470,62 @@ class TestParseTimestamp:
         # without this, a timestamp parsed as UTC would match one that isn't.
         assert parsed.utcoffset() == expected.utcoffset()
 
+    # The 3.10 parser is tested directly, on every version rather than only on the version that
+    # uses it, so that a regression in it fails everywhere instead of only in the 3.10 CI job.
+    @pytest.mark.parametrize(('timestamp', 'expected'), TIMESTAMPS)
+    def test_parse_310(self, timestamp: str, expected: datetime.datetime):
+        parsed = _utils._parse_timestamp_310(timestamp)
+        assert parsed == expected
+        assert parsed.utcoffset() == expected.utcoffset()
+
     @pytest.mark.parametrize(('timestamp', 'expected'), TIMESTAMPS)
     @pytest.mark.skipif(
         sys.version_info < (3, 11),
-        reason='fromisoformat only reads these formats on 3.11+, which is why we normalize',
+        reason='fromisoformat does not read these formats on 3.10, which is why we normalize',
     )
-    def test_parse_matches_fromisoformat(self, timestamp: str, expected: datetime.datetime):
-        # Where the stdlib can parse the timestamp itself, normalizing must not change the
-        # result: the expected values above are the stdlib's, not ours.
+    def test_parse_310_matches_fromisoformat(self, timestamp: str, expected: datetime.datetime):
+        # Where the stdlib can read the timestamp itself, the 3.10 parser must agree with it
+        # exactly: the expected values above are the stdlib's, not ours.
         del expected  # only in the signature to share the parametrization
         parsed = datetime.datetime.fromisoformat(timestamp)
-        assert _utils.parse_timestamp(timestamp) == parsed
-        assert _utils.parse_timestamp(timestamp).utcoffset() == parsed.utcoffset()
+        assert _utils._parse_timestamp_310(timestamp) == parsed
+        assert _utils._parse_timestamp_310(timestamp).utcoffset() == parsed.utcoffset()
 
-    @pytest.mark.parametrize('separator', ['T', 't', ' '])
+    @pytest.mark.parametrize('separator', ['T', ' '])
     def test_date_and_time_separator(self, separator: str):
-        # Snapd always writes 'T'. The other two are accepted because fromisoformat accepts them
-        # and str(datetime) produces the space form, which is what a caller passing a timestamp
-        # to InstalledInfo is most likely to have to hand.
-        parsed = _utils.parse_timestamp(f'2026-02-27{separator}03:01:19.488008Z')
-        assert parsed == datetime.datetime(2026, 2, 27, 3, 1, 19, 488008, UTC)
+        # Snapd always writes 'T'. The space form is accepted because str(datetime) produces it,
+        # and that's what a caller passing a timestamp to InstalledInfo has most readily to hand.
+        expected = datetime.datetime(2026, 2, 27, 3, 1, 19, 488008, UTC)
+        timestamp = f'2026-02-27{separator}03:01:19.488008Z'
+        assert _utils.parse_timestamp(timestamp) == expected
+        assert _utils._parse_timestamp_310(timestamp) == expected
 
     def test_no_timezone_is_naive(self):
         # Snapd always sends a timezone, but fromisoformat accepts a timestamp without one and
-        # returns a naive datetime rather than assuming UTC, so we do the same.
-        parsed = _utils.parse_timestamp('2026-02-27T03:01:19.488008')
-        assert parsed == datetime.datetime(2026, 2, 27, 3, 1, 19, 488008)
-        assert parsed.tzinfo is None
+        # returns a naive datetime rather than assuming UTC, so the 3.10 parser does the same.
+        for parsed in (
+            _utils.parse_timestamp('2026-02-27T03:01:19.488008'),
+            _utils._parse_timestamp_310('2026-02-27T03:01:19.488008'),
+        ):
+            assert parsed == datetime.datetime(2026, 2, 27, 3, 1, 19, 488008)
+            assert parsed.tzinfo is None
 
-    @pytest.mark.parametrize(
-        'timestamp',
-        [
-            '',
-            'not a timestamp',
-            '2026-02-27',  # A date with no time: snapd never sends one, so we don't accept it.
-            '03:01:19.488008Z',  # A time with no date.
-            '2026-02-27T03:01:19.488008+13',  # An offset must have minutes.
-            '2026-02-27T03:01:19.488008 Z',
-            '2026-02-27T03:01:19.Z',  # A fraction, if present, must have digits.
-            '2026-02-27T03:01:19.488008Z trailing',
-            'leading 2026-02-27T03:01:19.488008Z',
-        ],
-    )
-    def test_unparseable_raises_value_error(self, timestamp: str):
+    @pytest.mark.parametrize('timestamp', MALFORMED)
+    def test_malformed_raises_value_error(self, timestamp: str):
         # ValueError is what fromisoformat raises, and what logs() catches to skip an entry it
         # can't read rather than failing the whole call.
         with pytest.raises(ValueError, match='Invalid isoformat string'):
             _utils.parse_timestamp(timestamp)
+        with pytest.raises(ValueError, match='Invalid isoformat string'):
+            _utils._parse_timestamp_310(timestamp)
+
+    @pytest.mark.parametrize('timestamp', NOT_SNAPD_FORMAT)
+    def test_not_snapd_format_raises_value_error_on_310(self, timestamp: str):
+        # Only asserted of the 3.10 parser: on 3.11+ parse_timestamp hands the string straight
+        # to fromisoformat, which reads all of these. That difference is the price of dropping
+        # the parser by deleting a branch, and it only shows up for timestamps snapd never sends.
+        with pytest.raises(ValueError, match='Invalid isoformat string'):
+            _utils._parse_timestamp_310(timestamp)
 
     @pytest.mark.parametrize('channel', ['stable', 'candidate', 'beta', 'edge'])
     def test_resolving_the_tracked_channel_is_a_no_op(self, channel: str):


### PR DESCRIPTION
The goal of this PR is to document the user-facing `InstalledInfo` class, returned by `snap.list_one`. Doing so lead to the following changes:
- Add a `__repr__` (and test that it round-trips).
- Drop unnecessary `normalize_channel` call leftover from when we incorrectly used `'channel'` (whatever the user asked for) rather than `'tracking-channel'` (snapd's normalised value).
- Fix our Python 3.10 timestamp parsing (`fromisoformat` doesn't support snapd's format until 3.11) -- it previously always assumed the timezone was UTC, whereas snapd's timestamps are timezone aware (and reflect where the daemon is running).

I've left Claude's verbose comments for now, as I think they're somewhat helpful in the context of PR review, but I intend to trim them down before merging to avoid comment drift and make the code easier to follow.