### PR TITLE
feat(snap)!: private error value and kind

### DIFF
--- a/snap/src/charmlibs/snap/__init__.py
+++ b/snap/src/charmlibs/snap/__init__.py
@@ -58,7 +58,8 @@ never retried: it usually means snapd is not installed on the system.
 
 A :class:`BadResponseError` is raised if the snapd API returns a response the library does not
 understand. Callers will not be able to resolve this error directly, and should report it to the
-library maintainers.
+library maintainers, along with :attr:`BadResponseError.response` -- what snapd sent that the
+library could not read.
 """
 
 from ._errors import (

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -157,28 +157,16 @@ def _request(
         response = opener.open(request, timeout=_REQUEST_TIMEOUT)
     except TimeoutError:
         raise _errors.TimeoutError(
-            f'Request to snapd timed out after {_REQUEST_TIMEOUT}s: {method} {path}',
-            kind='charmlibs-snap-request-timeout',
-            value='',
+            f'Request to snapd timed out after {_REQUEST_TIMEOUT}s: {method} {path}'
         ) from None
     except urllib.error.URLError as e:
         if e.args and isinstance(e.args[0], FileNotFoundError):
             raise _errors.SocketNotFoundError(
-                f'Could not connect to snapd: socket not found at {_SOCKET_PATH!r}',
-                kind='charmlibs-snap-socket-not-found',
-                value='',
+                f'Could not connect to snapd: socket not found at {_SOCKET_PATH!r}'
             ) from None
-        raise _errors.ConnectionError(
-            str(e.reason),
-            kind='charmlibs-snap-connection-error',
-            value='',
-        ) from e
+        raise _errors.ConnectionError(str(e.reason)) from e
     except _TRANSPORT_ERRORS as e:
-        raise _errors.ConnectionError(
-            f'Connection to snapd lost: {method} {path}: {e}',
-            kind='charmlibs-snap-connection-error',
-            value='',
-        ) from e
+        raise _errors.ConnectionError(f'Connection to snapd lost: {method} {path}: {e}') from e
     if 300 <= response.status < 400:  # 3xx responses.
         # snapd itself never redirects, aside from path canonicalisation -- for example,
         # paths containing '//', '/./' or '/../' get a 301 to the cleaned path.
@@ -186,11 +174,7 @@ def _request(
         # to canonical paths. A redirect here means a bug on our side or a change in snapd.
         location = response.getheader('Location')
         raise _errors.BadResponseError(
-            message=f'Unexpected redirect for path {path!r} to {location!r}',
-            kind='charmlibs-snap-unexpected-redirect',
-            value=location or '',
-            status_code=response.status,
-            status=response.reason,
+            message=f'Unexpected {response.status} redirect for path {path!r} to {location!r}'
         )
     return response
 
@@ -206,20 +190,13 @@ def _decode(response: http.client.HTTPResponse) -> object | _Change:
     try:
         response_dict: dict[str, Any] = json.loads(response_bytes)
     except json.JSONDecodeError as e:
+        body = _errors._truncated(response_bytes.decode(errors='replace'))
         raise _errors.BadResponseError(
-            message=f'Invalid JSON in response for path {_get_path(response)!r}: {e}',
-            kind='charmlibs-snap',
-            value=response_bytes.decode(errors='replace'),
-            status_code=response.status,
-            status=response.reason,
+            message=f'Invalid JSON in response for path {_get_path(response)!r}: {e}: {body!r}'
         ) from None
     if not isinstance(response_dict, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise _errors.BadResponseError(
             message=f"Unexpected response type {type(response_dict).__name__!r} for path {_get_path(response)!r}, expected a 'dict'",  # noqa: E501
-            kind='charmlibs-snap',
-            value=str(response_dict),
-            status_code=response.status,
-            status=response.reason,
         )
     try:
         match response_dict['type']:
@@ -230,12 +207,10 @@ def _decode(response: http.client.HTTPResponse) -> object | _Change:
             case _:
                 return response_dict['result']
     except KeyError as e:
+        body = _errors._truncated(response_dict)
         raise _errors.BadResponseError(
-            message=f'Missing expected key {e} in response for path {_get_path(response)!r}',
-            kind='charmlibs-snap',
-            value=str(response_dict),
-            status_code=response.status,
-            status=response.reason,
+            message=f'Missing expected key {e} in response for path '
+            f'{_get_path(response)!r}: {body}'
         ) from None
 
 
@@ -253,12 +228,9 @@ def _decode_logs(response: http.client.HTTPResponse) -> list[dict[str, str]]:
             if (s := line.decode().strip())
         ]
     except json.JSONDecodeError as e:
+        body = _errors._truncated(response_bytes.decode(errors='replace'))
         raise _errors.BadResponseError(
-            message=f'Invalid JSON in response for path {_get_path(response)!r}: {e}',
-            kind='charmlibs-snap',
-            value=response_bytes.decode(errors='replace'),
-            status_code=response.status,
-            status=response.reason,
+            message=f'Invalid JSON in response for path {_get_path(response)!r}: {e}: {body!r}'
         ) from None
     # Error responses are a single JSON object, which we wrapped in a list when decoding.
     if len(logs) == 1 and logs[0].get('type') == 'error':
@@ -272,15 +244,11 @@ def _read(response: http.client.HTTPResponse) -> bytes:
         return response.read()
     except TimeoutError:
         raise _errors.TimeoutError(
-            f'Timed out reading snapd response for path {_get_path(response)!r}',
-            kind='charmlibs-snap-request-timeout',
-            value='',
+            f'Timed out reading snapd response for path {_get_path(response)!r}'
         ) from None
     except _TRANSPORT_ERRORS as e:
         raise _errors.ConnectionError(
             f'Connection to snapd lost while reading response for path {_get_path(response)!r}: {e}',  # noqa: E501
-            kind='charmlibs-snap-connection-error',
-            value='',
         ) from e
 
 
@@ -383,7 +351,5 @@ class _Change:
         if not isinstance(result, dict):
             raise _errors.BadResponseError(
                 message=f'Unexpected response type {type(result).__name__} while waiting for change {self._id}',  # noqa: E501
-                kind='charmlibs-snap',
-                value=str(result),
             )
         return typing.cast('dict[str, Any]', result)

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -190,13 +190,14 @@ def _decode(response: http.client.HTTPResponse) -> object | _Change:
     try:
         response_dict: dict[str, Any] = json.loads(response_bytes)
     except json.JSONDecodeError as e:
-        body = _errors._truncated(response_bytes.decode(errors='replace'))
         raise _errors.BadResponseError(
-            message=f'Invalid JSON in response for path {_get_path(response)!r}: {e}: {body!r}'
+            message=f'Invalid JSON in response for path {_get_path(response)!r}: {e}',
+            response=response_bytes.decode(errors='replace'),
         ) from None
     if not isinstance(response_dict, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
         raise _errors.BadResponseError(
             message=f"Unexpected response type {type(response_dict).__name__!r} for path {_get_path(response)!r}, expected a 'dict'",  # noqa: E501
+            response=response_dict,
         )
     try:
         match response_dict['type']:
@@ -207,10 +208,9 @@ def _decode(response: http.client.HTTPResponse) -> object | _Change:
             case _:
                 return response_dict['result']
     except KeyError as e:
-        body = _errors._truncated(response_dict)
         raise _errors.BadResponseError(
-            message=f'Missing expected key {e} in response for path '
-            f'{_get_path(response)!r}: {body}'
+            message=f'Missing expected key {e} in response for path {_get_path(response)!r}',
+            response=response_dict,
         ) from None
 
 
@@ -228,9 +228,9 @@ def _decode_logs(response: http.client.HTTPResponse) -> list[dict[str, str]]:
             if (s := line.decode().strip())
         ]
     except json.JSONDecodeError as e:
-        body = _errors._truncated(response_bytes.decode(errors='replace'))
         raise _errors.BadResponseError(
-            message=f'Invalid JSON in response for path {_get_path(response)!r}: {e}: {body!r}'
+            message=f'Invalid JSON in response for path {_get_path(response)!r}: {e}',
+            response=response_bytes.decode(errors='replace'),
         ) from None
     # Error responses are a single JSON object, which we wrapped in a list when decoding.
     if len(logs) == 1 and logs[0].get('type') == 'error':
@@ -351,5 +351,6 @@ class _Change:
         if not isinstance(result, dict):
             raise _errors.BadResponseError(
                 message=f'Unexpected response type {type(result).__name__} while waiting for change {self._id}',  # noqa: E501
+                response=result,
             )
         return typing.cast('dict[str, Any]', result)

--- a/snap/src/charmlibs/snap/_client.py
+++ b/snap/src/charmlibs/snap/_client.py
@@ -293,7 +293,7 @@ def _get_path(response: http.client.HTTPResponse) -> str:
 ##########
 
 
-_ERRORS = {
+_ERRORS: dict[str, type[_errors.APIError]] = {
     'snap-already-installed': _errors._AlreadyInstalledError,
     'app-not-found': _errors.AppNotFoundError,
     'option-not-found': _errors.OptionNotFoundError,

--- a/snap/src/charmlibs/snap/_errors.py
+++ b/snap/src/charmlibs/snap/_errors.py
@@ -24,86 +24,19 @@ if typing.TYPE_CHECKING:
 
 
 class Error(Exception):
-    """Base class for all library errors, not raised directly.
+    """Base class for all library errors, not raised directly."""
 
-    Args:
-        message: Typically the 'message' field from a snapd API response.
-        kind: The 'kind' field from a snapd API response, used to derive the specific error type.
-            Errors the library raises itself have a kind starting with 'charmlibs-snap', so that
-            they can't collide with a kind snapd may add in future.
-        value: The 'value' field from a snapd API response, which may contain additional details.
-            Almost always a string, but can be any JSON value.
-        status_code: The HTTP status code from the snapd API response, if applicable.
-            Stored privately for logging and debugging, not part of the public error API.
-        status: The 'status' field from a snapd API response, if applicable.
-            Stored privately for logging and debugging, not part of the public error API.
-    """
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        kind: str,
-        value: object,
-        status_code: int | None = None,
-        status: str | None = None,
-    ):
+    def __init__(self, message: str):
         super().__init__(message)
-        # Exposed publicly as read-only properties.
         self._message = message
-        self._kind = kind
-        self._value = value
-        # Too low-level to be part of the public API, but useful for debugging and logging.
-        self._status_code = status_code
-        self._status = status
-
-    @classmethod
-    def _from(cls, error: Error) -> Self:
-        return cls(
-            error._message,
-            kind=error._kind,
-            value=error._value,
-            status_code=error._status_code,
-            status=error._status,
-        )
 
     @property
     def message(self) -> str:
         """The error message, typically from the snapd API response."""
         return self._message
 
-    @property
-    def kind(self) -> str:
-        """The error kind, typically from the snapd API response."""
-        return self._kind
-
-    @property
-    def value(self) -> object:
-        """The error value, typically from the snapd API response.
-
-        Currently a string, but future library versions may return any ``object`` subtype.
-        """
-        return str(self._value)
-
-    def __str__(self) -> str:
-        # Surface `value` when it adds information the message doesn't already carry.
-        # Most useful for _NotFoundError, with message 'snap not installed' and value '<snap>'.
-        # Skip OptionNotFoundError's non-string value, which is redundant with its message.
-        value = self._value
-        if isinstance(value, str) and value and value not in self._message:
-            return f'{self._message} ({value})'
-        return self._message
-
     def __repr__(self) -> str:
-        return (
-            f'{type(self).__module__}.{type(self).__name__}('
-            f'{self.message!r}'
-            f', kind={self.kind!r}'
-            f', value={self.value!r}'
-            f', status_code={self._status_code!r}'
-            f', status={self._status!r}'
-            ')'
-        )
+        return f'{type(self).__module__}.{type(self).__name__}({self.message!r})'
 
 
 #####################################################
@@ -156,6 +89,51 @@ class TimeoutError(Error, _builtins.TimeoutError):  # noqa: A001 (shadowing a Py
 
 class APIError(Error):
     """Raised when the snapd API returns an error response."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        kind: str,
+        value: object,
+        status_code: int | None = None,
+        status: str | None = None,
+    ):
+        super().__init__(message)
+        self._kind = kind
+        self._value = value
+        self._status_code = status_code
+        self._status = status
+
+    @classmethod
+    def _from(cls, error: APIError) -> Self:
+        return cls(
+            error._message,
+            kind=error._kind,
+            value=error._value,
+            status_code=error._status_code,
+            status=error._status,
+        )
+
+    def __str__(self) -> str:
+        # Surface `value` when it adds information the message doesn't already carry.
+        # Most useful for _NotFoundError, with message 'snap not installed' and value '<snap>'.
+        # Skip OptionNotFoundError's non-string value, which is redundant with its message.
+        value = self._value
+        if isinstance(value, str) and value and value not in self._message:
+            return f'{self._message} ({value})'
+        return self._message
+
+    def __repr__(self) -> str:
+        return (
+            f'{type(self).__module__}.{type(self).__name__}('
+            f'{self.message!r}'
+            f', kind={self._kind!r}'
+            f', value={self._value!r}'
+            f', status_code={self._status_code!r}'
+            f', status={self._status!r}'
+            ')'
+        )
 
 
 class _AlreadyInstalledError(APIError):  # pyright: ignore[reportUnusedClass]

--- a/snap/src/charmlibs/snap/_errors.py
+++ b/snap/src/charmlibs/snap/_errors.py
@@ -23,23 +23,6 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Self
 
 
-_MAX_DETAIL = 200
-"""How much of an offending response a :class:`BadResponseError` message will quote."""
-
-
-def _truncated(detail: object) -> str:  # pyright: ignore[reportUnusedFunction]
-    """Render something snapd sent us for inclusion in a :class:`BadResponseError` message.
-
-    Errors outside the :class:`APIError` hierarchy carry no ``value``, so the message is the
-    only place the offending response can be recorded for a bug report. Long responses (the
-    log stream, for example) are truncated so that the message stays readable.
-    """
-    text = detail if isinstance(detail, str) else str(detail)
-    if len(text) <= _MAX_DETAIL:
-        return text
-    return f'{text[:_MAX_DETAIL]}... ({len(text)} characters)'
-
-
 class Error(Exception):
     """Base class for all library errors, not raised directly."""
 
@@ -65,8 +48,29 @@ class BadResponseError(Error):
     """Raised manually when the snapd API returns a response we don't understand.
 
     Callers will not be able to resolve this error directly. It means the library and snapd
-    disagree about the shape of a response, so it should be reported to the library maintainers.
+    disagree about the shape of a response, so it should be reported to the library maintainers,
+    along with :attr:`response` -- what snapd sent that the library could not read.
     """
+
+    def __init__(self, message: str, *, response: object = None):
+        super().__init__(message)
+        self._response = response
+
+    @property
+    def response(self) -> object:
+        """The part of snapd's response the library could not read, if any.
+
+        Typically a string for a response that wasn't valid JSON, or the decoded JSON value
+        for one that was well-formed but not what the library expected. ``None`` when the
+        message says all there is to say, as for an unexpected redirect.
+        """
+        return self._response
+
+    def __repr__(self) -> str:
+        return (
+            f'{type(self).__module__}.{type(self).__name__}('
+            f'{self.message!r}, response={self._response!r})'
+        )
 
 
 class ConnectionError(Error, _builtins.ConnectionError):  # noqa: A001 (shadowing a Python builtin)

--- a/snap/src/charmlibs/snap/_errors.py
+++ b/snap/src/charmlibs/snap/_errors.py
@@ -23,6 +23,23 @@ if typing.TYPE_CHECKING:
     from typing_extensions import Self
 
 
+_MAX_DETAIL = 200
+"""How much of an offending response a :class:`BadResponseError` message will quote."""
+
+
+def _truncated(detail: object) -> str:  # pyright: ignore[reportUnusedFunction]
+    """Render something snapd sent us for inclusion in a :class:`BadResponseError` message.
+
+    Errors outside the :class:`APIError` hierarchy carry no ``value``, so the message is the
+    only place the offending response can be recorded for a bug report. Long responses (the
+    log stream, for example) are truncated so that the message stays readable.
+    """
+    text = detail if isinstance(detail, str) else str(detail)
+    if len(text) <= _MAX_DETAIL:
+        return text
+    return f'{text[:_MAX_DETAIL]}... ({len(text)} characters)'
+
+
 class Error(Exception):
     """Base class for all library errors, not raised directly."""
 
@@ -190,10 +207,7 @@ class _InterfacesUnchangedError(APIError):  # pyright: ignore[reportUnusedClass]
 
 
 class OptionNotFoundError(APIError):
-    """Raised via the API when the specified snap config option is not found.
-
-    ``OptionNotFoundError.value`` looks like ``"{'SnapName': 'hello-world', 'Key': 'foo'}"``.
-    """
+    """Raised via the API when the specified snap config option is not found."""
 
 
 class ChangeError(APIError):

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -106,8 +106,6 @@ def get(snap: str, keys: str | Iterable[str] | None = None) -> dict[str, Any]:
     if not isinstance(config, dict):
         raise _errors.BadResponseError(
             message=f'Unexpected response type {type(config).__name__!r} for the configuration of snap {snap!r}, expected a "dict"',  # noqa: E501
-            kind='charmlibs-snap',
-            value=str(config),
         )
     config = typing.cast('dict[str, Any]', config)
     # Empty result when all config was requested: error if the snap isn't installed.

--- a/snap/src/charmlibs/snap/_snapd_conf.py
+++ b/snap/src/charmlibs/snap/_snapd_conf.py
@@ -106,6 +106,7 @@ def get(snap: str, keys: str | Iterable[str] | None = None) -> dict[str, Any]:
     if not isinstance(config, dict):
         raise _errors.BadResponseError(
             message=f'Unexpected response type {type(config).__name__!r} for the configuration of snap {snap!r}, expected a "dict"',  # noqa: E501
+            response=config,
         )
     config = typing.cast('dict[str, Any]', config)
     # Empty result when all config was requested: error if the snap isn't installed.

--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -155,6 +155,7 @@ def list_one(snap: str) -> InstalledInfo:
     if not isinstance(info_dict, dict):
         raise _errors.BadResponseError(
             message=f'Unexpected response type {type(info_dict).__name__!r} for snap {snap!r}, expected a "dict"',  # noqa: E501
+            response=info_dict,
         )
     info_dict = typing.cast('dict[str, str]', info_dict)
     try:
@@ -163,8 +164,8 @@ def list_one(snap: str) -> InstalledInfo:
         # A field we require is missing, or holds something we can't parse. Reported rather than
         # asserted, so that the documented contract -- every failure is an Error -- holds here too.
         raise _errors.BadResponseError(
-            message=f"Could not read snapd's description of snap {snap!r}: {e!r}: "
-            f'{_errors._truncated(info_dict)}'
+            message=f"Could not read snapd's description of snap {snap!r}: {e!r}",
+            response=info_dict,
         ) from None
 
 

--- a/snap/src/charmlibs/snap/_snapd_snaps.py
+++ b/snap/src/charmlibs/snap/_snapd_snaps.py
@@ -155,8 +155,6 @@ def list_one(snap: str) -> InstalledInfo:
     if not isinstance(info_dict, dict):
         raise _errors.BadResponseError(
             message=f'Unexpected response type {type(info_dict).__name__!r} for snap {snap!r}, expected a "dict"',  # noqa: E501
-            kind='charmlibs-snap',
-            value=str(info_dict),
         )
     info_dict = typing.cast('dict[str, str]', info_dict)
     try:
@@ -165,9 +163,8 @@ def list_one(snap: str) -> InstalledInfo:
         # A field we require is missing, or holds something we can't parse. Reported rather than
         # asserted, so that the documented contract -- every failure is an Error -- holds here too.
         raise _errors.BadResponseError(
-            message=f"Could not read snapd's description of snap {snap!r}: {e!r}",
-            kind='charmlibs-snap',
-            value=str(info_dict),
+            message=f"Could not read snapd's description of snap {snap!r}: {e!r}: "
+            f'{_errors._truncated(info_dict)}'
         ) from None
 
 

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -61,7 +61,7 @@ def test_post_sync_error_snap_already_installed():
     ensure_installed_store(_STORE_SNAP)
     with pytest.raises(_errors._AlreadyInstalledError) as ctx:
         _client.post(f'/v2/snaps/{_STORE_SNAP}', body={'action': 'install'})
-    assert ctx.value.kind == 'snap-already-installed'
+    assert ctx.value._kind == 'snap-already-installed'
 
 
 def test_post_sync_error_app_not_found():
@@ -70,16 +70,16 @@ def test_post_sync_error_app_not_found():
         _client.post(
             '/v2/apps', body={'action': 'start', 'names': [f'{_STORE_SNAP}.nonexistentservice']}
         )
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
 
 
 def test_post_sync_error_no_kind():
     # An invalid action returns an error with no 'kind'.
     ensure_installed_store(_STORE_SNAP)
-    with pytest.raises(_errors.Error) as ctx:
+    with pytest.raises(_errors.APIError) as ctx:
         _client.post(f'/v2/snaps/{_STORE_SNAP}', body={'action': 'invalid-action'})
-    assert not ctx.value.kind
-    assert not isinstance(ctx.value, _errors.BadResponseError)
+    assert type(ctx.value) is _errors.APIError
+    assert not ctx.value._kind
 
 
 def test_post_snap_no_update_available():
@@ -89,7 +89,7 @@ def test_post_snap_no_update_available():
         retry_on_rate_limit(_client.post)(
             f'/v2/snaps/{_STORE_SNAP}', body={'action': 'refresh', 'channel': 'latest/stable'}
         )
-    assert ctx.value.kind == 'snap-no-update-available'
+    assert ctx.value._kind == 'snap-no-update-available'
 
 
 def test_post_waits_for_async_change():
@@ -114,20 +114,21 @@ def test_get_sync_error_snap_not_found():
     with pytest.raises(_errors._NotFoundError) as ctx:
         _client.get(f'/v2/snaps/{_ABSENT_SNAP}')
     assert type(ctx.value) is _errors._NotFoundError
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     # This endpoint is what _utils.check_installed probes with; its message is terse, with the
-    # snap name in `value`. get()/connect()/disconnect() raise this very error unchanged, relying
-    # on str() to surface the name rather than building their own message.
+    # snap name in the response's 'value'. get()/connect()/disconnect() raise this very error
+    # unchanged, relying on str() to surface the name rather than building their own message.
     assert ctx.value.message == 'snap not installed'
-    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert str(ctx.value._value) == _ABSENT_SNAP
     assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
 def test_get_sync_error_no_kind():
-    # An error response with no 'kind' field maps to the base Error.
-    with pytest.raises(_errors.Error) as ctx:
+    # An error response with no 'kind' field maps to the base APIError.
+    with pytest.raises(_errors.APIError) as ctx:
         _client.get('/v2/nonexistent-endpoint')
-    assert not ctx.value.kind
+    assert type(ctx.value) is _errors.APIError
+    assert not ctx.value._kind
 
 
 def test_put_sync_error_snap_not_found():
@@ -135,7 +136,7 @@ def test_put_sync_error_snap_not_found():
     with pytest.raises(_errors._NotFoundError) as ctx:
         _client.put(f'/v2/snaps/{_ABSENT_SNAP}/conf', body={'key': 'value'})
     assert type(ctx.value) is _errors._NotFoundError
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
 
 
 def test_get_logs_error_snap_not_found():
@@ -143,7 +144,7 @@ def test_get_logs_error_snap_not_found():
     with pytest.raises(_errors._NotFoundError) as ctx:
         _client.get('/v2/logs', query={'names': _ABSENT_SNAP, 'n': 10})
     assert type(ctx.value) is _errors._NotFoundError
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +156,7 @@ def test_post_sync_error_snap_needs_classic():
     ensure_removed(_CLASSIC_SNAP)
     with pytest.raises(_errors.NeedsClassicError) as ctx:
         _client.post(f'/v2/snaps/{_CLASSIC_SNAP}', body={'action': 'install'})
-    assert ctx.value.kind == 'snap-needs-classic'
+    assert ctx.value._kind == 'snap-needs-classic'
 
 
 # ---------------------------------------------------------------------------
@@ -223,12 +224,12 @@ def test_put_waits_for_async_change():
 
 
 def test_put_no_body_raises():
-    # PUT with no body (None) raises a base Error: snapd can't decode EOF as patch values.
+    # PUT with no body (None) raises a base APIError: snapd can't decode EOF as patch values.
     ensure_installed_local(_CONF_SNAP)
-    with pytest.raises(_errors.Error) as ctx:
+    with pytest.raises(_errors.APIError) as ctx:
         _client.put(f'/v2/snaps/{_CONF_SNAP}/conf')
     assert 'EOF' in ctx.value.message
-    assert not ctx.value.kind
+    assert not ctx.value._kind
 
 
 def test_put_empty_body_succeeds():
@@ -251,7 +252,7 @@ def test_poll_fails_fast_when_socket_missing():
             mp.setattr(_client, '_SOCKET_PATH', '/run/this-snapd-socket-does-not-exist.socket')
             with pytest.raises(_errors.SocketNotFoundError) as ctx:
                 change.wait()
-        assert ctx.value.kind == 'charmlibs-snap-socket-not-found'
+        assert 'this-snapd-socket-does-not-exist' in ctx.value.message
     finally:
         # snapd is still processing the original change; wait for it before cleaning up.
         change.wait()
@@ -280,9 +281,9 @@ def test_redirect_raises_bad_response_error(path: str, location: str):
     # handled, the empty body of the 301 surfaced as a confusing 'Invalid JSON' error.
     with pytest.raises(_errors.BadResponseError) as ctx:
         _client.get(path)
-    assert ctx.value.kind == 'charmlibs-snap-unexpected-redirect'
-    assert ctx.value.value == location
-    assert path in ctx.value.message
+    assert '301' in ctx.value.message  # snapd's router cleans the path with a permanent redirect.
+    assert path in ctx.value.message  # The path we asked for.
+    assert location in ctx.value.message  # Where snapd points us.
     assert 'Invalid JSON' not in ctx.value.message
 
 
@@ -316,4 +317,4 @@ def test_get_logs_error_app_not_found():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.get_logs(query={'names': _NO_SERVICES_SNAP, 'n': 10})
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'

--- a/snap/tests/functional/test_client.py
+++ b/snap/tests/functional/test_client.py
@@ -285,6 +285,7 @@ def test_redirect_raises_bad_response_error(path: str, location: str):
     assert path in ctx.value.message  # The path we asked for.
     assert location in ctx.value.message  # Where snapd points us.
     assert 'Invalid JSON' not in ctx.value.message
+    assert ctx.value.response is None  # snapd sends an empty body with the redirect.
 
 
 def test_percent_encoded_separator_still_reaches_another_endpoint():

--- a/snap/tests/functional/test_confinement.py
+++ b/snap/tests/functional/test_confinement.py
@@ -52,7 +52,7 @@ def test_refresh_to_a_classic_revision_needs_the_flag():
     install_local(_STRICT, dangerous=True)
     with pytest.raises(_errors.NeedsClassicError) as ctx:
         install_local(_CLASSIC, dangerous=True, classic=False)
-    assert ctx.value.kind == 'snap-needs-classic'
+    assert ctx.value._kind == 'snap-needs-classic'
     assert snap.list_one(_SNAP).classic is False  # Unchanged by the failed refresh.
 
 

--- a/snap/tests/functional/test_snapd_aliases.py
+++ b/snap/tests/functional/test_snapd_aliases.py
@@ -143,12 +143,12 @@ def test_unalias_removes_alias():
 
 
 def test_unalias_nonexistent_alias_raises():
-    # Unaliasing an alias that doesn't exist raises a base Error (no kind).
+    # Unaliasing an alias that doesn't exist raises a base APIError (no kind).
     ensure_installed_store(_SNAP)
     _cleanup_alias()
-    with pytest.raises(_errors.Error) as ctx:
+    with pytest.raises(_errors.APIError) as ctx:
         _snapd_aliases.unalias(_ALIAS)
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'cannot find' in ctx.value.message or _ALIAS in ctx.value.message
 
 
@@ -182,7 +182,7 @@ def test_alias_not_installed_snap_raises():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_aliases.alias(_ABSENT_SNAP, 'hello', 'test-not-installed-alias')
     assert type(ctx.value) is _errors.NotInstalledError
-    assert ctx.value.kind == 'snap-not-installed'
+    assert ctx.value._kind == 'snap-not-installed'
 
 
 # ---------------------------------------------------------------------------
@@ -214,8 +214,8 @@ def test_raw_alias_empty_or_blank_snap_is_not_installed(snap_name: str):
             '/v2/aliases',
             body={'action': 'alias', 'snap': snap_name, 'app': _APP, 'alias': _ALIAS},
         )
-    assert ctx.value.kind == 'snap-not-installed'
-    assert ctx.value.value == snap_name
+    assert ctx.value._kind == 'snap-not-installed'
+    assert ctx.value._value == snap_name
 
 
 @pytest.mark.parametrize('app', ['', ' '])
@@ -263,5 +263,5 @@ def test_unalias_after_snap_removed_raises():
     ensure_removed(_SNAP)
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_aliases.unalias(_ALIAS)
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'cannot find' in ctx.value.message

--- a/snap/tests/functional/test_snapd_apps.py
+++ b/snap/tests/functional/test_snapd_apps.py
@@ -101,7 +101,7 @@ def test_start_nonexistent_service_raises():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _snapd_apps.start(_NO_SERVICES_SNAP, 'nonexistentservice')
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
 
 
 def test_start_multiple_services():
@@ -149,7 +149,7 @@ def test_stop_nonexistent_service_raises():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _snapd_apps.stop(_NO_SERVICES_SNAP, 'nonexistentservice')
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +184,7 @@ def test_restart_nonexistent_service_raises():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _snapd_apps.restart(_NO_SERVICES_SNAP, 'nonexistentservice')
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +207,7 @@ def test_not_installed_snap_raises_not_found(func: Any, services: Any):
     # including the empty list, which never reaches /v2/apps and is answered by the probe alone.
     with pytest.raises(_errors.NotInstalledError) as ctx:
         func(_ABSENT_SNAP, services)
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     assert _ABSENT_SNAP in str(ctx.value)
 
 
@@ -219,7 +219,7 @@ def test_not_installed_snap_converted_error_wording(func: Any, services: Any):
     with pytest.raises(_errors.NotInstalledError) as ctx:
         func(_ABSENT_SNAP, services)
     assert ctx.value.message == 'snap not installed'
-    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert str(ctx.value._value) == _ABSENT_SNAP
     assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
@@ -251,7 +251,7 @@ def test_raw_api_not_installed_snap_with_a_service_is_app_not_found():
     # than leaving the probe branch as untested dead code.
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.post('/v2/apps', body={'action': 'start', 'names': [f'{_ABSENT_SNAP}.svc']})
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
     assert ctx.value.message == f'snap "{_ABSENT_SNAP}" has no service "svc"'
 
 
@@ -262,7 +262,7 @@ def test_raw_api_installed_snap_without_the_service_is_indistinguishable():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.post('/v2/apps', body={'action': 'start', 'names': [f'{_NO_SERVICES_SNAP}.svc']})
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
     assert ctx.value.message == f'snap "{_NO_SERVICES_SNAP}" has no service "svc"'
 
 
@@ -271,7 +271,7 @@ def test_raw_api_not_installed_snap_alone_is_snap_not_found():
     # services, so this is already the error the library wants and no probe is made for it.
     with pytest.raises(_errors._NotFoundError) as ctx:
         _client.post('/v2/apps', body={'action': 'start', 'names': [_ABSENT_SNAP]})
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     assert ctx.value.message == f'snap "{_ABSENT_SNAP}" not found'
 
 
@@ -283,7 +283,7 @@ def test_system_is_not_special_here(func: Any):
     # 'core' is an ordinary one that may or may not be installed on the test machine.
     with pytest.raises(_errors.NotInstalledError) as ctx:
         func('system', [])
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
 
 
 # ---------------------------------------------------------------------------
@@ -311,21 +311,21 @@ def test_start_snap_with_no_services_raises():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _snapd_apps.start(_NO_SERVICES_SNAP)
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
 
 
 def test_stop_snap_with_no_services_raises():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _snapd_apps.stop(_NO_SERVICES_SNAP)
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
 
 
 def test_restart_snap_with_no_services_raises():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _snapd_apps.restart(_NO_SERVICES_SNAP)
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
 
 
 # ---------------------------------------------------------------------------
@@ -387,7 +387,7 @@ def test_raw_api_unusable_service_name_is_not_found(service: str):
     ensure_installed_local(_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.post('/v2/apps', body={'action': 'restart', 'names': [f'{_SNAP}.{service}']})
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
     assert f'has no service "{service}"' in ctx.value.message
 
 
@@ -438,5 +438,5 @@ def test_raw_api_invalid_snap_name(name: str, kind: str, message: str):
     # client-side: snapd resolves none of them to a snap either.
     with pytest.raises(_errors.APIError) as ctx:
         _client.post('/v2/apps', body={'action': 'start', 'names': [name]})
-    assert ctx.value.kind == kind
+    assert ctx.value._kind == kind
     assert ctx.value.message == message

--- a/snap/tests/functional/test_snapd_conf.py
+++ b/snap/tests/functional/test_snapd_conf.py
@@ -152,7 +152,7 @@ def test_get_option_not_found_raises():
     ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get(_SNAP, ['key-that-should-not-exist'])
-    assert ctx.value.kind == 'option-not-found'
+    assert ctx.value._kind == 'option-not-found'
     assert ctx.value.message
 
 
@@ -160,7 +160,7 @@ def test_get_option_not_found_value_contains_snap_and_key():
     ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get(_SNAP, ['key-that-should-not-exist'])
-    value = str(ctx.value.value)
+    value = str(ctx.value._value)
     assert 'SnapName' in value
     assert 'Key' in value
     assert _SNAP in value
@@ -172,13 +172,13 @@ def test_get_not_installed_snap_raises_not_found():
     # get() probes /v2/snaps/{snap} and raises _NotFoundError, consistent with set and unset.
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP, ['any-key'])
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     # get() raises snapd's own /v2/snaps/{snap} probe error unchanged: a terse message with the
     # snap name in value, which str() surfaces as 'snap not installed (<snap>)'. This reads
     # differently from set/unset (whose PUT error names the snap in the message) -- we pass each
     # endpoint's wording through rather than hand-building an error to normalise them.
     assert ctx.value.message == 'snap not installed'
-    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert str(ctx.value._value) == _ABSENT_SNAP
     assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
 
@@ -197,7 +197,7 @@ def test_get_all_not_installed_snap_raises_not_found():
     # /v2/snaps/{snap} and raises _NotFoundError instead of returning {}.
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP)
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     assert ctx.value.message == 'snap not installed'
     assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
     # No error was being handled when this was raised, so there's nothing to chain.
@@ -259,13 +259,13 @@ def test_get_one_missing_key_raises_option_not_found():
     ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get_one(_SNAP, 'key-that-should-not-exist')
-    assert ctx.value.kind == 'option-not-found'
+    assert ctx.value._kind == 'option-not-found'
 
 
 def test_get_one_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_conf.get_one(_ABSENT_SNAP, 'any-key')
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     assert ctx.value.message == 'snap not installed'
 
 
@@ -340,7 +340,7 @@ def test_get_empty_keys_returns_empty_dict():
 def test_get_empty_keys_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_conf.get(_ABSENT_SNAP, [])
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     assert ctx.value.message == 'snap not installed'
     assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
@@ -455,7 +455,7 @@ def test_unset_empty_keys_is_noop():
 def test_set_not_installed_snap_raises_snap_not_found(config: dict[str, Any]):
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_conf.set(_ABSENT_SNAP, config)
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     # set/unset surface snapd's PUT error directly, which names the snap in the message. get()
     # differs -- it raises the terse /v2/snaps probe error (name in value) -- because snapd words
     # its two endpoints differently and we pass each through rather than normalising them.
@@ -465,7 +465,7 @@ def test_set_not_installed_snap_raises_snap_not_found(config: dict[str, Any]):
 def test_unset_not_installed_snap_raises_snap_not_found():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_conf.unset(_ABSENT_SNAP, ['test-key'])
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
     assert ctx.value.message == f'snap "{_ABSENT_SNAP}" is not installed'
 
 
@@ -544,7 +544,7 @@ def test_get_key_with_an_empty_dotted_segment_raises(key: str):
     ensure_installed_store(_SNAP, channel='latest/edge')
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_conf.get(_SNAP, [key])
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert ctx.value.message == 'invalid option name: ""'
 
 
@@ -574,7 +574,7 @@ def test_get_mixed_keys_raises_option_not_found():
     _snapd_conf.set(_SNAP, {_KEY: 'exists'})
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get(_SNAP, [_KEY, 'key-that-does-not-exist-xyz'])
-    assert ctx.value.kind == 'option-not-found'
+    assert ctx.value._kind == 'option-not-found'
     _cleanup()
 
 

--- a/snap/tests/functional/test_snapd_conf_system.py
+++ b/snap/tests/functional/test_snapd_conf_system.py
@@ -76,9 +76,9 @@ def test_get_system_missing_key_raises_option_not_found(core_snap: str, name: st
     # served, so the probe must be skipped for these names.
     with pytest.raises(_errors.OptionNotFoundError) as ctx:
         _snapd_conf.get(name, ['key-that-does-not-exist-xyz'])
-    assert ctx.value.kind == 'option-not-found'
+    assert ctx.value._kind == 'option-not-found'
     # snapd resolves the alias in the error details: SnapName is always reported as 'core'.
-    assert 'core' in str(ctx.value.value)
+    assert 'core' in str(ctx.value._value)
 
 
 @pytest.mark.parametrize('name', ['system', 'core'])

--- a/snap/tests/functional/test_snapd_interfaces.py
+++ b/snap/tests/functional/test_snapd_interfaces.py
@@ -134,10 +134,10 @@ def test_connect_slot_empty_snap_wrong_interface_hits_system():
 
 
 def test_connect_nonexistent_plug_raises():
-    # Connecting a nonexistent plug raises a base Error (no kind from snapd).
-    with pytest.raises(_errors.Error) as ctx:
+    # Connecting a nonexistent plug raises a base APIError (no kind from snapd).
+    with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.connect((_SNAP, 'nonexistent-plug'))
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'nonexistent-plug' in ctx.value.message
 
 
@@ -146,7 +146,7 @@ def test_connect_interface_mismatch_raises():
     _ensure_disconnected()
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.connect((_SNAP, _PLUG), (_SYSTEM_SNAP, 'network'))
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'cannot connect' in ctx.value.message
 
 
@@ -155,7 +155,7 @@ def test_connect_all_empty_raises():
     # an empty-kind APIError. We deliberately do not guard this client-side.
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.connect(('', ''), ('', ''))
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'plug snap name is empty' in ctx.value.message
 
 
@@ -164,7 +164,7 @@ def test_connect_empty_plug_name_raises():
     # exists, but snapd cannot resolve which plug to connect).
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.connect((_SNAP, ''))
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'plug name is empty' in ctx.value.message
 
 
@@ -175,7 +175,7 @@ def test_connect_empty_plug_name_raises():
 def test_connect_empty_plug_snap_raises(slot: str | None):
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.connect(('', _PLUG), slot)
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'plug snap name is empty' in ctx.value.message
 
 
@@ -249,7 +249,7 @@ def test_disconnect_partial_spec_raises(plug: object, slot: object):
     _ensure_connected()
     with pytest.raises(_errors.APIError) as ctx:
         _disconnect(plug, slot)
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'allowed forms are' in ctx.value.message
 
 
@@ -273,7 +273,7 @@ def test_disconnect_both_sides_not_connected_raises():
     _ensure_disconnected()
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.disconnect((_SNAP, _PLUG), (_SYSTEM_SNAP, _PLUG))
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'not connected' in ctx.value.message
 
 
@@ -296,7 +296,7 @@ def test_disconnect_both_sides_forget_not_connected_raises():
     _ensure_disconnected()
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.disconnect((_SNAP, _PLUG), (_SYSTEM_SNAP, _PLUG), forget=True)
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'not connected' in ctx.value.message
 
 
@@ -304,7 +304,7 @@ def test_disconnect_nonexistent_plug_or_slot_raises():
     # disconnect: plug/slot name doesn't exist on the installed snap.
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.disconnect((_SNAP, 'nonexistent-slot'))
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'no plug or slot named' in ctx.value.message
 
 
@@ -315,7 +315,7 @@ def test_disconnect_all_empty_raises():
     for args in [(), (('', ''),), (('', ''), ('', ''))]:
         with pytest.raises(_errors.APIError) as ctx:
             _snapd_interfaces.disconnect(*args)
-        assert not ctx.value.kind
+        assert not ctx.value._kind
         assert 'allowed forms are' in ctx.value.message
 
 
@@ -337,8 +337,8 @@ def test_disconnect_all_empty_raises():
 def test_connect_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_interfaces.connect((_ABSENT_SNAP, 'home'))
-    assert ctx.value.kind == 'snap-not-found'
-    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert ctx.value._kind == 'snap-not-found'
+    assert str(ctx.value._value) == _ABSENT_SNAP
     assert ctx.value.message == 'snap not installed'
     assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
@@ -355,8 +355,8 @@ def test_connect_not_installed_snap_error_is_not_chained():
 def test_disconnect_not_installed_snap_raises_not_found():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_interfaces.disconnect((_ABSENT_SNAP, 'home'))
-    assert ctx.value.kind == 'snap-not-found'
-    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert ctx.value._kind == 'snap-not-found'
+    assert str(ctx.value._value) == _ABSENT_SNAP
     assert ctx.value.message == 'snap not installed'
     assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
@@ -364,8 +364,8 @@ def test_disconnect_not_installed_snap_raises_not_found():
 def test_connect_slot_snap_not_installed_raises_not_found():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_interfaces.connect((_SNAP, _PLUG), (_ABSENT_SNAP, _PLUG))
-    assert ctx.value.kind == 'snap-not-found'
-    assert str(ctx.value.value) == _ABSENT_SNAP
+    assert ctx.value._kind == 'snap-not-found'
+    assert str(ctx.value._value) == _ABSENT_SNAP
     assert ctx.value.message == 'snap not installed'
     assert str(ctx.value) == f'snap not installed ({_ABSENT_SNAP})'
 
@@ -401,7 +401,7 @@ def test_raw_api_slot_not_installed_precedes_bad_plug():
     # slot snap is reported even with a bad plug name -- as the empty-kind error the library hides.
     with pytest.raises(_errors.APIError) as ctx:
         _raw_connect(_SNAP, 'nonexistent-plug', _ABSENT_SNAP, '')
-    assert ctx.value.kind == ''
+    assert ctx.value._kind == ''
     assert _ABSENT_SNAP in ctx.value.message
     assert 'is not installed' in ctx.value.message
     assert 'nonexistent-plug' not in ctx.value.message
@@ -411,7 +411,7 @@ def test_raw_api_plug_snap_checked_before_slot_snap():
     # Native snapd: when both snaps are absent, the plug snap is reported first.
     with pytest.raises(_errors.APIError) as ctx:
         _raw_connect(_ABSENT_SNAP, 'x', _ABSENT_SNAP_2, '')
-    assert ctx.value.kind == ''
+    assert ctx.value._kind == ''
     assert _ABSENT_SNAP in ctx.value.message
     assert _ABSENT_SNAP_2 not in ctx.value.message
 
@@ -420,34 +420,34 @@ def test_connect_slot_snap_not_installed_precedes_bad_plug():
     # Library: the not-installed slot snap wins over the bad plug, surfaced as _NotFoundError.
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_interfaces.connect((_SNAP, 'nonexistent-plug'), (_ABSENT_SNAP, ''))
-    assert ctx.value.kind == 'snap-not-found'
-    assert _ABSENT_SNAP in str(ctx.value.value)
-    assert 'nonexistent-plug' not in str(ctx.value.value)
+    assert ctx.value._kind == 'snap-not-found'
+    assert _ABSENT_SNAP in str(ctx.value._value)
+    assert 'nonexistent-plug' not in str(ctx.value._value)
 
 
 def test_connect_plug_snap_checked_before_slot_snap():
     # Library: both absent -> the plug snap is probed first, so it is the one named.
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_interfaces.connect((_ABSENT_SNAP, 'x'), (_ABSENT_SNAP_2, ''))
-    assert ctx.value.kind == 'snap-not-found'
-    assert _ABSENT_SNAP in str(ctx.value.value)
-    assert _ABSENT_SNAP_2 not in str(ctx.value.value)
+    assert ctx.value._kind == 'snap-not-found'
+    assert _ABSENT_SNAP in str(ctx.value._value)
+    assert _ABSENT_SNAP_2 not in str(ctx.value._value)
 
 
 def test_disconnect_slot_snap_not_installed_precedes_bad_plug():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_interfaces.disconnect((_SNAP, 'nonexistent-plug'), (_ABSENT_SNAP, 'x'))
-    assert ctx.value.kind == 'snap-not-found'
-    assert _ABSENT_SNAP in str(ctx.value.value)
-    assert 'nonexistent-plug' not in str(ctx.value.value)
+    assert ctx.value._kind == 'snap-not-found'
+    assert _ABSENT_SNAP in str(ctx.value._value)
+    assert 'nonexistent-plug' not in str(ctx.value._value)
 
 
 def test_disconnect_plug_snap_checked_before_slot_snap():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_interfaces.disconnect((_ABSENT_SNAP, 'x'), (_ABSENT_SNAP_2, 'y'))
-    assert ctx.value.kind == 'snap-not-found'
-    assert _ABSENT_SNAP in str(ctx.value.value)
-    assert _ABSENT_SNAP_2 not in str(ctx.value.value)
+    assert ctx.value._kind == 'snap-not-found'
+    assert _ABSENT_SNAP in str(ctx.value._value)
+    assert _ABSENT_SNAP_2 not in str(ctx.value._value)
 
 
 def test_disconnect_empty_snap_with_unknown_name_reports_against_system_snap():
@@ -457,7 +457,7 @@ def test_disconnect_empty_snap_with_unknown_name_reports_against_system_snap():
     # are meaningful when empty here, so disconnect doesn't reject them client-side.
     with pytest.raises(_errors.APIError) as ctx:
         _snapd_interfaces.disconnect(('', 'nonexistent-plug'))
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'snap "snapd" has no plug or slot named "nonexistent-plug"' in ctx.value.message
 
 

--- a/snap/tests/functional/test_snapd_local.py
+++ b/snap/tests/functional/test_snapd_local.py
@@ -112,7 +112,7 @@ def test_install_local_without_dangerous_raises(snap_v1: Path):
     with pytest.raises(_errors.APIError) as ctx:
         install_local(snap_v1)  # dangerous=False by default.
     assert 'cannot find signatures with metadata' in ctx.value.message
-    assert ctx.value.kind == ''
+    assert ctx.value._kind == ''
 
 
 # ---------------------------------------------------------------------------

--- a/snap/tests/functional/test_snapd_logs.py
+++ b/snap/tests/functional/test_snapd_logs.py
@@ -141,7 +141,7 @@ def test_logs_snap_with_no_services_raises():
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _snapd_logs.logs(_NO_SERVICES_SNAP)
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +153,7 @@ def test_logs_not_installed_snap_raises():
     # Requesting logs for an uninstalled snap raises _NotFoundError.
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd_logs.logs(_ABSENT_SNAP)
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
 
 
 # ---------------------------------------------------------------------------
@@ -235,7 +235,7 @@ def test_discarded_and_stripped_entries_leave_the_named_snap(names: str):
     ensure_installed_local(_NO_SERVICES_SNAP)
     with pytest.raises(_errors.AppNotFoundError) as ctx:
         _client.get_logs(query={'n': -1, 'names': names})
-    assert ctx.value.kind == 'app-not-found'
+    assert ctx.value._kind == 'app-not-found'
     assert ctx.value.message == f'snap "{_NO_SERVICES_SNAP}" has no services'
 
 
@@ -248,8 +248,8 @@ def test_comma_in_a_name_queries_two_snaps():
     names = f'{_ABSENT_SNAP},{_ABSENT_SNAP_2}'
     with pytest.raises(_errors._NotFoundError) as ctx:
         _client.get_logs(query={'n': -1, 'names': names})
-    assert ctx.value.kind == 'snap-not-found'
-    assert ctx.value.value in (_ABSENT_SNAP, _ABSENT_SNAP_2)
+    assert ctx.value._kind == 'snap-not-found'
+    assert ctx.value._value in (_ABSENT_SNAP, _ABSENT_SNAP_2)
     assert names not in str(ctx.value)
 
 
@@ -258,4 +258,4 @@ def test_no_comma_in_a_name_is_one_snap():
     # about a name as passed is what a comma-free name looks like.
     with pytest.raises(_errors._NotFoundError) as ctx:
         _client.get_logs(query={'n': -1, 'names': _ABSENT_SNAP})
-    assert ctx.value.value == _ABSENT_SNAP
+    assert ctx.value._value == _ABSENT_SNAP

--- a/snap/tests/functional/test_snapd_snaps.py
+++ b/snap/tests/functional/test_snapd_snaps.py
@@ -105,14 +105,14 @@ def test_refresh_invalid_channel_raises():
     ensure_installed_store(_SNAP)
     with pytest.raises(_errors.ChannelNotAvailableError) as ctx:
         retry_on_rate_limit(_snapd.refresh)(_SNAP, channel='garbage')
-    assert ctx.value.kind == 'snap-channel-not-available'
+    assert ctx.value._kind == 'snap-channel-not-available'
 
 
 def test_refresh_revision_not_available_raises():
     ensure_installed_store(_SNAP)
     with pytest.raises(_errors.RevisionNotAvailableError) as ctx:
         retry_on_rate_limit(_snapd.refresh)(_SNAP, revision=99999999)
-    assert ctx.value.kind == 'snap-revision-not-available'
+    assert ctx.value._kind == 'snap-revision-not-available'
 
 
 def test_hold_with_duration():
@@ -175,7 +175,7 @@ def test_list_one_missing_raises():
     assert _SNAP not in {s.name for s in _list(None)}
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd.list_one(_SNAP)
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
 
 
 def test_remove_not_installed_returns_false():
@@ -199,7 +199,7 @@ def test_refresh_not_installed_raises_not_found():
     with pytest.raises(_errors.NotInstalledError) as ctx:
         retry_on_rate_limit(_snapd.refresh)(_SNAP)
     assert type(ctx.value) is _errors.NotInstalledError
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
 
 
 def test_raw_refresh_not_installed_has_no_kind():
@@ -208,7 +208,7 @@ def test_raw_refresh_not_installed_has_no_kind():
     ensure_removed(_SNAP)
     with pytest.raises(_errors.APIError) as ctx:
         _client.post(f'/v2/snaps/{_SNAP}', body={'action': 'refresh'})
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'not installed' in ctx.value.message
 
 
@@ -217,7 +217,7 @@ def test_hold_not_installed_raises_not_found():
     ensure_removed(_SNAP)
     with pytest.raises(_errors.NotInstalledError) as ctx:
         _snapd.hold(_SNAP)
-    assert ctx.value.kind == 'snap-not-found'
+    assert ctx.value._kind == 'snap-not-found'
 
 
 def test_raw_hold_not_installed_has_no_kind():
@@ -227,7 +227,7 @@ def test_raw_hold_not_installed_has_no_kind():
             f'/v2/snaps/{_SNAP}',
             body={'action': 'hold', 'hold-level': 'general', 'time': 'forever'},
         )
-    assert not ctx.value.kind
+    assert not ctx.value._kind
     assert 'not installed' in ctx.value.message
 
 
@@ -255,7 +255,7 @@ def test_install_invalid_channel_raises():
     ensure_removed(_SNAP)
     with pytest.raises(_errors.ChannelNotAvailableError) as ctx:
         retry_on_rate_limit(_snapd.install)(_SNAP, channel='garbage')
-    assert ctx.value.kind == 'snap-channel-not-available'
+    assert ctx.value._kind == 'snap-channel-not-available'
     assert 'channel' in ctx.value.message or 'no snap revision' in ctx.value.message
 
 
@@ -263,7 +263,7 @@ def test_install_revision_not_available_raises():
     ensure_removed(_SNAP)
     with pytest.raises(_errors.RevisionNotAvailableError) as ctx:
         retry_on_rate_limit(_snapd.install)(_SNAP, revision=99999999)
-    assert ctx.value.kind == 'snap-revision-not-available'
+    assert ctx.value._kind == 'snap-revision-not-available'
 
 
 # ---------------------------------------------------------------------------
@@ -315,7 +315,7 @@ def test_install_needs_classic_raises():
     ensure_removed(_CLASSIC_SNAP)
     with pytest.raises(_errors.NeedsClassicError) as ctx:
         retry_on_rate_limit(_snapd.install)(_CLASSIC_SNAP)
-    assert ctx.value.kind == 'snap-needs-classic'
+    assert ctx.value._kind == 'snap-needs-classic'
 
 
 def test_install_classic():
@@ -339,8 +339,8 @@ def test_install_nonexistent_snap_raises():
         retry_on_rate_limit(_snapd.install)(_ABSENT_SNAP)
     assert type(ctx.value) is _errors.NotInStoreError
     assert ctx.value.message == 'snap not found'
-    assert ctx.value.kind == 'snap-not-found'
-    assert ctx.value.value == _ABSENT_SNAP
+    assert ctx.value._kind == 'snap-not-found'
+    assert ctx.value._value == _ABSENT_SNAP
 
 
 def test_install_channel_and_revision():
@@ -363,7 +363,7 @@ def test_install_revision_not_on_channel_raises():
     absent_from_channel = int(channels[_ALT_CHANNEL].revision)
     with pytest.raises(_errors.ChannelNotAvailableError) as ctx:
         retry_on_rate_limit(_snapd.install)(_SNAP, channel=_CHANNEL, revision=absent_from_channel)
-    assert ctx.value.kind == 'snap-channel-not-available'
+    assert ctx.value._kind == 'snap-channel-not-available'
 
 
 def test_refresh_channel_and_revision():

--- a/snap/tests/unit/test_client.py
+++ b/snap/tests/unit/test_client.py
@@ -278,21 +278,37 @@ class TestErrorResponses:
         assert str(exc_info.value) == 'no channel'
 
     @pytest.mark.parametrize(
-        ('response', 'message_fragment'),
+        ('response', 'message_fragment', 'expected_response'),
         [
-            (b'not json at all', 'Invalid JSON'),
-            (b'[1, 2, 3]', 'Unexpected response type'),
-            ({'status-code': 200, 'result': {}}, 'Missing expected key'),  # No 'type' key.
-            ({'type': 'sync', 'status-code': 200}, 'Missing expected key'),  # No 'result' key.
+            # Undecodable JSON is reported as the text snapd sent, decoded as best we can.
+            (b'not json at all', 'Invalid JSON', 'not json at all'),
+            # Well-formed JSON of the wrong shape is reported as the decoded value.
+            (b'[1, 2, 3]', 'Unexpected response type', [1, 2, 3]),
+            (
+                {'status-code': 200, 'result': {}},  # No 'type' key.
+                'Missing expected key',
+                {'status-code': 200, 'result': {}},
+            ),
+            (
+                {'type': 'sync', 'status-code': 200},  # No 'result' key.
+                'Missing expected key',
+                {'type': 'sync', 'status-code': 200},
+            ),
         ],
     )
     def test_malformed_response_raises_bad_response_error(
-        self, mock_raw: MagicMock, response: bytes | dict[str, Any], message_fragment: str
+        self,
+        mock_raw: MagicMock,
+        response: bytes | dict[str, Any],
+        message_fragment: str,
+        expected_response: object,
     ):
         mock_raw.return_value = _fake_response(response)
         with pytest.raises(BadResponseError) as exc_info:
             _client.get('/v2/snaps/hello-world')
         assert message_fragment in exc_info.value.message
+        # What snapd sent is kept for the caller to report to the library maintainers.
+        assert exc_info.value.response == expected_response
 
     @pytest.mark.parametrize('status', [200, 400, 404, 500])
     def test_non_redirect_status_is_decoded_from_the_body(
@@ -328,6 +344,8 @@ class TestErrorResponses:
         assert '/v2/snaps//conf' in exc_info.value.message  # The path we asked for.
         assert '/v2/snaps/conf' in exc_info.value.message  # Where snapd points us.
         assert '301' in exc_info.value.message  # The kind of redirect it is.
+        # The 301's body is empty, and the message already says everything there is to say.
+        assert exc_info.value.response is None
 
     def test_request_timeout_raises_snap_timeout_error(self, monkeypatch: pytest.MonkeyPatch):
         # Patch opener.open inside _request to raise TimeoutError, exercising the conversion.
@@ -522,6 +540,7 @@ class TestAsyncChange:
         with pytest.raises(BadResponseError) as exc_info:
             _client.post('/v2/snaps/hello-world', body={'action': 'hold'})
         assert 'Unexpected response type' in exc_info.value.message
+        assert exc_info.value.response == []
 
     @pytest.mark.parametrize('status', ['Undo', 'Undoing'])
     def test_async_undo_statuses_continue_polling(self, mock_raw: MagicMock, status: str):
@@ -607,8 +626,7 @@ class TestLogsEndpoint:
             _client.get_logs(query={'n': 10, 'names': 'lxd'})
         assert 'Invalid JSON' in exc_info.value.message
         assert 'some-path' in exc_info.value.message
-        # BadResponseError has no 'value' field, so the message carries what snapd sent.
-        assert 'some-bytes' in exc_info.value.message
+        assert exc_info.value.response == 'some-bytes'
 
 
 def test_all_errors_mapped():

--- a/snap/tests/unit/test_client.py
+++ b/snap/tests/unit/test_client.py
@@ -240,8 +240,8 @@ class TestErrorResponses:
         assert type(exc_info.value) is expected_type  # Exact type, not a subclass.
         # Fields from the response body are preserved on the exception.
         assert exc_info.value.message == 'boom'
-        assert exc_info.value.kind == kind
-        assert exc_info.value.value == 'the-value'
+        assert exc_info.value._kind == kind
+        assert exc_info.value._value == 'the-value'
         assert exc_info.value._status_code == 400
 
     def test_error_missing_kind_and_value_use_defaults(self, mock_raw: MagicMock):
@@ -255,11 +255,11 @@ class TestErrorResponses:
         with pytest.raises(APIError) as exc_info:
             _client.get('/v2/snaps/hello-world')
         assert type(exc_info.value) is APIError  # Missing kind falls back to the base type.
-        assert exc_info.value.kind == ''
-        assert exc_info.value.value == ''
+        assert exc_info.value._kind == ''
+        assert exc_info.value._value == ''
 
-    def test_error_converts_value_to_str(self, mock_raw: MagicMock):
-        # snap-channel-not-available returns a rich dict as 'value'.
+    def test_error_keeps_non_string_value(self, mock_raw: MagicMock):
+        # snap-channel-not-available returns a rich dict as 'value', which is kept as decoded.
         value = {'channel': 'garbage', 'snap-name': 'hello-world'}
         mock_raw.return_value = _fake_response({
             'type': 'error',
@@ -273,7 +273,9 @@ class TestErrorResponses:
         })
         with pytest.raises(ChannelNotAvailableError) as exc_info:
             _client.get('/v2/snaps/hello-world')
-        assert exc_info.value.value == str(value)
+        assert exc_info.value._value == value
+        # A non-string value isn't appended to str(), which would be unreadable.
+        assert str(exc_info.value) == 'no channel'
 
     @pytest.mark.parametrize(
         ('response', 'message_fragment'),
@@ -323,11 +325,9 @@ class TestErrorResponses:
         )
         with pytest.raises(BadResponseError) as exc_info:
             _client.get('/v2/snaps//conf')
-        assert exc_info.value.kind == 'charmlibs-snap-unexpected-redirect'
         assert '/v2/snaps//conf' in exc_info.value.message  # The path we asked for.
         assert '/v2/snaps/conf' in exc_info.value.message  # Where snapd points us.
-        assert exc_info.value.value == '/v2/snaps/conf'
-        assert exc_info.value._status_code == 301
+        assert '301' in exc_info.value.message  # The kind of redirect it is.
 
     def test_request_timeout_raises_snap_timeout_error(self, monkeypatch: pytest.MonkeyPatch):
         # Patch opener.open inside _request to raise TimeoutError, exercising the conversion.
@@ -338,8 +338,8 @@ class TestErrorResponses:
         )
         with pytest.raises(TimeoutError) as exc_info:
             _client.get('/v2/snaps/hello-world')
-        assert exc_info.value.kind == 'charmlibs-snap-request-timeout'
-        assert isinstance(exc_info.value, TimeoutError)
+        assert 'timed out' in exc_info.value.message
+        assert isinstance(exc_info.value, builtins.TimeoutError)
 
     def test_socket_not_found_raises_socket_not_found_error(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -351,7 +351,7 @@ class TestErrorResponses:
         monkeypatch.setattr(_client.time, 'sleep', sleep)
         with pytest.raises(SocketNotFoundError) as exc_info:
             _client.get('/v2/snaps/hello-world')
-        assert exc_info.value.kind == 'charmlibs-snap-socket-not-found'
+        assert 'does-not-exist' in exc_info.value.message  # The socket path we looked for.
         # Callers that only care that snapd was unreachable can catch ConnectionError.
         assert isinstance(exc_info.value, ConnectionError)
         sleep.assert_not_called()
@@ -362,7 +362,8 @@ class TestErrorResponses:
         mock_raw.return_value = response
         with pytest.raises(TimeoutError) as exc_info:
             _client.get('/v2/snaps/hello-world')
-        assert exc_info.value.kind == 'charmlibs-snap-request-timeout'
+        # The failure was reading the body, not making the request.
+        assert 'reading snapd response' in exc_info.value.message
 
     def test_connection_error_retries_then_raises(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(_client, '_CONNECTION_RETRY_BUDGET', 0)
@@ -375,7 +376,7 @@ class TestErrorResponses:
         )
         with pytest.raises(ConnectionError) as exc_info:
             _client.get('/v2/snaps/hello-world')
-        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
+        assert 'connection refused' in exc_info.value.message  # urllib's reason, passed through.
         # A reachable-but-failing socket isn't the socket-missing case.
         assert not isinstance(exc_info.value, SocketNotFoundError)
         # Budget is 0, so the first failure is past the deadline: no retry sleep.
@@ -387,9 +388,7 @@ class TestErrorResponses:
         # A transient connection failure on a GET is retried, then the retry succeeds.
         monkeypatch.setattr(_client.time, 'sleep', MagicMock())
         mock_raw.side_effect = [
-            ConnectionError(
-                'connection refused', kind='charmlibs-snap-connection-error', value=''
-            ),
+            ConnectionError('connection refused'),
             _fake_response({'type': 'sync', 'result': {'foo': 'bar'}}),
         ]
         assert _client.get('/v2/snaps/hello-world') == {'foo': 'bar'}
@@ -442,7 +441,10 @@ class TestSnapdGoingAwayMidRequest:
             monkeypatch.setattr(_client, '_SOCKET_PATH', socket_path)
             with pytest.raises(ConnectionError) as exc_info:
                 _client.get('/v2/snaps/hello-world')
-        assert exc_info.value.kind == 'charmlibs-snap-connection-error'
+        # A raw ConnectionResetError would satisfy pytest.raises above, since the library's
+        # ConnectionError subclasses the builtin -- check the failure really was translated.
+        assert isinstance(exc_info.value, Error)
+        assert 'Connection to snapd lost' in exc_info.value.message
         # The socket existed and accepted us, so this isn't the snapd-not-installed case.
         assert not isinstance(exc_info.value, SocketNotFoundError)
         # The raw error is kept as the cause, so a charm's traceback still shows what broke.
@@ -494,9 +496,9 @@ class TestAsyncChange:
         ]
         with pytest.raises(ChangeError) as exc_info:
             _client.post('/v2/aliases', body={'action': 'alias'})
-        assert exc_info.value.kind == 'charmlibs-snap-change-error'
+        assert exc_info.value._kind == 'charmlibs-snap-change-error'
         assert exc_info.value.message == 'install failed'  # Taken from the 'err' field.
-        assert exc_info.value.value == '42'  # The change id.
+        assert exc_info.value._value == '42'  # The change id.
 
     def test_async_wait_status_logs_warning(self, mock_raw: MagicMock, caplog: LogCaptureFixture):
         wait: dict[str, Any] = {
@@ -549,9 +551,7 @@ class TestAsyncChange:
             _fake_response({'type': 'async', 'change': '42'}),
             # _request translates urllib errors into ConnectionError; mock that here since
             # the patch replaces _request (below that translation).
-            ConnectionError(
-                'connection refused', kind='charmlibs-snap-connection-error', value=''
-            ),
+            ConnectionError('connection refused'),
             _fake_response(done),
         ]
         _client.post('/v2/snaps/hello-world', body={'action': 'hold'})  # Should not raise.
@@ -567,9 +567,7 @@ class TestAsyncChange:
         mock_raw.side_effect = [
             _fake_response({'type': 'async', 'change': '42'}),
             # poll fails past the retry budget (see note above re: ConnectionError).
-            ConnectionError(
-                'connection refused', kind='charmlibs-snap-connection-error', value=''
-            ),
+            ConnectionError('connection refused'),
         ]
         with pytest.raises(ConnectionError):
             _client.post('/v2/snaps/hello-world', body={'action': 'hold'})
@@ -583,7 +581,7 @@ class TestAsyncChange:
         ]
         with pytest.raises(ChangeError) as exc_info:
             _client.post('/v2/snaps/hello-world', body={'action': 'hold'})
-        assert exc_info.value.kind == 'charmlibs-snap-change-unknown'
+        assert exc_info.value._kind == 'charmlibs-snap-change-unknown'
         assert 'Fake' in exc_info.value.message
 
 
@@ -599,9 +597,9 @@ class TestLogsEndpoint:
     def test_logs_error_response_raises(self, mock_raw: MagicMock):
         raw = (FIXTURES_DIR / 'app_not_found_raw.bin').read_bytes()
         mock_raw.return_value = _fake_response(raw)
-        with pytest.raises(Error) as exc_info:
+        with pytest.raises(APIError) as exc_info:
             _client.get_logs(query={'n': 10, 'names': 'hello-world'})
-        assert exc_info.value.kind == 'app-not-found'
+        assert exc_info.value._kind == 'app-not-found'
 
     def test_logs_malformed_response_raises_bad_response_error(self, mock_raw: MagicMock):
         mock_raw.return_value = _fake_response(b'some-bytes', url='http://foo/some-path')
@@ -609,7 +607,8 @@ class TestLogsEndpoint:
             _client.get_logs(query={'n': 10, 'names': 'lxd'})
         assert 'Invalid JSON' in exc_info.value.message
         assert 'some-path' in exc_info.value.message
-        assert exc_info.value.value == 'some-bytes'
+        # BadResponseError has no 'value' field, so the message carries what snapd sent.
+        assert 'some-bytes' in exc_info.value.message
 
 
 def test_all_errors_mapped():
@@ -676,8 +675,8 @@ class TestRealErrorFixtures:
         exc = exc_info.value
         assert type(exc) is expected_type  # Exact type, not a subclass.
         assert exc.message == result['message']
-        assert exc.kind == result.get('kind', '')
-        assert exc.value == str(result.get('value', ''))
+        assert exc._kind == result.get('kind', '')
+        assert exc._value == result.get('value', '')
         assert exc._status_code == envelope['status-code']
 
 
@@ -704,6 +703,6 @@ class TestRealChangeFixtures:
         ]
         with pytest.raises(ChangeError) as exc_info:
             _client.post('/v2/aliases', body={'action': 'alias'})
-        assert exc_info.value.kind == 'charmlibs-snap-change-error'
+        assert exc_info.value._kind == 'charmlibs-snap-change-error'
         assert exc_info.value.message == change['err']  # Message comes from the 'err' field.
-        assert exc_info.value.value == str(async_envelope['change'])  # The polled change id.
+        assert exc_info.value._value == str(async_envelope['change'])  # The polled change id.

--- a/snap/tests/unit/test_errors.py
+++ b/snap/tests/unit/test_errors.py
@@ -63,27 +63,32 @@ class TestErrorHierarchy:
 
 
 def test_snap_error():
-    err = _errors.Error(
+    err = _errors.Error('the message')
+    # The message is the only public field.
+    assert err.message == 'the message'
+    # It's a read-only property, not an attribute.
+    with pytest.raises(AttributeError):
+        err.message = ''  # pyright: ignore[reportAttributeAccessIssue]
+    # str() and repr() have nothing else to report.
+    assert str(err) == 'the message'
+    assert repr(err) == "charmlibs.snap._errors.Error('the message')"
+
+
+def test_api_error():
+    err = _errors.APIError(
         'the message',
         kind='the-kind',
         value='the-value',
         status_code=400,
         status='Bad Request',
     )
-    # The message, kind and value are public.
+    # The message is public, as for any Error.
     assert err.message == 'the message'
-    assert err.kind == 'the-kind'
-    assert err.value == 'the-value'
-    # They're read-only properties, not attributes.
-    with pytest.raises(AttributeError):
-        err.message = ''  # pyright: ignore[reportAttributeAccessIssue]
-    with pytest.raises(AttributeError):
-        err.kind = ''  # pyright: ignore[reportAttributeAccessIssue]
-    with pytest.raises(AttributeError):
-        err.value = None  # pyright: ignore[reportAttributeAccessIssue]
-    # Status code and status message aren't public.
-    assert not hasattr(err, 'status_code')
-    assert not hasattr(err, 'status')
+    # The fields from the snapd error response are recorded privately, for logging and debugging.
+    assert err._kind == 'the-kind'
+    assert err._value == 'the-value'
+    assert err._status_code == 400
+    assert err._status == 'Bad Request'
     # The repr() contains *all* the arguments.
     r = repr(err)
     assert 'the message' in r
@@ -93,6 +98,15 @@ def test_snap_error():
     assert 'Bad Request' in r
     # str() appends a string value that adds information the message doesn't already carry.
     assert str(err) == 'the message (the-value)'
+
+
+@pytest.mark.parametrize('name', ['kind', 'value', 'status_code', 'status'])
+def test_error_response_fields_are_not_public(name: str):
+    # Only the message is public, on Error and APIError alike.
+    assert not hasattr(_errors.Error('boom'), name)
+    assert not hasattr(
+        _errors.APIError('boom', kind='k', value='v', status_code=1, status='s'), name
+    )
 
 
 @pytest.mark.parametrize(
@@ -115,4 +129,19 @@ def test_snap_error():
     ],
 )
 def test_str_appends_informative_string_value(message: str, value: object, expected: str):
-    assert str(_errors.Error(message, kind='some-kind', value=value)) == expected
+    assert str(_errors.APIError(message, kind='some-kind', value=value)) == expected
+
+
+class TestTruncated:
+    def test_short_detail_is_returned_whole(self):
+        assert _errors._truncated('boom') == 'boom'
+
+    def test_non_string_detail_is_stringified(self):
+        assert _errors._truncated({'a': 1}) == "{'a': 1}"
+
+    def test_long_detail_is_truncated_and_sized(self):
+        detail = 'x' * (_errors._MAX_DETAIL + 1)
+        truncated = _errors._truncated(detail)
+        assert truncated.startswith('x' * _errors._MAX_DETAIL)
+        assert not truncated.startswith(detail)
+        assert str(len(detail)) in truncated

--- a/snap/tests/unit/test_errors.py
+++ b/snap/tests/unit/test_errors.py
@@ -132,16 +132,27 @@ def test_str_appends_informative_string_value(message: str, value: object, expec
     assert str(_errors.APIError(message, kind='some-kind', value=value)) == expected
 
 
-class TestTruncated:
-    def test_short_detail_is_returned_whole(self):
-        assert _errors._truncated('boom') == 'boom'
+class TestBadResponseError:
+    """BadResponseError carries what snapd sent, for the caller to put in a bug report."""
 
-    def test_non_string_detail_is_stringified(self):
-        assert _errors._truncated({'a': 1}) == "{'a': 1}"
+    def test_response_is_public(self):
+        err = _errors.BadResponseError('boom', response={'unexpected': 'shape'})
+        assert err.response == {'unexpected': 'shape'}
 
-    def test_long_detail_is_truncated_and_sized(self):
-        detail = 'x' * (_errors._MAX_DETAIL + 1)
-        truncated = _errors._truncated(detail)
-        assert truncated.startswith('x' * _errors._MAX_DETAIL)
-        assert not truncated.startswith(detail)
-        assert str(len(detail)) in truncated
+    def test_response_is_read_only(self):
+        err = _errors.BadResponseError('boom', response='oops')
+        with pytest.raises(AttributeError):
+            err.response = ''  # pyright: ignore[reportAttributeAccessIssue]
+
+    def test_response_defaults_to_none(self):
+        # Not every bad response has anything to report beyond the message.
+        assert _errors.BadResponseError('boom').response is None
+
+    def test_response_is_not_appended_to_str(self):
+        # Unlike APIError's value: a whole response body doesn't belong in a charm's status.
+        assert str(_errors.BadResponseError('boom', response='oops')) == 'boom'
+
+    @pytest.mark.parametrize('response', ['oops', {'unexpected': 'shape'}, None])
+    def test_repr_contains_the_message_and_the_response(self, response: object):
+        r = repr(_errors.BadResponseError('boom', response=response))
+        assert r == f"charmlibs.snap._errors.BadResponseError('boom', response={response!r})"

--- a/snap/tests/unit/test_not_found.py
+++ b/snap/tests/unit/test_not_found.py
@@ -76,8 +76,8 @@ def test_raises_not_installed_error(name: str, mock_client: MockClient):
     assert type(e) is not _NotFoundError, 'Must narrow to a subtype.'
     assert type(e) is NotInstalledError
     assert e.message == error.message
-    assert e.value == error.value
-    assert e.kind == error.kind
+    assert e._value == error._value
+    assert e._kind == error._kind
     assert e._status_code == error._status_code
     assert e._status == error._status
 
@@ -91,8 +91,8 @@ def test_raises_not_in_store_error(name: str, mock_client: MockClient):
     assert type(e) is not _NotFoundError, 'Must narrow to a subtype.'
     assert type(e) is NotInStoreError
     assert e.message == error.message
-    assert e.value == error.value
-    assert e.kind == error.kind
+    assert e._value == error._value
+    assert e._kind == error._kind
     assert e._status_code == error._status_code
     assert e._status == error._status
 
@@ -123,7 +123,7 @@ def test_refresh_also_raises_not_in_store_error(
     assert type(e) is not _NotFoundError, 'Must narrow to a subtype.'
     assert type(e) is NotInStoreError
     assert e.message == error.message
-    assert e.value == error.value
-    assert e.kind == error.kind
+    assert e._value == error._value
+    assert e._kind == error._kind
     assert e._status_code == error._status_code
     assert e._status == error._status

--- a/snap/tests/unit/test_snapd_apps.py
+++ b/snap/tests/unit/test_snapd_apps.py
@@ -139,7 +139,7 @@ class TestEmptyServices:
         # snapd's own probe error is raised unchanged: terse message, snap name in value (which
         # str() surfaces). Not chained -- the probe's error was handled, not propagated.
         assert ctx.value.message == 'snap not installed'
-        assert ctx.value.value == 'hello-world'
+        assert ctx.value._value == 'hello-world'
         assert str(ctx.value) == 'snap not installed (hello-world)'
         assert ctx.value.__context__ is None
         mock_client.post.assert_not_called()
@@ -199,7 +199,7 @@ class TestAppNotFoundConversion:
         mock_client.get.side_effect = self._snap_not_found()
         with pytest.raises(_NotFoundError) as ctx:
             func('hello-world', 'daemon')
-        assert ctx.value.kind == 'snap-not-found'
+        assert ctx.value._kind == 'snap-not-found'
         assert str(ctx.value) == 'snap not installed (hello-world)'
         mock_client.get.assert_called_once_with('/v2/snaps/hello-world')
 
@@ -222,7 +222,7 @@ class TestAppNotFoundConversion:
         mock_client.get.return_value = result_of('snap_info_hello_world.json')
         with pytest.raises(AppNotFoundError) as ctx:
             func('hello-world', 'daemon')
-        assert ctx.value.kind == 'app-not-found'
+        assert ctx.value._kind == 'app-not-found'
         mock_client.get.assert_called_once_with('/v2/snaps/hello-world')
 
     @pytest.mark.parametrize('func', _FUNCTIONS, ids=lambda f: f.__name__)

--- a/snap/tests/unit/test_snapd_conf.py
+++ b/snap/tests/unit/test_snapd_conf.py
@@ -158,7 +158,7 @@ class TestGetEmptyKeys:
         # snapd's own probe error is raised unchanged: terse message, snap name in value (which
         # str() surfaces). Not chained -- the probe's error was handled, not propagated.
         assert ctx.value.message == 'snap not installed'
-        assert ctx.value.value == 'hello-world'
+        assert ctx.value._value == 'hello-world'
         assert str(ctx.value) == 'snap not installed (hello-world)'
         assert ctx.value.__context__ is None
 
@@ -206,7 +206,7 @@ class TestGetAbsentSnapProbe:
         with pytest.raises(_NotFoundError) as ctx:
             _snapd_conf.get('hello-world', ['mykey'])
         assert ctx.value.message == 'snap not installed'
-        assert ctx.value.value == 'hello-world'
+        assert ctx.value._value == 'hello-world'
         assert str(ctx.value) == 'snap not installed (hello-world)'
 
     def test_missing_key_on_absent_snap_does_not_chain_option_not_found(

--- a/snap/tests/unit/test_snapd_conf.py
+++ b/snap/tests/unit/test_snapd_conf.py
@@ -53,6 +53,7 @@ class TestGet:
             _snapd_conf.get('lxd')
         assert 'Unexpected response type' in ctx.value.message
         assert "'list'" in ctx.value.message
+        assert ctx.value.response == ['integer']
         # Reported as a bad response, rather than probed as a possibly-absent snap.
         assert mock_client.get.call_count == 1
 

--- a/snap/tests/unit/test_snapd_interfaces.py
+++ b/snap/tests/unit/test_snapd_interfaces.py
@@ -103,7 +103,7 @@ class TestConnect:
             _snapd_interfaces.connect(('installed-plug', 'p'), ('absent-slot', 's'))
         # The plug snap is probed before the slot snap (matching snapd's blame order).
         assert mock_client.get.call_args_list[0].args[0] == '/v2/snaps/installed-plug'
-        assert ctx.value.value == 'absent-slot'
+        assert ctx.value._value == 'absent-slot'
 
     def test_connect_not_found_is_snapd_probe_error_and_does_not_chain(
         self, mock_client: MockClient
@@ -116,8 +116,8 @@ class TestConnect:
         with pytest.raises(_NotFoundError) as ctx:
             _snapd_interfaces.connect(('absent', 'home'))
         assert ctx.value.message == 'snap not installed'
-        assert ctx.value.kind == 'snap-not-found'
-        assert ctx.value.value == 'absent'
+        assert ctx.value._kind == 'snap-not-found'
+        assert ctx.value._value == 'absent'
         assert str(ctx.value) == 'snap not installed (absent)'
         assert ctx.value.__cause__ is None
         assert ctx.value.__suppress_context__
@@ -219,7 +219,7 @@ class TestDisconnect:
         with pytest.raises(_NotFoundError) as ctx:
             _snapd_interfaces.disconnect(('absent', 'p'))
         assert ctx.value.message == 'snap not installed'
-        assert ctx.value.value == 'absent'
+        assert ctx.value._value == 'absent'
         assert str(ctx.value) == 'snap not installed (absent)'
         assert ctx.value.__cause__ is None
         assert ctx.value.__suppress_context__

--- a/snap/tests/unit/test_snapd_snaps.py
+++ b/snap/tests/unit/test_snapd_snaps.py
@@ -222,6 +222,7 @@ class TestListOne:
             _snapd.list_one('hello-world')
         assert 'Unexpected response type' in ctx.value.message
         assert "'list'" in ctx.value.message
+        assert ctx.value.response == ['hello-world']
 
     @pytest.mark.parametrize('missing', ['name', 'version', 'revision', 'confinement'])
     def test_list_one_missing_field_raises_bad_response(
@@ -232,6 +233,7 @@ class TestListOne:
         with pytest.raises(BadResponseError) as ctx:
             _snapd.list_one('hello-world')
         assert missing in ctx.value.message  # Named by the KeyError repr.
+        assert ctx.value.response == info_dict  # The description we couldn't read.
         assert ctx.value.__suppress_context__
 
     def test_list_one_unparseable_hold_raises_bad_response(self, mock_client: MockClient):

--- a/snap/tests/unit/test_snapd_snaps.py
+++ b/snap/tests/unit/test_snapd_snaps.py
@@ -240,7 +240,7 @@ class TestListOne:
             _snapd.list_one('hello-world')
 
     def test_list_one_other_error_propagates(self, mock_client: MockClient):
-        mock_client.get.side_effect = Error(
+        mock_client.get.side_effect = APIError(
             'internal error',
             kind='internal-error',
             value='',
@@ -293,7 +293,7 @@ class TestInstall:
             _snapd.install('hello-world')
         assert type(ctx.value) is NotInStoreError
         assert ctx.value.message == 'snap not found'
-        assert ctx.value.value == 'hello-world'
+        assert ctx.value._value == 'hello-world'
         assert ctx.value.__suppress_context__
 
 
@@ -406,8 +406,8 @@ class TestRefreshNotInstalled:
             _snapd.refresh('hello-world')
         # snapd's own probe error, narrowed: terse message, snap name in value.
         assert type(ctx.value) is NotInstalledError
-        assert ctx.value.kind == 'snap-not-found'
-        assert ctx.value.value == 'hello-world'
+        assert ctx.value._kind == 'snap-not-found'
+        assert ctx.value._value == 'hello-world'
         assert str(ctx.value) == 'snap not installed (hello-world)'
         mock_client.get.assert_called_once_with('/v2/snaps/hello-world')
 
@@ -443,7 +443,7 @@ class TestRefreshNotInstalled:
             _snapd.refresh('hello-world')
         assert type(ctx.value) is NotInStoreError
         assert ctx.value.message == 'snap not found'  # Not the probe's 'snap not installed'.
-        assert ctx.value.value == 'hello-world'
+        assert ctx.value._value == 'hello-world'
 
     def test_typed_errors_are_reraised_unchanged(self, mock_client: MockClient):
         # A refresh failure snapd does classify keeps its own type once the probe finds the snap.

--- a/snap/tests/unit/test_utils.py
+++ b/snap/tests/unit/test_utils.py
@@ -298,7 +298,7 @@ class TestCheckInstalled:
         )
         error = _utils.check_installed(snap)
         assert type(error) is NotInstalledError
-        assert error.value == snap
+        assert error._value == snap
         mock_client.get.assert_called_once_with(f'/v2/snaps/{snap}')
 
     def test_installed_snap_is_probed(self, mock_client: MockClient):
@@ -315,8 +315,8 @@ class TestCheckInstalled:
         assert type(error) is NotInstalledError
         # Every field is carried across, so the caller raises snapd's own message and value.
         assert error.message == 'snap not installed'
-        assert error.value == 'hello-world'
-        assert error.kind == 'snap-not-found'
+        assert error._value == 'hello-world'
+        assert error._kind == 'snap-not-found'
 
     def test_narrowed_error_has_no_traceback(self, mock_client: MockClient):
         # The caller raises this error itself, so it must not carry the probe's frames.


### PR DESCRIPTION
This PR makes the `value` and `kind` fields returned by snapd errors private on our Python error types. Since they're not longer part of the public `Error` contract, they move to private fields on `APIError` (errors snapd returns), which means that other `Error` subclasses don't need to populate artificial `kind` and `value` fields.

Additionally, `BadResponseError` has the `response` field added for the bad response itself -- this was previously exposed as `value`. (But maybe this should be private and just surfaced in the `repr`?).

---

Why wouldn't we want snapd's `value` and `kind` to be public? Because they're very inconsistent -- the same logical error (the snap isn't installed) can have many different snapd kinds depending on which snapd endpoint is raising the error. Conversely, the library resolves these to a single Python error type based on a combination of mapping kind -> error, endpoint specific knowledge, and probing the current state of the snap.

We should make these attributes private before the 2.0 release, becaase we can always commit to them being part of the public API later, but we can't easily make them private later.

Why might we want to make them public in future? `value`, for instance, might hold useful information for a particular error -- for example, being able to query exactly the snap name for a  `NotInstalledError` might be useful. However, if this becomes a feature worth delivering, we can do better than just surfacing `value` -- we can add, for example, a `snap` field to `NotInstalledError` (populated from `value` or call-site knowledge), or `snap`, `revision` and `channel` fields to `RevisionNotAvailable`.