### PR TITLE
feat(snap): add `SocketNotFound` + additional error coverage; document error behaviour

### DIFF
--- a/snap/src/charmlibs/snap/__init__.py
+++ b/snap/src/charmlibs/snap/__init__.py
@@ -37,19 +37,24 @@ invalid arguments to library functions.
 
 All functions will raise a :class:`APIError` (or a subclass) if snapd returns an error response.
 Functions will raise specific subclasses where possible to allow callers to handle logical errors.
-Check the documentation for each function for details on which exceptions it may raise.
+Check the documentation for each function for details on which exceptions it may raise. A
+function's documented errors are the ones it can report specifically: a plain :class:`APIError`,
+or one of the transport errors below, is possible for any call.
 
 Separately from the :class:`APIError` hierarchy (but inheriting from :class:`Error`),
 the library may also raise the following exceptions:
 
-A :class:`TimeoutError` indicates that the snapd API did not respond in a timely manner.
-This may be transient, due to the snap store infrastructure being under load, and the library
-makes some efforts to retry operations. Callers may catch this error to layer their own retry
-logic on top, or report a transient failure to the user.
+A :class:`TimeoutError` indicates that snapd did not respond to a request in time. The library
+does not retry a request that timed out: the timeout is generous, and already covers the retries
+snapd itself makes against the store within a single request. The failure may still be transient,
+due to the snap store infrastructure being under load, so callers may catch this error to layer
+their own retry logic on top, or report a transient failure to the user.
 
-A :class:`ConnectionError` indicates other transport level failures, and may require user action.
-For example, :class:`SocketNotFoundError` indicates that the library was unable to connect to the
-snapd socket at all, which usually means snapd is not installed on the system.
+A :class:`ConnectionError` indicates that snapd could not be reached at all, and may require user
+action. The library briefly retries read-only requests, since snapd may be restarting as part of
+a snap operation, but not requests that change state, since it cannot tell whether snapd received
+them. :class:`SocketNotFoundError`, a subclass raised when the snapd socket does not exist, is
+never retried: it usually means snapd is not installed on the system.
 
 A :class:`BadResponseError` is raised if the snapd API returns a response the library does not
 understand. Callers will not be able to resolve this error directly, and should report it to the
@@ -69,6 +74,7 @@ from ._errors import (
     NotInStoreError,
     OptionNotFoundError,
     RevisionNotAvailableError,
+    SocketNotFoundError,
     TimeoutError,  # noqa: A004 (shadowing a Python builtin)
 )
 from ._functions import (
@@ -123,6 +129,7 @@ __all__ = [
     'NotInstalledError',
     'OptionNotFoundError',
     'RevisionNotAvailableError',
+    'SocketNotFoundError',
     'TimeoutError',
     'alias',
     'connect',

--- a/snap/src/charmlibs/snap/__init__.py
+++ b/snap/src/charmlibs/snap/__init__.py
@@ -31,18 +31,29 @@ Also manage:
 Exceptions
 ----------
 
-All functions will raise a :class:`Error` subclass if the snapd API returns an error response.
+All errors raised due to interactions with the snapd API are subclasses of :class:`Error`.
+Callers may trigger regular Python exceptions (e.g. :class:`ValueError`) when passing
+invalid arguments to library functions.
 
+All functions will raise a :class:`APIError` (or a subclass) if snapd returns an error response.
 Functions will raise specific subclasses where possible to allow callers to handle logical errors.
 Check the documentation for each function for details on which exceptions it may raise.
 
-The :class:`APIError` subclass will be raised if the snapd API returns a malformed response.
-Callers will not be able to resolve this error directly, but may want to catch it for logging,
-or to trigger retries if the error may be transient. If retries are not successful,
-user intervention may be required.
+Separately from the :class:`APIError` hierarchy (but inheriting from :class:`Error`),
+the library may also raise the following exceptions:
 
-A :class:`ConnectionError` indicates a failure to connect to the snapd socket at all. In this case
-something is badly wrong with the system, and user intervention is almost certainly required.
+A :class:`TimeoutError` indicates that the snapd API did not respond in a timely manner.
+This may be transient, due to the snap store infrastructure being under load, and the library
+makes some efforts to retry operations. Callers may catch this error to layer their own retry
+logic on top, or report a transient failure to the user.
+
+A :class:`ConnectionError` indicates other transport level failures, and may require user action.
+For example, :class:`SocketNotFoundError` indicates that the library was unable to connect to the
+snapd socket at all, which usually means snapd is not installed on the system.
+
+A :class:`BadResponseError` is raised if the snapd API returns a response the library does not
+understand. Callers will not be able to resolve this error directly, and should report it to the
+library maintainers.
 """
 
 from ._errors import (

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -35,18 +35,8 @@ from . import _client_sockets, _errors
 
 logger = logging.getLogger(__name__)
 
-# The transport failures that reach us untranslated once a request is on the wire. urllib only
-# wraps failures from opening the connection and sending the request (AbstractHTTPHandler.do_open
-# wraps those in URLError); anything that goes wrong while snapd is answering comes back out of
-# http.client as-is, in two flavours:
-# - OSError, when the connection breaks: a ConnectionResetError if snapd aborts, or
-#   http.client.RemoteDisconnected (which subclasses it) if snapd closes cleanly.
-# - http.client.HTTPException, when the connection delivers something unusable: IncompleteRead
-#   for a body cut short, BadStatusLine or LineTooLong for an answer that isn't HTTP. These are
-#   *not* OSErrors, so catching OSError alone would let them escape.
-# Both flavours can arise at either point we touch the socket -- sending the request in _request
-# and reading the body in _read -- so both use this tuple. All four combinations are pinned
-# against a real socket in tests/unit/test_client.py::TestSnapdGoingAwayMidRequest.
+# urllib wraps failures from opening the connection and sending the request in URLError,
+# but if a connection breaks we can get an OSError, or an HTTPException on a truncated response.
 _TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
 
 # Defined in the snap application itself under dirs/dirs.go as SnapdSocket.
@@ -184,9 +174,6 @@ def _request(
             value='',
         ) from e
     except _TRANSPORT_ERRORS as e:
-        # See _TRANSPORT_ERRORS: a failure while snapd answers isn't wrapped by urllib, most
-        # visibly when snapd restarts after accepting the request. Without this the error would
-        # escape the library's hierarchy, and _retry_json_get wouldn't retry it.
         raise _errors.ConnectionError(
             f'Connection to snapd lost: {method} {path}: {e}',
             kind='charmlibs-snap-connection-error',
@@ -280,14 +267,7 @@ def _decode_logs(response: http.client.HTTPResponse) -> list[dict[str, str]]:
 
 
 def _read(response: http.client.HTTPResponse) -> bytes:
-    """Read a response body, translating a transport failure mid-read into a library error.
-
-    The body is read after :func:`_request` returns, so the translation it does doesn't cover
-    this: snapd going away between sending the headers and finishing the body would otherwise
-    surface as one of the raw :data:`_TRANSPORT_ERRORS`, outside the library's error hierarchy.
-    A body cut short is the :class:`http.client.IncompleteRead` case specifically -- snapd
-    promised a Content-Length it then didn't deliver.
-    """
+    """Read a response body, translating a transport failure mid-read into a library error."""
     try:
         return response.read()
     except TimeoutError:

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -35,6 +35,16 @@ from . import _client_sockets, _errors
 
 logger = logging.getLogger(__name__)
 
+# The transport failures that reach us untranslated once a request is on the wire. urllib only
+# wraps failures from opening the connection and sending the request (AbstractHTTPHandler.do_open
+# wraps those in URLError); anything that goes wrong while snapd is answering comes back out of
+# http.client as-is, in two flavours the tests pin down against a real socket:
+# - OSError, when the connection breaks (a ConnectionResetError if snapd aborts, or
+#   http.client.RemoteDisconnected, which subclasses both, if it closes cleanly).
+# - http.client.HTTPException, when the connection delivers something unusable
+#   (http.client.IncompleteRead for a body cut short, which is *not* an OSError).
+_TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
+
 # Defined in the snap application itself under dirs/dirs.go as SnapdSocket.
 _SOCKET_PATH = '/run/snapd.socket'
 # Timeout for a single request.
@@ -143,7 +153,41 @@ def _request(
         headers=headers or {},
         data=data,
     )
-    response = _open(request)
+    opener = urllib.request.OpenerDirector()
+    opener.add_handler(_client_sockets.UnixSocketHandler(_SOCKET_PATH))
+    # We need to handle HTTP errors ourselves, since the response body contains meaningful info,
+    # so we don't add HTTPErrorProcessor or HTTPDefaultErrorHandler, which would raise too early.
+    # Without HTTPErrorProcessor, urllib never dispatches 3xx to HTTPRedirectHandler either.
+    # We don't expect redirects, so we manually convert 3xx responses into errors below.
+    try:
+        response = opener.open(request, timeout=_REQUEST_TIMEOUT)
+    except TimeoutError:
+        raise _errors.TimeoutError(
+            f'Request to snapd timed out after {_REQUEST_TIMEOUT}s: {method} {path}',
+            kind='charmlibs-snap-request-timeout',
+            value='',
+        ) from None
+    except urllib.error.URLError as e:
+        if e.args and isinstance(e.args[0], FileNotFoundError):
+            raise _errors.SocketNotFoundError(
+                f'Could not connect to snapd: socket not found at {_SOCKET_PATH!r}',
+                kind='charmlibs-snap-socket-not-found',
+                value='',
+            ) from None
+        raise _errors.ConnectionError(
+            str(e.reason),
+            kind='charmlibs-snap-connection-error',
+            value='',
+        ) from e
+    except _TRANSPORT_ERRORS as e:
+        # See _TRANSPORT_ERRORS: a failure while snapd answers isn't wrapped by urllib, most
+        # visibly when snapd restarts after accepting the request. Without this the error would
+        # escape the library's hierarchy, and _retry_json_get wouldn't retry it.
+        raise _errors.ConnectionError(
+            f'Connection to snapd lost: {method} {path}: {e}',
+            kind='charmlibs-snap-connection-error',
+            value='',
+        ) from e
     if 300 <= response.status < 400:  # 3xx responses.
         # snapd itself never redirects, aside from path canonicalisation -- for example,
         # paths containing '//', '/./' or '/../' get a 301 to the cleaned path.
@@ -231,72 +275,12 @@ def _decode_logs(response: http.client.HTTPResponse) -> list[dict[str, str]]:
     return logs
 
 
-#############
-# transport #
-#############
-
-
-# The transport failures that reach us untranslated. urllib only wraps failures from opening the
-# connection and sending the request (AbstractHTTPHandler.do_open wraps those in URLError);
-# anything that goes wrong while snapd is answering comes back out of http.client as-is, in two
-# flavours the tests pin down against a real socket:
-# - OSError, when the connection breaks (a ConnectionResetError if snapd aborts, or
-#   http.client.RemoteDisconnected, which subclasses both, if it closes cleanly).
-# - http.client.HTTPException, when the connection delivers something unusable
-#   (http.client.IncompleteRead for a body cut short, which is *not* an OSError).
-_TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
-
-
-def _open(request: urllib.request.Request) -> http.client.HTTPResponse:
-    """Send a prepared request over the snapd socket, returning the raw HTTPResponse.
-
-    Every way the connection can fail is translated here, so that :func:`_request` deals only
-    with responses snapd actually sent, and callers only ever see an :class:`_errors.Error`.
-    """
-    opener = urllib.request.OpenerDirector()
-    opener.add_handler(_client_sockets.UnixSocketHandler(_SOCKET_PATH))
-    # We need to handle HTTP errors ourselves, since the response body contains meaningful info,
-    # so we don't add HTTPErrorProcessor or HTTPDefaultErrorHandler, which would raise too early.
-    # Without HTTPErrorProcessor, urllib never dispatches 3xx to HTTPRedirectHandler either.
-    # We don't expect redirects, so _request converts 3xx responses into errors itself.
-    target = f'{request.get_method()} {urllib.parse.urlparse(request.full_url).path}'
-    try:
-        return opener.open(request, timeout=_REQUEST_TIMEOUT)
-    except TimeoutError:
-        raise _errors.TimeoutError(
-            f'Request to snapd timed out after {_REQUEST_TIMEOUT}s: {target}',
-            kind='charmlibs-snap-request-timeout',
-            value='',
-        ) from None
-    except urllib.error.URLError as e:
-        if e.args and isinstance(e.args[0], FileNotFoundError):
-            raise _errors.SocketNotFoundError(
-                f'Could not connect to snapd: socket not found at {_SOCKET_PATH!r}',
-                kind='charmlibs-snap-socket-not-found',
-                value='',
-            ) from None
-        raise _errors.ConnectionError(
-            str(e.reason),
-            kind='charmlibs-snap-connection-error',
-            value='',
-        ) from e
-    except _TRANSPORT_ERRORS as e:
-        # See _TRANSPORT_ERRORS: a failure while snapd answers isn't wrapped by urllib, most
-        # visibly when snapd restarts after accepting the request. Without this the error would
-        # escape the library's hierarchy, and _retry_json_get wouldn't retry it.
-        raise _errors.ConnectionError(
-            f'Connection to snapd lost: {target}: {e}',
-            kind='charmlibs-snap-connection-error',
-            value='',
-        ) from e
-
-
 def _read(response: http.client.HTTPResponse) -> bytes:
     """Read a response body, translating a transport failure mid-read into a library error.
 
-    The body is read after :func:`_open` returns, so the translation it does doesn't cover this:
-    snapd going away between sending the headers and finishing the body would otherwise surface
-    as one of the raw :data:`_TRANSPORT_ERRORS`, outside the library's error hierarchy.
+    The body is read after :func:`_request` returns, so the translation it does doesn't cover
+    this: snapd going away between sending the headers and finishing the body would otherwise
+    surface as one of the raw :data:`_TRANSPORT_ERRORS`, outside the library's error hierarchy.
     A body cut short is the :class:`http.client.IncompleteRead` case specifically -- snapd
     promised a Content-Length it then didn't deliver.
     """

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -35,16 +35,6 @@ from . import _client_sockets, _errors
 
 logger = logging.getLogger(__name__)
 
-# The transport failures that reach us untranslated once a request is on the wire. urllib only
-# wraps failures from opening the connection and sending the request (AbstractHTTPHandler.do_open
-# wraps those in URLError); anything that goes wrong while snapd is answering comes back out of
-# http.client as-is, in two flavours the tests pin down against a real socket:
-# - OSError, when the connection breaks (a ConnectionResetError if snapd aborts, or
-#   http.client.RemoteDisconnected, which subclasses both, if it closes cleanly).
-# - http.client.HTTPException, when the connection delivers something unusable
-#   (http.client.IncompleteRead for a body cut short, which is *not* an OSError).
-_TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
-
 # Defined in the snap application itself under dirs/dirs.go as SnapdSocket.
 _SOCKET_PATH = '/run/snapd.socket'
 # Timeout for a single request.
@@ -153,41 +143,7 @@ def _request(
         headers=headers or {},
         data=data,
     )
-    opener = urllib.request.OpenerDirector()
-    opener.add_handler(_client_sockets.UnixSocketHandler(_SOCKET_PATH))
-    # We need to handle HTTP errors ourselves, since the response body contains meaningful info,
-    # so we don't add HTTPErrorProcessor or HTTPDefaultErrorHandler, which would raise too early.
-    # Without HTTPErrorProcessor, urllib never dispatches 3xx to HTTPRedirectHandler either.
-    # We don't expect redirects, so we manually convert 3xx responses into errors below.
-    try:
-        response = opener.open(request, timeout=_REQUEST_TIMEOUT)
-    except TimeoutError:
-        raise _errors.TimeoutError(
-            f'Request to snapd timed out after {_REQUEST_TIMEOUT}s: {method} {path}',
-            kind='charmlibs-snap-request-timeout',
-            value='',
-        ) from None
-    except urllib.error.URLError as e:
-        if e.args and isinstance(e.args[0], FileNotFoundError):
-            raise _errors.SocketNotFoundError(
-                f'Could not connect to snapd: socket not found at {_SOCKET_PATH!r}',
-                kind='charmlibs-snap-socket-not-found',
-                value='',
-            ) from None
-        raise _errors.ConnectionError(
-            str(e.reason),
-            kind='charmlibs-snap-connection-error',
-            value='',
-        ) from e
-    except _TRANSPORT_ERRORS as e:
-        # See _TRANSPORT_ERRORS: a failure while snapd answers isn't wrapped by urllib, most
-        # visibly when snapd restarts after accepting the request. Without this the error would
-        # escape the library's hierarchy, and _retry_json_get wouldn't retry it.
-        raise _errors.ConnectionError(
-            f'Connection to snapd lost: {method} {path}: {e}',
-            kind='charmlibs-snap-connection-error',
-            value='',
-        ) from e
+    response = _open(request)
     if 300 <= response.status < 400:  # 3xx responses.
         # snapd itself never redirects, aside from path canonicalisation -- for example,
         # paths containing '//', '/./' or '/../' get a 301 to the cleaned path.
@@ -275,12 +231,72 @@ def _decode_logs(response: http.client.HTTPResponse) -> list[dict[str, str]]:
     return logs
 
 
+#############
+# transport #
+#############
+
+
+# The transport failures that reach us untranslated. urllib only wraps failures from opening the
+# connection and sending the request (AbstractHTTPHandler.do_open wraps those in URLError);
+# anything that goes wrong while snapd is answering comes back out of http.client as-is, in two
+# flavours the tests pin down against a real socket:
+# - OSError, when the connection breaks (a ConnectionResetError if snapd aborts, or
+#   http.client.RemoteDisconnected, which subclasses both, if it closes cleanly).
+# - http.client.HTTPException, when the connection delivers something unusable
+#   (http.client.IncompleteRead for a body cut short, which is *not* an OSError).
+_TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
+
+
+def _open(request: urllib.request.Request) -> http.client.HTTPResponse:
+    """Send a prepared request over the snapd socket, returning the raw HTTPResponse.
+
+    Every way the connection can fail is translated here, so that :func:`_request` deals only
+    with responses snapd actually sent, and callers only ever see an :class:`_errors.Error`.
+    """
+    opener = urllib.request.OpenerDirector()
+    opener.add_handler(_client_sockets.UnixSocketHandler(_SOCKET_PATH))
+    # We need to handle HTTP errors ourselves, since the response body contains meaningful info,
+    # so we don't add HTTPErrorProcessor or HTTPDefaultErrorHandler, which would raise too early.
+    # Without HTTPErrorProcessor, urllib never dispatches 3xx to HTTPRedirectHandler either.
+    # We don't expect redirects, so _request converts 3xx responses into errors itself.
+    target = f'{request.get_method()} {urllib.parse.urlparse(request.full_url).path}'
+    try:
+        return opener.open(request, timeout=_REQUEST_TIMEOUT)
+    except TimeoutError:
+        raise _errors.TimeoutError(
+            f'Request to snapd timed out after {_REQUEST_TIMEOUT}s: {target}',
+            kind='charmlibs-snap-request-timeout',
+            value='',
+        ) from None
+    except urllib.error.URLError as e:
+        if e.args and isinstance(e.args[0], FileNotFoundError):
+            raise _errors.SocketNotFoundError(
+                f'Could not connect to snapd: socket not found at {_SOCKET_PATH!r}',
+                kind='charmlibs-snap-socket-not-found',
+                value='',
+            ) from None
+        raise _errors.ConnectionError(
+            str(e.reason),
+            kind='charmlibs-snap-connection-error',
+            value='',
+        ) from e
+    except _TRANSPORT_ERRORS as e:
+        # See _TRANSPORT_ERRORS: a failure while snapd answers isn't wrapped by urllib, most
+        # visibly when snapd restarts after accepting the request. Without this the error would
+        # escape the library's hierarchy, and _retry_json_get wouldn't retry it.
+        raise _errors.ConnectionError(
+            f'Connection to snapd lost: {target}: {e}',
+            kind='charmlibs-snap-connection-error',
+            value='',
+        ) from e
+
+
 def _read(response: http.client.HTTPResponse) -> bytes:
     """Read a response body, translating a transport failure mid-read into a library error.
 
-    The body is read after :func:`_request` returns, so the translation it does doesn't cover
-    this: snapd going away between sending the headers and finishing the body would otherwise
-    surface as one of the raw :data:`_TRANSPORT_ERRORS`, outside the library's error hierarchy.
+    The body is read after :func:`_open` returns, so the translation it does doesn't cover this:
+    snapd going away between sending the headers and finishing the body would otherwise surface
+    as one of the raw :data:`_TRANSPORT_ERRORS`, outside the library's error hierarchy.
     A body cut short is the :class:`http.client.IncompleteRead` case specifically -- snapd
     promised a Content-Length it then didn't deliver.
     """

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -38,11 +38,15 @@ logger = logging.getLogger(__name__)
 # The transport failures that reach us untranslated once a request is on the wire. urllib only
 # wraps failures from opening the connection and sending the request (AbstractHTTPHandler.do_open
 # wraps those in URLError); anything that goes wrong while snapd is answering comes back out of
-# http.client as-is, in two flavours the tests pin down against a real socket:
-# - OSError, when the connection breaks (a ConnectionResetError if snapd aborts, or
-#   http.client.RemoteDisconnected, which subclasses both, if it closes cleanly).
-# - http.client.HTTPException, when the connection delivers something unusable
-#   (http.client.IncompleteRead for a body cut short, which is *not* an OSError).
+# http.client as-is, in two flavours:
+# - OSError, when the connection breaks: a ConnectionResetError if snapd aborts, or
+#   http.client.RemoteDisconnected (which subclasses it) if snapd closes cleanly.
+# - http.client.HTTPException, when the connection delivers something unusable: IncompleteRead
+#   for a body cut short, BadStatusLine or LineTooLong for an answer that isn't HTTP. These are
+#   *not* OSErrors, so catching OSError alone would let them escape.
+# Both flavours can arise at either point we touch the socket -- sending the request in _request
+# and reading the body in _read -- so both use this tuple. All four combinations are pinned
+# against a real socket in tests/unit/test_client.py::TestSnapdGoingAwayMidRequest.
 _TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
 
 # Defined in the snap application itself under dirs/dirs.go as SnapdSocket.

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -96,8 +96,8 @@ def _retry_json_get(
             return _json_request('GET', path, query=query, log=log)
         except _errors.ConnectionError as e:  # noqa: PERF203
             # We don't catch TimeoutError -- the timeout is longer than our retry budget.
-            # We don't retry on a missing socket, since that means snapd is not running at all.
-            if e.kind == 'charmlibs-snap-socket-not-found':
+            # We don't retry on a missing socket, since that means snapd is not installed at all.
+            if isinstance(e, _errors.SocketNotFoundError):
                 raise
             if time.monotonic() > deadline:
                 raise
@@ -161,13 +161,24 @@ def _request(
         ) from None
     except urllib.error.URLError as e:
         if e.args and isinstance(e.args[0], FileNotFoundError):
-            raise _errors.ConnectionError(
+            raise _errors.SocketNotFoundError(
                 f'Could not connect to snapd: socket not found at {_SOCKET_PATH!r}',
                 kind='charmlibs-snap-socket-not-found',
                 value='',
             ) from None
         raise _errors.ConnectionError(
             str(e.reason),
+            kind='charmlibs-snap-connection-error',
+            value='',
+        ) from e
+    except OSError as e:
+        # urllib only wraps failures from opening the connection and sending the request (it does
+        # so in AbstractHTTPHandler.do_open). A failure while snapd sends the response comes back
+        # out of http.client raw -- most visibly a ConnectionResetError when snapd restarts after
+        # accepting the request -- so we translate it here as well. Without this the error would
+        # escape the library's hierarchy, and _retry_json_get wouldn't retry it.
+        raise _errors.ConnectionError(
+            f'Connection to snapd lost: {method} {path}: {e}',
             kind='charmlibs-snap-connection-error',
             value='',
         ) from e
@@ -194,7 +205,7 @@ def _decode(response: http.client.HTTPResponse) -> object | _Change:
     :class:`_Change` (which the caller can :meth:`_Change.wait` on), a sync
     response returns its ``result`` field, and an error response raises.
     """
-    response_bytes = response.read()
+    response_bytes = _read(response)
     try:
         response_dict: dict[str, Any] = json.loads(response_bytes)
     except json.JSONDecodeError as e:
@@ -236,7 +247,7 @@ def _decode_logs(response: http.client.HTTPResponse) -> list[dict[str, str]]:
 
     Sanitization checks for individual entries are left to the caller.
     """
-    response_bytes = response.read()
+    response_bytes = _read(response)
     # /v2/logs returns a stream of JSON objects separated by \n\x1e
     try:
         logs = [
@@ -256,6 +267,29 @@ def _decode_logs(response: http.client.HTTPResponse) -> list[dict[str, str]]:
     if len(logs) == 1 and logs[0].get('type') == 'error':
         raise _make_error(logs[0])
     return logs
+
+
+def _read(response: http.client.HTTPResponse) -> bytes:
+    """Read a response body, translating a transport failure mid-read into a library error.
+
+    The body is read after :func:`_request` returns, so the translation it does doesn't cover
+    this: snapd going away between sending the headers and finishing the body would otherwise
+    surface as a raw :class:`OSError`, outside the library's error hierarchy.
+    """
+    try:
+        return response.read()
+    except TimeoutError:
+        raise _errors.TimeoutError(
+            f'Timed out reading snapd response for path {_get_path(response)!r}',
+            kind='charmlibs-snap-request-timeout',
+            value='',
+        ) from None
+    except OSError as e:
+        raise _errors.ConnectionError(
+            f'Connection to snapd lost while reading response for path {_get_path(response)!r}: {e}',  # noqa: E501
+            kind='charmlibs-snap-connection-error',
+            value='',
+        ) from e
 
 
 def _get_path(response: http.client.HTTPResponse) -> str:

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -21,6 +21,7 @@ Errors are converted into :class:`Error` exceptions, with specific subclasses wh
 
 from __future__ import annotations
 
+import http.client
 import json
 import logging
 import time
@@ -32,10 +33,17 @@ from typing import Any
 
 from . import _client_sockets, _errors
 
-if typing.TYPE_CHECKING:
-    import http.client
-
 logger = logging.getLogger(__name__)
+
+# The transport failures that reach us untranslated once a request is on the wire. urllib only
+# wraps failures from opening the connection and sending the request (AbstractHTTPHandler.do_open
+# wraps those in URLError); anything that goes wrong while snapd is answering comes back out of
+# http.client as-is, in two flavours the tests pin down against a real socket:
+# - OSError, when the connection breaks (a ConnectionResetError if snapd aborts, or
+#   http.client.RemoteDisconnected, which subclasses both, if it closes cleanly).
+# - http.client.HTTPException, when the connection delivers something unusable
+#   (http.client.IncompleteRead for a body cut short, which is *not* an OSError).
+_TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
 
 # Defined in the snap application itself under dirs/dirs.go as SnapdSocket.
 _SOCKET_PATH = '/run/snapd.socket'
@@ -171,11 +179,9 @@ def _request(
             kind='charmlibs-snap-connection-error',
             value='',
         ) from e
-    except OSError as e:
-        # urllib only wraps failures from opening the connection and sending the request (it does
-        # so in AbstractHTTPHandler.do_open). A failure while snapd sends the response comes back
-        # out of http.client raw -- most visibly a ConnectionResetError when snapd restarts after
-        # accepting the request -- so we translate it here as well. Without this the error would
+    except _TRANSPORT_ERRORS as e:
+        # See _TRANSPORT_ERRORS: a failure while snapd answers isn't wrapped by urllib, most
+        # visibly when snapd restarts after accepting the request. Without this the error would
         # escape the library's hierarchy, and _retry_json_get wouldn't retry it.
         raise _errors.ConnectionError(
             f'Connection to snapd lost: {method} {path}: {e}',
@@ -274,7 +280,9 @@ def _read(response: http.client.HTTPResponse) -> bytes:
 
     The body is read after :func:`_request` returns, so the translation it does doesn't cover
     this: snapd going away between sending the headers and finishing the body would otherwise
-    surface as a raw :class:`OSError`, outside the library's error hierarchy.
+    surface as one of the raw :data:`_TRANSPORT_ERRORS`, outside the library's error hierarchy.
+    A body cut short is the :class:`http.client.IncompleteRead` case specifically -- snapd
+    promised a Content-Length it then didn't deliver.
     """
     try:
         return response.read()
@@ -284,7 +292,7 @@ def _read(response: http.client.HTTPResponse) -> bytes:
             kind='charmlibs-snap-request-timeout',
             value='',
         ) from None
-    except OSError as e:
+    except _TRANSPORT_ERRORS as e:
         raise _errors.ConnectionError(
             f'Connection to snapd lost while reading response for path {_get_path(response)!r}: {e}',  # noqa: E501
             kind='charmlibs-snap-connection-error',

--- a/snap/src/charmlibs/snap/_errors.py
+++ b/snap/src/charmlibs/snap/_errors.py
@@ -29,7 +29,8 @@ class Error(Exception):
     Args:
         message: Typically the 'message' field from a snapd API response.
         kind: The 'kind' field from a snapd API response, used to derive the specific error type.
-            Manually constructed errors have the kind 'charmlibs-snap'.
+            Errors the library raises itself have a kind starting with 'charmlibs-snap', so that
+            they can't collide with a kind snapd may add in future.
         value: The 'value' field from a snapd API response, which may contain additional details.
             Almost always a string, but can be any JSON value.
         status_code: The HTTP status code from the snapd API response, if applicable.
@@ -113,15 +114,29 @@ class Error(Exception):
 class BadResponseError(Error):
     """Raised manually when the snapd API returns a response we don't understand.
 
-    Callers will not be able to resolve this error directly, but may want to catch it for logging,
-    or to trigger retries. If retries are not successful, user intervention may be required.
+    Callers will not be able to resolve this error directly. It means the library and snapd
+    disagree about the shape of a response, so it should be reported to the library maintainers.
     """
 
 
 class ConnectionError(Error, _builtins.ConnectionError):  # noqa: A001 (shadowing a Python builtin)
     """Raised when a connection to the snapd socket fails.
 
-    This typically indicates that snapd is not installed or running.
+    This typically indicates that snapd isn't running -- for example, it may be restarting
+    as part of a snap operation. The library briefly retries read-only requests before giving
+    up, so a caller that sees this error is looking at a system where snapd stayed unreachable.
+    Requests that change state aren't retried, since the library can't tell whether snapd
+    received them.
+
+    See :class:`SocketNotFoundError` for the case where the socket doesn't exist at all.
+    """
+
+
+class SocketNotFoundError(ConnectionError):
+    """Raised when the snapd socket does not exist.
+
+    This typically indicates that snapd is not installed on the system. Unlike other connection
+    failures, this is not retried: a socket that isn't there won't appear moments later.
     """
 
 

--- a/snap/src/charmlibs/snap/_snapd_aliases.py
+++ b/snap/src/charmlibs/snap/_snapd_aliases.py
@@ -59,7 +59,7 @@ def unalias(alias: str) -> None:
         ValueError: if the alias is empty or blank.
         ChangeError: if the alias removal fails after starting.
         APIError: if the alias does not exist (for example, was never created, or the snap it
-            belonged to was removed — aliases do not survive snap removal).
+            belonged to was removed -- aliases do not survive snap removal).
     """
     _utils.raise_if_empty_or_blank(alias, label='alias')
     data = {'action': 'unalias', 'alias': alias}

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -61,6 +61,7 @@ def get(snap: str, keys: str | Iterable[str] | None = None) -> dict[str, Any]:
             snap doesn't recognise, a key that was never set, and a key that was unset. Any
             defaults a snap applies internally are invisible here unless its configure hook has
             stored them with ``snapctl set``.
+        BadResponseError: if snapd answers with something other than a configuration mapping.
 
     ::
 
@@ -102,6 +103,13 @@ def get(snap: str, keys: str | Iterable[str] | None = None) -> dict[str, Any]:
         if error := _utils.check_installed(snap, skip_system=True):
             raise error from None
         raise
+    if not isinstance(config, dict):
+        raise _errors.BadResponseError(
+            message=f'Unexpected response type {type(config).__name__!r} for the configuration of snap {snap!r}, expected a "dict"',  # noqa: E501
+            kind='charmlibs-snap',
+            value=str(config),
+        )
+    config = typing.cast('dict[str, Any]', config)
     # Empty result when all config was requested: error if the snap isn't installed.
     if (
         (not config)
@@ -112,8 +120,7 @@ def get(snap: str, keys: str | Iterable[str] | None = None) -> dict[str, Any]:
         # The CLI returns 'error: snap "foo" has no configuration' for a missing snap.
         # For symmetry with PUT (set/unset), we raise NotInstalledError for a missing snap.
         raise error
-    assert isinstance(config, dict)
-    return typing.cast('dict[str, Any]', config)
+    return config
 
 
 def get_one(snap: str, key: str) -> Any:
@@ -137,6 +144,7 @@ def get_one(snap: str, key: str) -> Any:
             whose configuration is served whether or not the core snap is installed.
         OptionNotFoundError: if the key has no value stored in the snap's configuration. See
             :func:`get` for why snapd cannot distinguish an unrecognised key from an unset one.
+        BadResponseError: if snapd answers with something other than a configuration mapping.
 
     ::
 

--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -113,8 +113,9 @@ def list_one(snap: str) -> InstalledInfo:
         An :class:`InstalledInfo` object with information about the snap.
 
     Raises:
-        ValueError: if the snap name is empty or is not a single path segment.
+        ValueError: if the snap name is empty, blank, or is not a single path segment.
         NotInstalledError: if the snap is not installed.
+        BadResponseError: if snapd's description of the snap isn't one we can read.
         Error: (or a subtype) if the information could not be retrieved for another reason.
     """
     try:
@@ -122,9 +123,23 @@ def list_one(snap: str) -> InstalledInfo:
     except _errors._NotFoundError as e:
         # snap-not-found -> NotInstalledError: This queries local state only.
         raise _errors.NotInstalledError._from(e) from None
-    assert isinstance(info_dict, dict)
+    if not isinstance(info_dict, dict):
+        raise _errors.BadResponseError(
+            message=f'Unexpected response type {type(info_dict).__name__!r} for snap {snap!r}, expected a "dict"',  # noqa: E501
+            kind='charmlibs-snap',
+            value=str(info_dict),
+        )
     info_dict = typing.cast('dict[str, str]', info_dict)
-    return InstalledInfo._from_dict(info_dict)
+    try:
+        return InstalledInfo._from_dict(info_dict)
+    except (KeyError, TypeError, ValueError) as e:
+        # A field we require is missing, or holds something we can't parse. Reported rather than
+        # asserted, so that the documented contract -- every failure is an Error -- holds here too.
+        raise _errors.BadResponseError(
+            message=f"Could not read snapd's description of snap {snap!r}: {e!r}",
+            kind='charmlibs-snap',
+            value=str(info_dict),
+        ) from None
 
 
 def install(
@@ -160,7 +175,7 @@ def install(
         at all.
 
     Raises:
-        ValueError: if the snap name is empty or is not a single path segment.
+        ValueError: if the snap name is empty, blank, or is not a single path segment.
         NotInStoreError: if the store has no snap by that name.
         RevisionNotAvailableError: if the specified revision is not available on any channel.
         ChannelNotAvailableError: if the specified channel is not available, or if the specified
@@ -209,7 +224,7 @@ def remove(snap: str, *, purge: bool = False) -> object:
         Not guaranteed to be an actual :class:`bool`.
 
     Raises:
-        ValueError: if the snap name is empty or is not a single path segment.
+        ValueError: if the snap name is empty, blank, or is not a single path segment.
         ChangeError: if the removal fails after starting (for example, a remove hook errors).
         Error: (or a subtype) if the snap could not be removed as requested.
     """
@@ -257,7 +272,7 @@ def refresh(
         revision is specified, even if that revision is already installed.
 
     Raises:
-        ValueError: if the snap name is empty or is not a single path segment.
+        ValueError: if the snap name is empty, blank, or is not a single path segment.
         NotInstalledError: if the snap is not installed.
         NotInStoreError: if the snap is installed but the store no longer offers it.
         RevisionNotAvailableError: if the specified revision is not available on any channel.
@@ -306,7 +321,7 @@ def hold(snap: str, duration: datetime.timedelta | int | float | None = None) ->
             (default), the snap is held indefinitely.
 
     Raises:
-        ValueError: if the snap name is empty or is not a single path segment.
+        ValueError: if the snap name is empty, blank, or is not a single path segment.
         NotInstalledError: If the snap is not installed.
         ChangeError: If the hold change fails after starting.
     """
@@ -339,7 +354,7 @@ def unhold(snap: str) -> None:
         snap: The name of the snap to unhold.
 
     Raises:
-        ValueError: if the snap name is empty or is not a single path segment.
+        ValueError: if the snap name is empty, blank, or is not a single path segment.
         ChangeError: If the unhold change fails after starting.
     """
     # NOTE: Neither the API nor CLI error if the snap isn't installed or held.

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -249,7 +249,7 @@ def test_poll_fails_fast_when_socket_missing():
     try:
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(_client, '_SOCKET_PATH', '/run/this-snapd-socket-does-not-exist.socket')
-            with pytest.raises(_errors.ConnectionError) as ctx:
+            with pytest.raises(_errors.SocketNotFoundError) as ctx:
                 change.wait()
         assert ctx.value.kind == 'charmlibs-snap-socket-not-found'
     finally:

--- a/snap/tests/unit/test_client.py
+++ b/snap/tests/unit/test_client.py
@@ -140,11 +140,8 @@ _FAILURES = [
 
 @contextlib.contextmanager
 def _snapd_that(*behaviours: str) -> Iterator[str]:
-    """Serve one connection per behaviour on a real unix socket, and yield its path.
-
-    The socket lives directly under the system temp dir rather than pytest's tmp_path, because
-    a unix socket path has to fit in sockaddr_un (108 bytes) and pytest's paths are long.
-    """
+    """Serve one connection per behaviour on a real unix socket, and yield its path."""
+    # pytest's tmp_paths are too long -- a unix socket path has to fit in sockaddr_un (108 bytes).
     with tempfile.TemporaryDirectory() as tmp:
         socket_path = str(pathlib.Path(tmp) / 's')
         server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/snap/tests/unit/test_client.py
+++ b/snap/tests/unit/test_client.py
@@ -6,8 +6,15 @@
 from __future__ import annotations
 
 import builtins
+import contextlib
+import http.client
 import json
 import logging
+import pathlib
+import socket
+import tempfile
+import threading
+import time
 import urllib.error
 import urllib.request
 from types import SimpleNamespace
@@ -17,12 +24,13 @@ from unittest.mock import MagicMock
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from pytest import LogCaptureFixture
 
 import charmlibs.snap._errors
-from charmlibs.snap import _client
+from charmlibs.snap import _client, _client_sockets
 from charmlibs.snap._errors import (
     APIError,
     AppNotFoundError,
@@ -53,6 +61,64 @@ def _fake_response(
     if isinstance(data, (dict, list)):
         data = json.dumps(data).encode()
     return SimpleNamespace(read=lambda: data, status=status, reason=reason, url=url)
+
+
+# A fake snapd on a real unix socket, used by TestSnapdGoingAwayMidRequest below. Each name is
+# one connection's worth of behaviour; a server is given one per connection it should accept.
+_RECV_SIZE = 4096
+# Long enough for the client's request to land in the receive buffer before we close on it.
+# Only the 'abort' behaviour waits, and only to make the reset the *unread* kind (see below).
+_ABORT_DELAY = 0.2
+
+
+def _serve(server: socket.socket, behaviours: tuple[str, ...]) -> None:
+    for behaviour in behaviours:
+        conn, _ = server.accept()
+        with conn:
+            if behaviour == 'abort':
+                # Close with the request still sitting unread in the receive buffer: the kernel
+                # then resets the connection rather than closing it cleanly, so the client gets
+                # ECONNRESET -- the errno 104 a live snapd was seen to produce when it goes away
+                # after accepting a request.
+                time.sleep(_ABORT_DELAY)
+                continue
+            conn.recv(_RECV_SIZE)  # Read the request, so the failure is in our answer, not theirs.
+            if behaviour == 'close':
+                continue  # Close without answering at all.
+            if behaviour == 'truncated_body':
+                # Promise more body than we send, so read() raises http.client.IncompleteRead.
+                conn.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n{"type": "sync"')
+                continue
+            body = json.dumps({'type': 'sync', 'result': {'foo': 'bar'}}).encode()
+            conn.sendall(
+                b'HTTP/1.1 200 OK\r\nContent-Length: '
+                + str(len(body)).encode()
+                + b'\r\n\r\n'
+                + body
+            )
+
+
+@contextlib.contextmanager
+def _snapd_that(*behaviours: str) -> Iterator[str]:
+    """Serve one connection per behaviour on a real unix socket, and yield its path.
+
+    The socket lives directly under the system temp dir rather than pytest's tmp_path, because
+    a unix socket path has to fit in sockaddr_un (108 bytes) and pytest's paths are long.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        socket_path = str(pathlib.Path(tmp) / 's')
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        # Bound and listening before we yield, so the client can't connect before we're ready.
+        server.bind(socket_path)
+        server.listen(len(behaviours))
+        server.settimeout(10)  # Don't hang the suite if the client never connects.
+        thread = threading.Thread(target=_serve, args=(server, behaviours), daemon=True)
+        thread.start()
+        try:
+            yield socket_path
+        finally:
+            thread.join(timeout=10)
+            server.close()
 
 
 @pytest.fixture
@@ -253,51 +319,6 @@ class TestErrorResponses:
         assert isinstance(exc_info.value, ConnectionError)
         sleep.assert_not_called()
 
-    def test_reset_while_receiving_response_raises_snap_connection_error(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        # urllib wraps failures from sending the request, but lets a failure from
-        # h.getresponse() through raw -- most visibly a reset when snapd restarts after
-        # accepting the request. We translate it, so it stays inside the library's hierarchy.
-        monkeypatch.setattr(_client, '_CONNECTION_RETRY_BUDGET', 0)
-        monkeypatch.setattr(_client.time, 'sleep', MagicMock())
-        monkeypatch.setattr(
-            urllib.request.OpenerDirector,
-            'open',
-            MagicMock(side_effect=builtins.ConnectionResetError(104, 'Connection reset by peer')),
-        )
-        with pytest.raises(ConnectionError) as exc_info:
-            _client.get('/v2/snaps/hello-world')
-        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
-        assert 'Connection to snapd lost' in exc_info.value.message
-
-    def test_reset_while_receiving_response_is_retried(self, monkeypatch: pytest.MonkeyPatch):
-        # Being a library ConnectionError, it also reaches the GET retry -- the whole point of
-        # that retry is snapd restarting mid-operation, which is how this error arises.
-        monkeypatch.setattr(_client.time, 'sleep', MagicMock())
-        opener = MagicMock(
-            side_effect=[
-                builtins.ConnectionResetError(104, 'Connection reset by peer'),
-                _fake_response({'type': 'sync', 'result': {'foo': 'bar'}}),
-            ]
-        )
-        monkeypatch.setattr(urllib.request.OpenerDirector, 'open', opener)
-        assert _client.get('/v2/snaps/hello-world') == {'foo': 'bar'}
-        assert opener.call_count == 2
-
-    def test_reset_while_reading_body_raises_snap_connection_error(self, mock_raw: MagicMock):
-        # The body is read after _request returns, so it needs translating separately.
-        response = _fake_response({'type': 'sync', 'result': {}})
-        response.read = MagicMock(
-            side_effect=builtins.ConnectionResetError(104, 'Connection reset by peer')
-        )
-        mock_raw.return_value = response
-        with pytest.raises(ConnectionError) as exc_info:
-            _client.get('/v2/snaps/hello-world')
-        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
-        assert 'while reading response' in exc_info.value.message
-        assert '/v2/snaps/hello-world' in exc_info.value.message
-
     def test_timeout_while_reading_body_raises_snap_timeout_error(self, mock_raw: MagicMock):
         response = _fake_response({'type': 'sync', 'result': {}})
         response.read = MagicMock(side_effect=builtins.TimeoutError('timed out'))
@@ -305,16 +326,6 @@ class TestErrorResponses:
         with pytest.raises(TimeoutError) as exc_info:
             _client.get('/v2/snaps/hello-world')
         assert exc_info.value.kind == 'charmlibs-snap-request-timeout'
-
-    def test_reset_while_reading_logs_body_raises_snap_connection_error(self, mock_raw: MagicMock):
-        response = _fake_response(b'')
-        response.read = MagicMock(
-            side_effect=builtins.ConnectionResetError(104, 'Connection reset by peer')
-        )
-        mock_raw.return_value = response
-        with pytest.raises(ConnectionError) as exc_info:
-            _client.get_logs(query={'n': 10, 'names': 'lxd'})
-        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
 
     def test_connection_error_retries_then_raises(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(_client, '_CONNECTION_RETRY_BUDGET', 0)
@@ -346,6 +357,71 @@ class TestErrorResponses:
         ]
         assert _client.get('/v2/snaps/hello-world') == {'foo': 'bar'}
         assert mock_raw.call_count == 2
+
+
+class TestSnapdGoingAwayMidRequest:
+    """Transport failures reproduced against a real unix socket, not a mocked opener.
+
+    urllib only wraps failures from opening the connection and sending the request, in
+    AbstractHTTPHandler.do_open. Anything that goes wrong while the peer is *answering* reaches
+    us untranslated, which is what the except arms in _request and _read exist for. These tests
+    pin down both halves: that urllib really does let each failure through, and that the library
+    converts it. The first half is the premise, so it's asserted rather than assumed -- if a
+    future Python starts wrapping these, these tests fail and those arms can go.
+    """
+
+    @pytest.mark.parametrize(
+        ('behaviour', 'raw_type'),
+        [
+            # RemoteDisconnected subclasses ConnectionResetError, so this assertion holds whether
+            # or not the request lands unread in time to make the reset the kernel-level kind.
+            ('abort', builtins.ConnectionResetError),
+            ('close', http.client.RemoteDisconnected),
+            ('truncated_body', http.client.IncompleteRead),
+        ],
+    )
+    def test_urllib_lets_the_failure_through_untranslated(
+        self, behaviour: str, raw_type: type[BaseException]
+    ):
+        with _snapd_that(behaviour) as socket_path:
+            opener = urllib.request.OpenerDirector()
+            opener.add_handler(_client_sockets.UnixSocketHandler(socket_path))
+            request = urllib.request.Request('http://localhost/v2/snaps/hello-world')
+            with pytest.raises(raw_type) as exc_info:
+                opener.open(request, timeout=10).read()
+        # Not a URLError, so the URLError arm can't catch these...
+        assert not isinstance(exc_info.value, urllib.error.URLError)
+        # ...and IncompleteRead isn't even an OSError, so catching OSError alone would miss it.
+        assert isinstance(exc_info.value, _client._TRANSPORT_ERRORS)
+
+    @pytest.mark.parametrize('behaviour', ['abort', 'close', 'truncated_body'])
+    def test_the_library_translates_the_failure(
+        self, behaviour: str, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Budget 0 so the GET isn't retried: one connection is all the server offers.
+        monkeypatch.setattr(_client, '_CONNECTION_RETRY_BUDGET', 0)
+        monkeypatch.setattr(_client.time, 'sleep', MagicMock())
+        with _snapd_that(behaviour) as socket_path:
+            monkeypatch.setattr(_client, '_SOCKET_PATH', socket_path)
+            with pytest.raises(ConnectionError) as exc_info:
+                _client.get('/v2/snaps/hello-world')
+        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
+        # The socket existed and accepted us, so this isn't the snapd-not-installed case.
+        assert not isinstance(exc_info.value, SocketNotFoundError)
+
+    def test_the_failure_is_retried_on_a_get(self, monkeypatch: pytest.MonkeyPatch):
+        # Translating these is what puts them in front of the GET retry, and snapd restarting
+        # mid-operation -- exactly this failure -- is what that retry exists for.
+        monkeypatch.setattr(_client.time, 'sleep', MagicMock())
+        with _snapd_that('abort', 'ok') as socket_path:
+            monkeypatch.setattr(_client, '_SOCKET_PATH', socket_path)
+            assert _client.get('/v2/snaps/hello-world') == {'foo': 'bar'}
+
+    def test_a_healthy_socket_still_works(self, monkeypatch: pytest.MonkeyPatch):
+        # The control: the same fake snapd answering properly goes through the untouched path.
+        with _snapd_that('ok') as socket_path:
+            monkeypatch.setattr(_client, '_SOCKET_PATH', socket_path)
+            assert _client.get('/v2/snaps/hello-world') == {'foo': 'bar'}
 
 
 class TestAsyncChange:

--- a/snap/tests/unit/test_client.py
+++ b/snap/tests/unit/test_client.py
@@ -12,6 +12,7 @@ import json
 import logging
 import pathlib
 import socket
+import struct
 import tempfile
 import threading
 import time
@@ -71,16 +72,32 @@ _RECV_SIZE = 4096
 _ABORT_DELAY = 0.2
 
 
+def _abort(conn: socket.socket) -> None:
+    """Reset the connection instead of closing it cleanly, the way an aborting peer does.
+
+    Closing while the peer's data sits unread in the receive buffer makes the kernel send RST
+    rather than FIN, so the client gets ECONNRESET -- the errno 104 a live snapd was seen to
+    produce when it goes away mid-request. SO_LINGER with a zero timeout forces the same for a
+    connection whose request we did read.
+    """
+    conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack('ii', 1, 0))
+
+
 def _serve(server: socket.socket, behaviours: tuple[str, ...]) -> None:
     for behaviour in behaviours:
         conn, _ = server.accept()
         with conn:
             if behaviour == 'abort':
-                # Close with the request still sitting unread in the receive buffer: the kernel
-                # then resets the connection rather than closing it cleanly, so the client gets
-                # ECONNRESET -- the errno 104 a live snapd was seen to produce when it goes away
-                # after accepting a request.
+                # Never read the request, so closing on it resets the connection. The wait is
+                # only to let the request land in the buffer first.
                 time.sleep(_ABORT_DELAY)
+                continue
+            if behaviour == 'reset_mid_body':
+                # Answer with headers the client can parse, then reset while it reads the body,
+                # so the failure lands in _read rather than _request. Again, don't read.
+                conn.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: 100000\r\n\r\n' + b'x' * 10)
+                time.sleep(_ABORT_DELAY)
+                _abort(conn)
                 continue
             conn.recv(_RECV_SIZE)  # Read the request, so the failure is in our answer, not theirs.
             if behaviour == 'close':
@@ -89,6 +106,10 @@ def _serve(server: socket.socket, behaviours: tuple[str, ...]) -> None:
                 # Promise more body than we send, so read() raises http.client.IncompleteRead.
                 conn.sendall(b'HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n{"type": "sync"')
                 continue
+            if behaviour == 'not_http':
+                # Something that isn't snapd on the socket: http.client.BadStatusLine.
+                conn.sendall(b'this is not a status line\r\n\r\n')
+                continue
             body = json.dumps({'type': 'sync', 'result': {'foo': 'bar'}}).encode()
             conn.sendall(
                 b'HTTP/1.1 200 OK\r\nContent-Length: '
@@ -96,6 +117,25 @@ def _serve(server: socket.socket, behaviours: tuple[str, ...]) -> None:
                 + b'\r\n\r\n'
                 + body
             )
+
+
+# Each failure a peer can hand us once the request is on the wire: the behaviour that provokes
+# it, the raw error urllib lets through, and which of the two places we touch the socket it
+# surfaces from -- 'sending' for _request (which covers h.getresponse()), 'reading' for _read.
+#
+# Both flavours of _client._TRANSPORT_ERRORS arise at both places, which is why both except arms
+# need the whole tuple: 'not_http' is the pure-HTTPException case that catching OSError alone
+# would miss in _request, and 'reset_mid_body' the pure-OSError case that catching HTTPException
+# alone would miss in _read. RemoteDisconnected subclasses ConnectionResetError, so the 'abort'
+# expectation holds whether or not the request lands unread in time to make the reset the
+# kernel-level kind.
+_FAILURES = [
+    ('abort', builtins.ConnectionResetError, 'sending'),
+    ('close', http.client.RemoteDisconnected, 'sending'),
+    ('not_http', http.client.BadStatusLine, 'sending'),
+    ('truncated_body', http.client.IncompleteRead, 'reading'),
+    ('reset_mid_body', builtins.ConnectionResetError, 'reading'),
+]
 
 
 @contextlib.contextmanager
@@ -368,37 +408,37 @@ class TestSnapdGoingAwayMidRequest:
     pin down both halves: that urllib really does let each failure through, and that the library
     converts it. The first half is the premise, so it's asserted rather than assumed -- if a
     future Python starts wrapping these, these tests fail and those arms can go.
+
+    See _FAILURES for the cases and why each one is there.
     """
 
-    @pytest.mark.parametrize(
-        ('behaviour', 'raw_type'),
-        [
-            # RemoteDisconnected subclasses ConnectionResetError, so this assertion holds whether
-            # or not the request lands unread in time to make the reset the kernel-level kind.
-            ('abort', builtins.ConnectionResetError),
-            ('close', http.client.RemoteDisconnected),
-            ('truncated_body', http.client.IncompleteRead),
-        ],
-    )
+    @pytest.mark.parametrize(('behaviour', 'raw_type', 'stage'), _FAILURES)
     def test_urllib_lets_the_failure_through_untranslated(
-        self, behaviour: str, raw_type: type[BaseException]
+        self, behaviour: str, raw_type: type[BaseException], stage: str
     ):
         with _snapd_that(behaviour) as socket_path:
             opener = urllib.request.OpenerDirector()
             opener.add_handler(_client_sockets.UnixSocketHandler(socket_path))
             request = urllib.request.Request('http://localhost/v2/snaps/hello-world')
             with pytest.raises(raw_type) as exc_info:
-                opener.open(request, timeout=10).read()
-        # Not a URLError, so the URLError arm can't catch these...
-        assert not isinstance(exc_info.value, urllib.error.URLError)
-        # ...and IncompleteRead isn't even an OSError, so catching OSError alone would miss it.
+                response = opener.open(request, timeout=10)
+                # Getting this far means urllib parsed a response, so the failure is in the body.
+                assert stage == 'reading'
+                response.read()
+        if stage == 'sending':
+            assert not isinstance(exc_info.value, urllib.error.URLError)
         assert isinstance(exc_info.value, _client._TRANSPORT_ERRORS)
 
-    @pytest.mark.parametrize('behaviour', ['abort', 'close', 'truncated_body'])
+    @pytest.mark.parametrize(('behaviour', 'raw_type', 'stage'), _FAILURES)
     def test_the_library_translates_the_failure(
-        self, behaviour: str, monkeypatch: pytest.MonkeyPatch
+        self,
+        behaviour: str,
+        raw_type: type[BaseException],
+        stage: str,
+        monkeypatch: pytest.MonkeyPatch,
     ):
-        # Budget 0 so the GET isn't retried: one connection is all the server offers.
+        # Budget 0 so the GET isn't retried: one connection is all the server offers. (A failure
+        # while reading the body isn't retried anyway -- that happens after _retry_json_get.)
         monkeypatch.setattr(_client, '_CONNECTION_RETRY_BUDGET', 0)
         monkeypatch.setattr(_client.time, 'sleep', MagicMock())
         with _snapd_that(behaviour) as socket_path:
@@ -408,6 +448,8 @@ class TestSnapdGoingAwayMidRequest:
         assert exc_info.value.kind == 'charmlibs-snap-connection-error'
         # The socket existed and accepted us, so this isn't the snapd-not-installed case.
         assert not isinstance(exc_info.value, SocketNotFoundError)
+        # The raw error is kept as the cause, so a charm's traceback still shows what broke.
+        assert isinstance(exc_info.value.__cause__, raw_type)
 
     def test_the_failure_is_retried_on_a_get(self, monkeypatch: pytest.MonkeyPatch):
         # Translating these is what puts them in front of the GET retry, and snapd restarting

--- a/snap/tests/unit/test_client.py
+++ b/snap/tests/unit/test_client.py
@@ -34,6 +34,7 @@ from charmlibs.snap._errors import (
     NeedsClassicError,
     NotInstalledError,
     OptionNotFoundError,
+    SocketNotFoundError,
     TimeoutError,  # noqa: A004 (shadowing a Python builtin)
     _AlreadyInstalledError,
     _NotFoundError,
@@ -237,7 +238,7 @@ class TestErrorResponses:
         assert exc_info.value.kind == 'charmlibs-snap-request-timeout'
         assert isinstance(exc_info.value, TimeoutError)
 
-    def test_socket_not_found_raises_snap_connection_error(
+    def test_socket_not_found_raises_socket_not_found_error(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ):
         # Point _SOCKET_PATH at a real non-existent path so the real URLError fires.
@@ -245,11 +246,75 @@ class TestErrorResponses:
         # A missing socket means snapd is absent, so the request fails fast without retrying.
         sleep = MagicMock()
         monkeypatch.setattr(_client.time, 'sleep', sleep)
-        with pytest.raises(ConnectionError) as exc_info:
+        with pytest.raises(SocketNotFoundError) as exc_info:
             _client.get('/v2/snaps/hello-world')
         assert exc_info.value.kind == 'charmlibs-snap-socket-not-found'
+        # Callers that only care that snapd was unreachable can catch ConnectionError.
         assert isinstance(exc_info.value, ConnectionError)
         sleep.assert_not_called()
+
+    def test_reset_while_receiving_response_raises_snap_connection_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # urllib wraps failures from sending the request, but lets a failure from
+        # h.getresponse() through raw -- most visibly a reset when snapd restarts after
+        # accepting the request. We translate it, so it stays inside the library's hierarchy.
+        monkeypatch.setattr(_client, '_CONNECTION_RETRY_BUDGET', 0)
+        monkeypatch.setattr(_client.time, 'sleep', MagicMock())
+        monkeypatch.setattr(
+            urllib.request.OpenerDirector,
+            'open',
+            MagicMock(side_effect=builtins.ConnectionResetError(104, 'Connection reset by peer')),
+        )
+        with pytest.raises(ConnectionError) as exc_info:
+            _client.get('/v2/snaps/hello-world')
+        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
+        assert 'Connection to snapd lost' in exc_info.value.message
+
+    def test_reset_while_receiving_response_is_retried(self, monkeypatch: pytest.MonkeyPatch):
+        # Being a library ConnectionError, it also reaches the GET retry -- the whole point of
+        # that retry is snapd restarting mid-operation, which is how this error arises.
+        monkeypatch.setattr(_client.time, 'sleep', MagicMock())
+        opener = MagicMock(
+            side_effect=[
+                builtins.ConnectionResetError(104, 'Connection reset by peer'),
+                _fake_response({'type': 'sync', 'result': {'foo': 'bar'}}),
+            ]
+        )
+        monkeypatch.setattr(urllib.request.OpenerDirector, 'open', opener)
+        assert _client.get('/v2/snaps/hello-world') == {'foo': 'bar'}
+        assert opener.call_count == 2
+
+    def test_reset_while_reading_body_raises_snap_connection_error(self, mock_raw: MagicMock):
+        # The body is read after _request returns, so it needs translating separately.
+        response = _fake_response({'type': 'sync', 'result': {}})
+        response.read = MagicMock(
+            side_effect=builtins.ConnectionResetError(104, 'Connection reset by peer')
+        )
+        mock_raw.return_value = response
+        with pytest.raises(ConnectionError) as exc_info:
+            _client.get('/v2/snaps/hello-world')
+        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
+        assert 'while reading response' in exc_info.value.message
+        assert '/v2/snaps/hello-world' in exc_info.value.message
+
+    def test_timeout_while_reading_body_raises_snap_timeout_error(self, mock_raw: MagicMock):
+        response = _fake_response({'type': 'sync', 'result': {}})
+        response.read = MagicMock(side_effect=builtins.TimeoutError('timed out'))
+        mock_raw.return_value = response
+        with pytest.raises(TimeoutError) as exc_info:
+            _client.get('/v2/snaps/hello-world')
+        assert exc_info.value.kind == 'charmlibs-snap-request-timeout'
+
+    def test_reset_while_reading_logs_body_raises_snap_connection_error(self, mock_raw: MagicMock):
+        response = _fake_response(b'')
+        response.read = MagicMock(
+            side_effect=builtins.ConnectionResetError(104, 'Connection reset by peer')
+        )
+        mock_raw.return_value = response
+        with pytest.raises(ConnectionError) as exc_info:
+            _client.get_logs(query={'n': 10, 'names': 'lxd'})
+        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
 
     def test_connection_error_retries_then_raises(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(_client, '_CONNECTION_RETRY_BUDGET', 0)
@@ -263,7 +328,8 @@ class TestErrorResponses:
         with pytest.raises(ConnectionError) as exc_info:
             _client.get('/v2/snaps/hello-world')
         assert exc_info.value.kind == 'charmlibs-snap-connection-error'
-        assert isinstance(exc_info.value, ConnectionError)
+        # A reachable-but-failing socket isn't the socket-missing case.
+        assert not isinstance(exc_info.value, SocketNotFoundError)
         # Budget is 0, so the first failure is past the deadline: no retry sleep.
         sleep.assert_not_called()
 
@@ -438,6 +504,7 @@ def test_all_errors_mapped():
         'APIError',
         # Transport errors
         'ConnectionError',
+        'SocketNotFoundError',
         'TimeoutError',
         # Manually raised errors
         'BadResponseError',

--- a/snap/tests/unit/test_errors.py
+++ b/snap/tests/unit/test_errors.py
@@ -17,6 +17,7 @@ _NON_API_ERROR_TYPES = frozenset({
     _errors.Error,
     _errors.BadResponseError,
     _errors.ConnectionError,
+    _errors.SocketNotFoundError,
     _errors.TimeoutError,
 })
 
@@ -54,6 +55,11 @@ class TestErrorHierarchy:
     def test_timeout_and_connection_errors_subclass_builtins(self):
         assert issubclass(_errors.TimeoutError, builtins.TimeoutError)
         assert issubclass(_errors.ConnectionError, builtins.ConnectionError)
+        assert issubclass(_errors.SocketNotFoundError, builtins.ConnectionError)
+
+    def test_socket_not_found_subclasses_connection_error(self):
+        # Callers that only care that snapd was unreachable can catch ConnectionError.
+        assert issubclass(_errors.SocketNotFoundError, _errors.ConnectionError)
 
 
 def test_snap_error():

--- a/snap/tests/unit/test_snapd_conf.py
+++ b/snap/tests/unit/test_snapd_conf.py
@@ -11,7 +11,12 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from charmlibs.snap import _snapd_conf
-from charmlibs.snap._errors import ChangeError, OptionNotFoundError, _NotFoundError
+from charmlibs.snap._errors import (
+    BadResponseError,
+    ChangeError,
+    OptionNotFoundError,
+    _NotFoundError,
+)
 from conftest import result_of
 
 if TYPE_CHECKING:
@@ -39,6 +44,17 @@ class TestGet:
         _snapd_conf.get('lxd', ['a', 'b'])
         query = mock_client.get.call_args.kwargs['query']
         assert query == {'keys': 'a,b'}
+
+    def test_get_non_dict_raises_bad_response(self, mock_client: MockClient):
+        # snapd answering with the wrong shape is a library-level error, not an AssertionError:
+        # asserts are stripped under python -O, and wouldn't be an Error subclass anyway.
+        mock_client.get.return_value = ['integer']
+        with pytest.raises(BadResponseError) as ctx:
+            _snapd_conf.get('lxd')
+        assert 'Unexpected response type' in ctx.value.message
+        assert "'list'" in ctx.value.message
+        # Reported as a bad response, rather than probed as a possibly-absent snap.
+        assert mock_client.get.call_count == 1
 
     def test_get_accepts_arbitrary_iterable(self, mock_client: MockClient):
         # keys need not be a list -- any non-string iterable of strings works.

--- a/snap/tests/unit/test_snapd_snaps.py
+++ b/snap/tests/unit/test_snapd_snaps.py
@@ -13,6 +13,7 @@ import pytest
 from charmlibs.snap import _snapd_snaps as _snapd
 from charmlibs.snap._errors import (
     APIError,
+    BadResponseError,
     ChannelNotAvailableError,
     Error,
     NotInstalledError,
@@ -132,6 +133,31 @@ class TestListOne:
         assert type(ctx.value) is NotInstalledError
         assert ctx.value.message == 'snap "hello-world" is not installed'
         assert ctx.value.__suppress_context__
+
+    def test_list_one_non_dict_raises_bad_response(self, mock_client: MockClient):
+        # snapd answering with the wrong shape is a library-level error, not an AssertionError:
+        # asserts are stripped under python -O, and wouldn't be an Error subclass anyway.
+        mock_client.get.return_value = ['hello-world']
+        with pytest.raises(BadResponseError) as ctx:
+            _snapd.list_one('hello-world')
+        assert 'Unexpected response type' in ctx.value.message
+        assert "'list'" in ctx.value.message
+
+    @pytest.mark.parametrize('missing', ['name', 'version', 'revision', 'confinement'])
+    def test_list_one_missing_field_raises_bad_response(
+        self, mock_client: MockClient, missing: str
+    ):
+        info_dict = {k: v for k, v in _MINIMAL_INFO_DICT.items() if k != missing}
+        mock_client.get.return_value = info_dict
+        with pytest.raises(BadResponseError) as ctx:
+            _snapd.list_one('hello-world')
+        assert missing in ctx.value.message  # Named by the KeyError repr.
+        assert ctx.value.__suppress_context__
+
+    def test_list_one_unparseable_hold_raises_bad_response(self, mock_client: MockClient):
+        mock_client.get.return_value = {**_MINIMAL_INFO_DICT, 'hold': 'not-a-timestamp'}
+        with pytest.raises(BadResponseError):
+            _snapd.list_one('hello-world')
 
     def test_list_one_other_error_propagates(self, mock_client: MockClient):
         mock_client.get.side_effect = Error(


### PR DESCRIPTION
This PR documents the `charmlibs.snap` error behaviour, and:
- adds the `SocketNotFound` error type as a subclass of `ConnectionError`.
- replaces `assert` statements in library code with `raise BadResponseError`.
- wraps the call to `InstalledInfo._from_dict` to raise `BadResponseError` on failure.
- wraps the client's `response.read()` call to convert errors while reading into library errors.
- adds additional error branch coverage to the `opener.open(...)` call to convert errors into library errors.

I've left Claude's verbose comments for now, as I think they're somewhat helpful in the context of PR review, but I intend to trim them down before merging to avoid comment drift and make the code easier to follow.